### PR TITLE
Pull Request: feat: 优化轮次分类与本地向量检索及降级机制，支持前端高动态参数调优

### DIFF
--- a/app/services/ai/data_query_turn_classifier.py
+++ b/app/services/ai/data_query_turn_classifier.py
@@ -125,7 +125,44 @@ def _looks_like_explicit_new_data_query(user_query: str) -> bool:
         "用户表", "用户列表", "query", "how many", "count", "select ",
         "from ", "where ", "group by", "table", "users",
     ]
-    return any(keyword in q for keyword in keywords)
+    return any(keyword in q for keyword in keywords) or _looks_like_business_status_data_query(q)
+
+
+def _looks_like_business_status_data_query(user_query: str) -> bool:
+    """识别“查看某业务对象的状态/延迟/异常”等不一定包含“查询”的查数请求。"""
+    q = (user_query or "").strip().lower()
+    if not q:
+        return False
+
+    action_signals = [
+        "我要看", "想看", "看一下", "看看", "查看", "检查", "确认", "检测",
+        "监控", "展示", "显示", "排查",
+    ]
+    status_or_metric_signals = [
+        "是否延迟", "延迟", "延时", "滞后", "是否正常", "状态", "运行情况",
+        "运行状态", "同步情况", "采集时间", "更新时间", "上报时间", "最新",
+        "离线", "在线", "异常", "失败", "成功", "断流", "超时", "积压",
+        "缺失", "波动", "偏高", "偏低",
+    ]
+
+    action_matches = [(q.find(signal), signal) for signal in action_signals if signal in q]
+    status_matches = [(q.find(signal), signal) for signal in status_or_metric_signals if signal in q]
+    if not action_matches or not status_matches:
+        return False
+
+    action_idx, action = min(action_matches, key=lambda item: item[0])
+    status_idx, _ = min(status_matches, key=lambda item: item[0])
+    if status_idx <= action_idx:
+        return False
+
+    object_text = q[action_idx + len(action):status_idx]
+    object_text = re.sub(r"[，,。？！\s]|的|一下|一下子|是否|是不是", "", object_text)
+    vague_refs = {"这个", "那个", "这些", "那些", "它", "其", "上面", "刚才"}
+    if not object_text or object_text in vague_refs:
+        return False
+
+    scope_markers = ["各", "每", "所有", "全部", "全量", "不同", "各个", "各类", "各项"]
+    return len(object_text) >= 2 or any(marker in q for marker in scope_markers)
 
 
 def _classification_for_clarification(reasoning: str, *, skip_intent_llm: bool) -> DataQueryTurnClassification:
@@ -343,10 +380,17 @@ async def resolve_data_query_turn_classification(
                 skip_intent_llm=False,
             )
         elif not _recent_history_supports_reuse(messages):
-            classification = _classification_for_clarification(
-                "最近对话没有明确的上一轮数据结果上下文，需要先确认是否基于之前的查询结果继续分析",
-                skip_intent_llm=False,
-            )
+            if _looks_like_explicit_new_data_query(q):
+                classification = _classification_for_turn_type(
+                    DataQueryTurnType.NEW_DATA_QUERY,
+                    "复用上一轮结果上下文不可信，但当前问题包含明确新数据查询诉求，改按新数据查询处理",
+                    skip_intent_llm=False,
+                )
+            else:
+                classification = _classification_for_clarification(
+                    "最近对话没有明确的上一轮数据结果上下文，需要先确认是否基于之前的查询结果继续分析",
+                    skip_intent_llm=False,
+                )
 
     if classification is None and looks_like_context_action(q):
         classification = DataQueryTurnClassification(

--- a/app/services/ai/memory_index_service.py
+++ b/app/services/ai/memory_index_service.py
@@ -641,7 +641,21 @@ class MemoryIndexService:
             return {"available": False, "index_name": idx, "message": "Redis 不可用"}
         try:
             info = await redis.execute_command("FT.INFO", idx)
-            return {"available": True, "index_name": idx, "info": info}
+            
+            # 清理嵌套结构中可能存在的非标准浮点数（如 NaN, Infinity），以防止 JSON 序列化失败
+            import math
+            def _sanitize(obj: Any) -> Any:
+                if isinstance(obj, float):
+                    if math.isnan(obj) or math.isinf(obj):
+                        return None
+                    return obj
+                elif isinstance(obj, dict):
+                    return {k: _sanitize(v) for k, v in obj.items()}
+                elif isinstance(obj, (list, tuple)):
+                    return [_sanitize(x) for x in obj]
+                return obj
+
+            return {"available": True, "index_name": idx, "info": _sanitize(info)}
         except Exception as e:
             return {"available": False, "index_name": idx, "message": str(e)}
 

--- a/app/services/ai/runners/data_agent_runner.py
+++ b/app/services/ai/runners/data_agent_runner.py
@@ -71,6 +71,8 @@ logger = logging.getLogger(__name__)
 SCHEMA_GATE_PREFIX = "[SCHEMA_GATE]"
 SQL_REPEAT_GATE_PREFIX = "[SQL_REPEAT_GATE]"
 SQL_STATIC_GATE_PREFIX = "[SQL_STATIC_GATE]"
+TOOL_LOOP_FUSE_THRESHOLD = 3
+DELAY_SECONDS_EXTREME_THRESHOLD = 7 * 24 * 60 * 60
 MAX_DATA_REPAIR_ROUNDS = 2
 DATA_REPAIR_BUDGETS = {
     "sql_before_schema": 1,
@@ -82,6 +84,8 @@ DATA_REPAIR_BUDGETS = {
     "sql_error": 2,
     "empty_sql_result": 1,
     "ratio_anomaly": 1,
+    "duration_anomaly": 1,
+    "tool_loop_fuse": 0,
     "diagnostic_sql_pending_final": 1,
     "missing_schema": 1,
     "missing_sql": 2,
@@ -142,6 +146,7 @@ class _DataRunState:
     sql_fatal_message: str = ""
     sql_static_risk: bool = False
     sql_static_risk_reason: str = ""
+    sql_repeat_gate_block: bool = False
     requires_sql_plan: bool = False
     sql_plan_seen: bool = False
     sql_plan_missing: bool = False
@@ -157,6 +162,11 @@ class _DataRunState:
     successful_sqls: dict[str, Any] = field(default_factory=dict)
     ratio_anomaly: bool = False          # SQL 结果含超阈值比率（>1.5 或负值），触发对账修复
     ratio_anomaly_reason: str = ""       # 异常说明，用于修复提示词
+    duration_anomaly: bool = False       # 时延/时长/时间差字段结果明显反常，触发 SQL 复核
+    duration_anomaly_reason: str = ""
+    tool_call_signatures: dict[str, int] = field(default_factory=dict)
+    tool_loop_fuse_triggered: bool = False
+    tool_loop_fuse_reason: str = ""
     schema_miss_count: int = 0           # 累计 schema_miss 次数（含 prefetch + ReAct 内）
     repair_attempts: dict[str, int] = field(default_factory=dict)
 
@@ -174,6 +184,8 @@ class _DataRunState:
 
     @property
     def ready_to_answer(self) -> bool:
+        if self.tool_loop_fuse_triggered:
+            return False
         if not self.requires_fresh_data:
             return True
         if self.sql_fatal_error:
@@ -189,6 +201,8 @@ class _DataRunState:
             and not self.empty_sql_result
             and not self.diagnostic_sql_pending_final
             and not self.ratio_anomaly
+            and not self.duration_anomaly
+            and not self.tool_loop_fuse_triggered
         )
 
 
@@ -351,6 +365,72 @@ class DataAgentRunner(BaseExecutor):
     def _is_sql_static_gate_block(output: Any) -> bool:
         return str(output or "").startswith(SQL_STATIC_GATE_PREFIX)
 
+    @staticmethod
+    def _normalize_tool_arg_value(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                str(key): DataAgentRunner._normalize_tool_arg_value(value[key])
+                for key in sorted(value.keys(), key=str)
+            }
+        if isinstance(value, list):
+            return [DataAgentRunner._normalize_tool_arg_value(item) for item in value]
+        if isinstance(value, str):
+            return " ".join(value.strip().split())
+        return value
+
+    @classmethod
+    def _tool_call_signature(cls, tool_name: str, tool_args: dict[str, Any] | None) -> str:
+        normalized_args = cls._normalize_tool_arg_value(tool_args or {})
+        try:
+            args_text = json.dumps(normalized_args, ensure_ascii=False, sort_keys=True, default=str)
+        except Exception:
+            args_text = str(normalized_args)
+        return f"{tool_name}:{args_text}"
+
+    def _record_tool_call_signature(
+        self,
+        state: _DataRunState,
+        tool_name: str,
+        tool_args: dict[str, Any] | None,
+    ) -> None:
+        if not tool_name or state.tool_loop_fuse_triggered:
+            return
+        signature = self._tool_call_signature(tool_name, tool_args)
+        if self._tool_call_made_progress(state, tool_name):
+            state.tool_call_signatures.pop(signature, None)
+            return
+        count = state.tool_call_signatures.get(signature, 0) + 1
+        state.tool_call_signatures[signature] = count
+        if count >= TOOL_LOOP_FUSE_THRESHOLD:
+            state.tool_loop_fuse_triggered = True
+            state.halt_current_react = True
+            state.tool_loop_fuse_reason = (
+                f"工具 `{tool_name}` 使用相同参数连续/重复调用 {count} 次，"
+                "系统判断继续执行大概率只会消耗步数。"
+            )
+
+    def _tool_call_made_progress(self, state: _DataRunState, tool_name: str) -> bool:
+        if tool_name == "get_dataset_schema":
+            return (
+                state.schema_completed
+                and not self._is_schema_fatal(state)
+                and not state.schema_miss
+                and not state.schema_needs_refinement
+                and not state.schema_ambiguous
+            )
+        if tool_name == "execute_sql_query":
+            return (
+                state.sql_completed
+                and not state.sql_error
+                and not state.empty_sql_result
+                and not state.sql_static_risk
+                and not state.sql_repeat_gate_block
+                and not state.ratio_anomaly
+                and not state.duration_anomaly
+                and not state.diagnostic_sql_pending_final
+            )
+        return False
+
     def _wrap_tools_with_schema_gate(
         self,
         tools: list[RuntimeToolSpec],
@@ -415,7 +495,8 @@ class DataAgentRunner(BaseExecutor):
                         parsed_output = self._try_parse_json_output(result)
                         empty_reason = self._detect_empty_result(parsed_output)
                         sql_error, _ = self._detect_sql_error(result)
-                        if not sql_error and not empty_reason:
+                        duration_anomaly, _ = self._detect_duration_anomaly(parsed_output)
+                        if not sql_error and not empty_reason and not duration_anomaly:
                             if current_sql_normalized:
                                 state.successful_sqls[current_sql_normalized] = result
                             state.last_successful_sql_output = result
@@ -842,6 +923,25 @@ class DataAgentRunner(BaseExecutor):
                     state=agent.state,
                 )
             return
+        if state.sql_repeat_gate_block and state.last_successful_sql_output is not None:
+            async for chunk in self._synthesize_from_cached_sql_result(
+                runtime_messages=runtime_messages,
+                system_prompt=system_content,
+                user_question=user_question,
+                state=state,
+            ):
+                yield chunk
+            if self.conversation_id:
+                await agent_state_store.save(
+                    user_id=self._runtime_user_id(),
+                    conversation_id=self.conversation_id,
+                    agent_name=agent_name,
+                    agent_version=self.config.agent_version,
+                    tools_fingerprint=tools_fingerprint,
+                    model_name=str(model_name) if model_name else None,
+                    state=agent.state,
+                )
+            return
 
         max_repair_rounds = max(sum(DATA_REPAIR_BUDGETS.values()), MAX_DATA_REPAIR_ROUNDS)
         for _ in range(max_repair_rounds):
@@ -898,6 +998,25 @@ class DataAgentRunner(BaseExecutor):
                     )
                     state.full_content = deduped
                     yield {"type": "retraction", "content": deduped}
+                if self.conversation_id:
+                    await agent_state_store.save(
+                        user_id=self._runtime_user_id(),
+                        conversation_id=self.conversation_id,
+                        agent_name=agent_name,
+                        agent_version=self.config.agent_version,
+                        tools_fingerprint=tools_fingerprint,
+                        model_name=str(model_name) if model_name else None,
+                        state=agent.state,
+                    )
+                return
+            if state.sql_repeat_gate_block and state.last_successful_sql_output is not None:
+                async for chunk in self._synthesize_from_cached_sql_result(
+                    runtime_messages=runtime_messages,
+                    system_prompt=system_content,
+                    user_question=user_question,
+                    state=state,
+                ):
+                    yield chunk
                 if self.conversation_id:
                     await agent_state_store.save(
                         user_id=self._runtime_user_id(),
@@ -1454,6 +1573,125 @@ class DataAgentRunner(BaseExecutor):
             )
         )
 
+    async def _synthesize_from_cached_sql_result(
+        self,
+        *,
+        runtime_messages: List[Any],
+        system_prompt: str,
+        user_question: str,
+        state: _DataRunState,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        start_synthesis = time.time()
+        yield {
+            "type": "log",
+            "id": f"repeat_sql_{uuid.uuid4().hex[:8]}",
+            "title": "复用已执行 SQL 结果",
+            "details": "检测到模型重复调用相同 SQL。平台已拦截重复执行，并基于首次成功查询结果生成最终回答。",
+            "status": "success",
+        }
+
+        raw_result = state.last_successful_sql_output
+        parsed_result = self._try_parse_json_output(raw_result)
+        result_json = json.dumps(parsed_result, ensure_ascii=False, indent=2, default=str)
+        if len(result_json) > 20000:
+            result_json = result_json[:20000] + "\n... [SQL 结果过长已截断]"
+
+        execution_review = (
+            "【执行过程回顾】\n"
+            "- 已成功执行 SQL 并获得非空结果。\n"
+            "- 随后模型重复调用相同 SQL，平台已拦截重复执行并复用首次成功查询结果。\n\n"
+            "【查询结果】\n"
+            f"{result_json}"
+        )
+        prompt_without_menu = (system_prompt or "").replace(
+            "{dataset_menu}",
+            DataQueryPrompts.REUSE_DATASET_MENU_PLACEHOLDER,
+        )
+        synthesis_messages = [SystemMessage(content=prompt_without_menu)]
+        synthesis_messages.extend(
+            message
+            for message in runtime_messages[-6:-1]
+            if isinstance(message, HumanMessage) and getattr(message, "content", None)
+        )
+        synthesis_messages.append(
+            HumanMessage(content=DataQueryPrompts.synthesis_user_message(user_question, execution_review))
+        )
+
+        final_llm = await AgentConfigProvider.get_synthesis_llm(streaming=True, config=self.config)
+        full_synthesis_content = ""
+        content_emitted = False
+        generation_start = None
+        gen_log_id = f"gen_{uuid.uuid4().hex[:8]}"
+        last_synthesis_chunk = None
+        try:
+            async for chunk in final_llm.astream(normalize_messages_for_llm(synthesis_messages)):
+                last_synthesis_chunk = chunk
+                content = str(getattr(chunk, "content", "") or "")
+                if not content:
+                    continue
+                if not content_emitted:
+                    generation_start = time.time()
+                    content_emitted = True
+                    yield {
+                        "type": "log",
+                        "id": gen_log_id,
+                        "title": "✨ 开始生成回复",
+                        "status": "pending",
+                        "started_at": int(generation_start * 1000),
+                    }
+                full_synthesis_content += content
+                yield {"content": content}
+            if generation_start:
+                yield {
+                    "type": "log",
+                    "id": gen_log_id,
+                    "title": "✨ 生成回复完成",
+                    "status": "success",
+                    "execution_time_ms": (time.time() - generation_start) * 1000,
+                }
+        except Exception as syn_err:
+            logger.error("[DataAgentRunner] Cached SQL synthesis failed: %s", syn_err)
+            fallback = DataQueryPrompts.SYNTHESIS_FAILED_FALLBACK
+            full_synthesis_content = fallback
+            yield {
+                "type": "log",
+                "id": f"syn_err_{uuid.uuid4().hex[:6]}",
+                "title": "⚠️ 总结生成失败",
+                "details": str(syn_err),
+                "status": "error",
+            }
+            yield {"content": fallback}
+
+        deduped_synthesis = collapse_repeated_reply(full_synthesis_content)
+        if deduped_synthesis != full_synthesis_content:
+            logger.warning(
+                "[DataAgentRunner] Collapsed duplicated cached SQL synthesis output (len %s -> %s)",
+                len(full_synthesis_content),
+                len(deduped_synthesis),
+            )
+            full_synthesis_content = deduped_synthesis
+            if content_emitted:
+                yield {"type": "retraction", "content": full_synthesis_content}
+
+        synthesis_tokens = extract_tokens_from_message(last_synthesis_chunk)
+        self._increment_step()
+        self.trace_buffer.append(
+            AgentExecutionStep(
+                step_number=self.step_counter,
+                event_type="synthesis",
+                agent_name=self.config.agent_name,
+                model=str(getattr(final_llm, "model_name", self.config.synthesis_model_name or self.config.model_name)),
+                temperature=float(self.config.synthesis_temperature or self.config.temperature or 0),
+                tool_output={"content": full_synthesis_content, "reused_repeated_sql_result": True},
+                raw_log=full_synthesis_content,
+                prompt_tokens=synthesis_tokens["prompt_tokens"],
+                completion_tokens=synthesis_tokens["completion_tokens"],
+                total_tokens=synthesis_tokens["total_tokens"],
+                execution_time_ms=(time.time() - start_synthesis) * 1000,
+                timestamp=datetime.fromtimestamp(start_synthesis),
+            )
+        )
+
     async def _build_system_content(
         self,
         *,
@@ -1569,15 +1807,19 @@ class DataAgentRunner(BaseExecutor):
                     tool_args=tool_args,
                     output=output,
                 )
-                state.halt_current_react = (
-                    state.sql_error
-                    or state.empty_sql_result
-                    or state.sql_static_risk
-                    or state.ratio_anomaly
-                    or state.diagnostic_sql_pending_final
-                )
                 if should_save_followup:
                     await self._save_last_data_result_for_followups(tool_args, parsed_output)
+            self._record_tool_call_signature(state, tool_name, tool_args)
+            state.halt_current_react = (
+                state.sql_error
+                or state.empty_sql_result
+                or state.sql_static_risk
+                or state.sql_repeat_gate_block
+                or state.ratio_anomaly
+                or state.duration_anomaly
+                or state.diagnostic_sql_pending_final
+                or state.tool_loop_fuse_triggered
+            )
             self._sync_pending_data_run_state(state, stream_state)
             self._increment_step()
             self.trace_buffer.append(
@@ -1787,7 +2029,9 @@ class DataAgentRunner(BaseExecutor):
             or state.empty_sql_result
             or state.sql_static_risk
             or state.ratio_anomaly
+            or state.duration_anomaly
             or state.diagnostic_sql_pending_final
+            or state.tool_loop_fuse_triggered
             or self._is_schema_fatal(state)
         )
         if state.full_content or state.ready_to_answer or not has_guard_condition:
@@ -1804,8 +2048,12 @@ class DataAgentRunner(BaseExecutor):
             content = "SQL 存在高风险执行特征，必须先修正 SQL 后才能继续查数。"
         elif state.ratio_anomaly:
             content = "比率/占比结果疑似异常，必须先完成对账 SQL 复核后才能回答。"
+        elif state.duration_anomaly:
+            content = "时间差/时延/时长结果疑似异常，必须先复核时间字段方向、时区或单位换算后才能回答。"
         elif state.diagnostic_sql_pending_final:
             content = "诊断 SQL 只能用于定位问题，必须执行修正后的最终 SQL 后才能回答。"
+        elif state.tool_loop_fuse_triggered:
+            content = f"检测到工具重复调用循环，已停止继续执行。{state.tool_loop_fuse_reason}"
         else:
             content = "为保证数据准确性，必须先完成数据集定义检索和 SQL 查询后才能回答。"
         yield {
@@ -1839,6 +2087,10 @@ class DataAgentRunner(BaseExecutor):
             return "empty_sql_result"
         if state.ratio_anomaly:
             return "ratio_anomaly"
+        if state.duration_anomaly:
+            return "duration_anomaly"
+        if state.tool_loop_fuse_triggered:
+            return "tool_loop_fuse"
         if state.diagnostic_sql_pending_final:
             return "diagnostic_sql_pending_final"
         if (
@@ -1925,6 +2177,15 @@ class DataAgentRunner(BaseExecutor):
             )
         if state.ratio_anomaly:
             return DataQueryPrompts.ratio_anomaly_recheck(state.ratio_anomaly_reason)
+        if state.duration_anomaly:
+            return (
+                "【时间差/时延结果异常复核】上一轮 execute_sql_query 返回了明显异常的时间差、"
+                f"时延或时长字段。原因：{state.duration_anomaly_reason}\n"
+                "请检查 SQL 中时间字段的相减方向、时区口径、now()/当前时间来源、单位换算（秒/毫秒/分钟/小时），"
+                "修正 SQL 后重新调用 execute_sql_query。修正并执行成功前禁止直接回答用户。"
+            )
+        if state.tool_loop_fuse_triggered:
+            return ""
         if state.diagnostic_sql_pending_final:
             return (
                 "【最终 SQL 执行要求】上一轮 execute_sql_query 是诊断 SQL，只能用于定位候选值、"
@@ -1988,6 +2249,8 @@ class DataAgentRunner(BaseExecutor):
         state.diagnostic_sql_pending_final = False
         state.ratio_anomaly = False          # 比率异常状态清除（每轮重新检测）
         state.ratio_anomaly_reason = ""
+        state.duration_anomaly = False
+        state.duration_anomaly_reason = ""
         # 彻底清空上一轮的 SQL 缓存，并重置 Schema 未命中状态，防范修复过程中的 Gate 误拦截
         state.last_successful_sql_output = None
         state.successful_sqls = {}
@@ -2026,6 +2289,8 @@ class DataAgentRunner(BaseExecutor):
             return ToolChoice(mode="execute_sql_query")
         if state.ratio_anomaly:
             return ToolChoice(mode="required")  # 强制调用工具补充对账 SQL
+        if state.duration_anomaly:
+            return ToolChoice(mode="execute_sql_query")
         if state.sql_error or state.empty_sql_result or state.diagnostic_sql_pending_final:
             return ToolChoice(mode="required")
         if (
@@ -2059,6 +2324,10 @@ class DataAgentRunner(BaseExecutor):
             return "修正高风险 SQL"
         if state.ratio_anomaly:
             return "比率/占比异常复核"
+        if state.duration_anomaly:
+            return "时间差/时延异常复核"
+        if state.tool_loop_fuse_triggered:
+            return "停止重复工具调用"
         if state.diagnostic_sql_pending_final:
             return "执行最终 SQL"
         if (
@@ -2177,6 +2446,14 @@ class DataAgentRunner(BaseExecutor):
             else:
                 result_text = self._format_sql_result_for_display(output)
                 details = truncate_for_context(result_text, max_len=1000)
+                output_text = str(output or "")
+                if "[Executed SQL]:" not in output_text and tool_args:
+                    raw_sql = tool_args.get("sql") or tool_args.get("query")
+                    if isinstance(raw_sql, str) and raw_sql.strip():
+                        details = (
+                            f"[Executed SQL]:\n{raw_sql.strip()}\n\n"
+                            f"{_SQL_TOOL_RESULT_DELIMITER}\n{details}"
+                        )
         else:
             details = truncate_for_context(str(output or ""), max_len=1000)
         if tool_name == "execute_sql_query" and self._is_schema_gate_block(output):
@@ -2187,8 +2464,13 @@ class DataAgentRunner(BaseExecutor):
             details = f"{details}\n\n[系统检测] SQL 存在高风险执行特征，已拦截执行。"
         if tool_name == "execute_sql_query" and state.empty_sql_reason:
             details = f"{details}\n\n[系统检测] {state.empty_sql_reason}"
+        if tool_name == "execute_sql_query" and state.duration_anomaly_reason:
+            details = f"{details}\n\n[系统检测] {state.duration_anomaly_reason}"
         if tool_name == "execute_sql_query" and state.sql_error_message:
-            details = f"{details}\n\n[系统检测] SQL 执行异常: {state.sql_error_message[:500]}"
+            error_message = str(state.sql_error_message or "")
+            if "[Executed SQL]:" in error_message:
+                error_message = error_message.split("[Executed SQL]:", 1)[0].strip()
+            details = f"{details}\n\n[系统检测] SQL 执行异常: {error_message[:500]}"
         if tool_name == "get_dataset_schema" and state.schema_miss:
             details = f"{details}\n\n[系统检测] 未命中相关数据集定义。"
         if tool_name == "get_dataset_schema" and state.schema_needs_refinement:
@@ -2201,6 +2483,8 @@ class DataAgentRunner(BaseExecutor):
             details = f"{details}\n\n[系统检测] 元数据服务不可用，已终止查数流程。"
         if tool_name == "get_dataset_schema" and state.rag_not_synced:
             details = f"{details}\n\n[系统检测] 元数据未同步到知识库，已终止查数流程。"
+        if state.tool_loop_fuse_triggered and state.tool_loop_fuse_reason:
+            details = f"{details}\n\n[系统检测] {state.tool_loop_fuse_reason}"
         return details
 
     @staticmethod
@@ -2220,6 +2504,15 @@ class DataAgentRunner(BaseExecutor):
         state.schema_ambiguous, state.schema_ambiguous_reason = self._detect_schema_ambiguity(output)
         if state.schema_miss:
             state.schema_miss_count += 1
+        elif not (
+            state.schema_service_unavailable
+            or state.no_authorized_schema
+            or state.rag_not_synced
+            or state.schema_needs_refinement
+            or state.schema_ambiguous
+            or not str(output or "").strip()
+        ):
+            state.schema_miss_count = 0
         if (
             self._is_schema_fatal(state)
             or state.schema_miss
@@ -2241,6 +2534,7 @@ class DataAgentRunner(BaseExecutor):
         output: Any,
     ) -> tuple[Any, bool]:
         if self._is_sql_repeat_gate_block(output):
+            state.sql_repeat_gate_block = True
             state.sql_completed = True
             text = str(output or "")
             cached_text = text
@@ -2303,7 +2597,15 @@ class DataAgentRunner(BaseExecutor):
         state.diagnostic_sql_pending_final = False
         state.sql_static_risk = False
         state.sql_static_risk_reason = ""
+        state.sql_repeat_gate_block = False
         state.last_successful_sql_output = output
+        duration_anomaly, duration_reason = self._detect_duration_anomaly(parsed_output)
+        if duration_anomaly:
+            state.duration_anomaly = True
+            state.duration_anomaly_reason = duration_reason
+            return parsed_output, False
+        state.duration_anomaly = False
+        state.duration_anomaly_reason = ""
         ratio_anomaly, anomaly_reason = self._detect_ratio_anomaly(parsed_output)
         if ratio_anomaly:
             state.ratio_anomaly = True
@@ -2571,6 +2873,104 @@ class DataAgentRunner(BaseExecutor):
         ]
         q_lower = q.lower()
         return any(kw in q_lower for kw in fatal_keywords)
+
+    @staticmethod
+    def _extract_column_names(parsed: dict[str, Any]) -> list[str]:
+        columns = parsed.get("columns")
+        if not isinstance(columns, list):
+            return []
+        names: list[str] = []
+        for item in columns:
+            if isinstance(item, dict):
+                name = item.get("name") or item.get("field") or item.get("column")
+            else:
+                name = item
+            if name is None:
+                names.append("")
+            else:
+                names.append(str(name))
+        return names
+
+    def _iter_named_result_rows(self, parsed: Any, depth: int = 0) -> list[dict[str, Any]]:
+        if depth > 3:
+            return []
+        if isinstance(parsed, list):
+            return [row for row in parsed if isinstance(row, dict)]
+        if not isinstance(parsed, dict):
+            return []
+
+        rows: list[dict[str, Any]] = []
+        column_names = self._extract_column_names(parsed)
+        for key in ("items", "rows", "data", "records"):
+            value = parsed.get(key)
+            if isinstance(value, list):
+                for row in value:
+                    if isinstance(row, dict):
+                        rows.append(row)
+                    elif isinstance(row, list) and column_names:
+                        rows.append(
+                            {
+                                column_names[index]: cell
+                                for index, cell in enumerate(row)
+                                if index < len(column_names) and column_names[index]
+                            }
+                        )
+                if rows:
+                    return rows
+            elif isinstance(value, dict):
+                rows.extend(self._iter_named_result_rows(value, depth + 1))
+                if rows:
+                    return rows
+        return rows
+
+    @staticmethod
+    def _is_duration_like_column(column: str) -> bool:
+        name = str(column or "").strip().lower()
+        if not name:
+            return False
+        return bool(
+            re.search(
+                r"(interval|duration|latency|delay|lag|elapsed|time[_-]?diff|timediff|"
+                r"diff[_-]?(seconds|minutes|hours|ms)|age[_-]?(seconds|minutes|hours)|"
+                r"seconds|minutes|hours|milliseconds|"
+                r"时延|延迟|耗时|时长|时间差|间隔|秒|分钟|小时)",
+                name,
+                flags=re.IGNORECASE,
+            )
+        )
+
+    @staticmethod
+    def _is_delay_like_column(column: str) -> bool:
+        name = str(column or "").strip().lower()
+        return bool(re.search(r"(latency|delay|lag|延迟|时延|滞后)", name, flags=re.IGNORECASE))
+
+    def _detect_duration_anomaly(self, parsed: Any) -> tuple[bool, str]:
+        """Detect obviously impossible or suspicious duration/time-delta results."""
+        rows = self._iter_named_result_rows(parsed)
+        if not rows:
+            return False, ""
+
+        for row in rows[:50]:
+            for column, value in row.items():
+                if not self._is_duration_like_column(str(column)):
+                    continue
+                if isinstance(value, bool):
+                    continue
+                try:
+                    numeric_value = float(value)
+                except (TypeError, ValueError):
+                    continue
+                if numeric_value < 0:
+                    return True, (
+                        f"字段 `{column}` 值为 {numeric_value:g}，时间差/时延/时长不应为负值，"
+                        "疑似时间字段相减方向、时区或单位换算错误"
+                    )
+                if self._is_delay_like_column(str(column)) and numeric_value > DELAY_SECONDS_EXTREME_THRESHOLD:
+                    return True, (
+                        f"字段 `{column}` 值为 {numeric_value:g} 秒，超过 7 天，"
+                        "疑似延迟计算口径、时区或单位换算错误"
+                    )
+        return False, ""
 
     @staticmethod
     def _detect_ratio_anomaly(parsed: Any) -> tuple[bool, str]:

--- a/app/services/ai/runtime/agentscope/middleware.py
+++ b/app/services/ai/runtime/agentscope/middleware.py
@@ -75,6 +75,10 @@ def _safe_getattr(obj: Any, name: str, default: Any = None) -> Any:
         return default
 
 
+def _is_async_iterable(obj: Any) -> bool:
+    return _safe_getattr(obj, "__aiter__") is not None
+
+
 def _extract_tool_calls_detail(content: Any) -> list[dict[str, Any]]:
     """从 ChatResponse.content 中提取包含详细参数的工具调用列表。"""
     tool_calls: list[dict[str, Any]] = []
@@ -260,7 +264,7 @@ class ModelCallStatsMiddleware(MiddlewareBase):
         }
 
         # ── 流式响应：return 包装后的 async generator ──────────────────────
-        if hasattr(result, "__aiter__"):
+        if _is_async_iterable(result):
             return _stream_with_stats(
                 result,
                 redis_key=redis_key,

--- a/app/services/ai/tools/data_api.py
+++ b/app/services/ai/tools/data_api.py
@@ -313,113 +313,27 @@ async def get_dataset_schema(keywords: Optional[str] = None) -> str:
 
     Args:
         keywords: Optional. A search term or topic (e.g., "sales", "user behavior") to find relevant data.
-                 In Local Mode, all authorized datasets are returned regardless of keywords.
+                 In Local Mode, this is used for local vector metadata search.
                  In RAGFlow Mode, this is used as the semantic search query.
     """
     try:
         from app.core.orm import AsyncSessionLocal
-        from app.services.metadata_service import MetadataService
-        from app.services.auth_service import AuthService
         from app.core.context import get_current_agent_context
-        from app.services.config_service import ConfigService
+        from app.services.chatbi_dataset_schema_service import fetch_dataset_schema_core
 
         ctx = get_current_agent_context()
         user_id = ctx.user_id if ctx else None
         is_admin = ctx.is_admin if ctx else False
+        api_key = ctx.api_key if ctx else None
 
         async with AsyncSessionLocal() as session:
-            # Fallback: Resolve User via API Key if ID missing
-            if not user_id and ctx and ctx.api_key:
-                u_info = await AuthService.verify_api_key(ctx.api_key, session)
-                if u_info:
-                    user_id = int(u_info["user_id"])
-                    if u_info["role"] == "admin":
-                        is_admin = True
-
-            # 1. Get ALL Authorized Datasets (Permission Check)
-            # In Local Mode, we return all of these. In RAG Mode, we use these to filter search.
-            # We pass query=None to get everything the user has access to.
-            authorized_datasets = await MetadataService.search_datasets(
+            return await fetch_dataset_schema_core(
                 session,
-                query=None,
+                keywords=keywords,
                 user_id=user_id,
                 is_admin=is_admin,
-                status=1
+                api_key=api_key,
             )
-
-            if not authorized_datasets:
-                return "No authorized datasets found. You do not have permission to view any data."
-
-            # Check Metadata Provider Config
-            provider = await ConfigService.get("metadata_provider", default="local")
-            logger.info(f"[Tool: get_dataset_schema] Using provider: {provider.upper()}")
-
-            # --- RAGFlow Mode ---
-            if provider == "ragflow":
-                from app.services.ai.ragflow_client import RagFlowClient
-                from app.services.metadata_rag_service import MetadataRagService, MetadataServiceUnavailableError
-
-                # Filter for datasets that actually have a RAG ID
-                rag_ids = [ds.rag_dataset_id for ds in authorized_datasets if ds.rag_dataset_id]
-
-                if not rag_ids:
-                    return "Authorized datasets found, but none are synced to RAG knowledge base."
-
-                # If no keywords provided, return a directory of datasets instead of searching
-                if not keywords:
-                    directory = ["Available Datasets (Please provide keywords to search specific tables):"]
-                    for ds in authorized_datasets:
-                        if ds.rag_dataset_id:
-                            directory.append(f"- {ds.display_name or ds.name} (Source: {ds.data_source or 'clickhouse'})")
-                            if ds.description:
-                                directory.append(f"  Description: {ds.description}")
-                    return "\n".join(directory)
-
-                # Retrieve with Auto-Retry using Semantic Search
-                # Agent is expected to provide expanded keywords for better recall
-                query = keywords
-                threshold = float(await ConfigService.get("ragflow_similarity_threshold") or 0.2)
-                weight = float(await ConfigService.get("ragflow_vector_weight") or 0.3)
-                top_k = int(await ConfigService.get("ragflow_metadata_top_k") or 5)
-
-                logger.info(f"[Agent Debug] Tool get_dataset_schema: top_k={top_k}, threshold={threshold}, weight={weight}")
-
-                client = RagFlowClient()
-                try:
-                    chunks, trace_logs = await MetadataRagService.retrieve_with_retry(
-                        client,
-                        query,
-                        rag_ids,
-                        top_k=top_k,
-                        threshold=threshold,
-                        weight=weight
-                    )
-                except MetadataServiceUnavailableError as e:
-                    logger.error(f"[Tool: get_dataset_schema] Metadata service unavailable: {e}")
-                    return MetadataRagService.unavailable_hint(str(e))
-
-                if not chunks:
-                    return f"No relevant schema info found for '{query}'.\nDebug Logs: {'; '.join(trace_logs)}"
-
-                # Format
-                context_parts = []
-                for chunk in chunks:
-                    similarity = chunk.get('similarity', 0)
-                    context_parts.append(f"[置信度: {similarity:.2f}]\n--- Source: {chunk['doc_name']} ---\n{chunk['content']}")
-
-                return "\n\n".join(context_parts)
-
-            # --- Local Mode (Default) ---
-            # Return Schema for ALL authorized datasets (ignoring keywords as requested)
-            results = []
-            for ds in authorized_datasets:
-                # Get full detail (tables, columns, metrics)
-                # Note: We rely on the initial search_datasets to have checked permissions.
-                # export_dataset_yaml handles the formatting.
-                yaml_text = await MetadataService.export_dataset_yaml(session, ds.id)
-                results.append(f"--- Dataset: {ds.display_name} ({ds.name}) ---\n{yaml_text}")
-
-            return "\n\n".join(results)
 
     except Exception as e:
         logger.error(f"[Tool Error] Schema Retrieval Failed: {e}", exc_info=True)

--- a/app/services/chatbi_dataset_schema_service.py
+++ b/app/services/chatbi_dataset_schema_service.py
@@ -22,10 +22,10 @@ async def fetch_dataset_schema_core(
     api_key: Optional[str] = None,
 ) -> str:
     """
-    按当前用户权限获取数据集 Schema 文本（local 为 YAML；ragflow 为检索片段或目录）。
+    按当前用户权限获取数据集 Schema 文本（local/ragflow 均优先返回检索片段）。
 
     Args:
-        keywords: RAGFlow 模式下作为语义检索 query；local 模式下忽略。
+        keywords: 元数据检索 query；local 模式下用于本地向量检索，向量异常时用于 MySQL LIKE 兜底。
         user_id: 用户 ID；可与 api_key 二选一补全（工具场景）。
         is_admin: 是否平台管理员。
         api_key: 无 user_id 时用于解析用户身份。
@@ -132,8 +132,69 @@ async def _fetch_dataset_schema_impl(
         return "\n\n".join(context_parts)
 
     # --- Local Mode (Default) ---
+    query = (keywords or "").strip()
+    threshold = float(await ConfigService.get("ragflow_similarity_threshold") or 0.2)
+    top_k = int(await ConfigService.get("ragflow_metadata_top_k") or 5)
+
+    if query:
+        try:
+            from app.services.ai.embedding_client import EmbeddingClient
+            from app.services.ai.metadata_index_service import MetadataIndexService
+
+            authorized_ids = None if is_admin_eff else [
+                ds.id for ds in authorized_datasets if getattr(ds, "id", None) is not None
+            ]
+            query_embedding = await EmbeddingClient.embed_text(query, use_global=True)
+            redis_results = await MetadataIndexService.search_knn(
+                query_embedding=query_embedding,
+                authorized_dataset_ids=authorized_ids,
+                top_k=top_k,
+            )
+
+            context_parts = []
+            for item in redis_results:
+                try:
+                    similarity = float(item.get("similarity", 0.0) or 0.0)
+                except (TypeError, ValueError):
+                    similarity = 0.0
+                if similarity < threshold:
+                    continue
+                doc_name = item.get("doc_name", "unknown")
+                content = str(item.get("content") or "").strip()
+                if not content:
+                    continue
+                context_parts.append(
+                    f"[置信度: {similarity:.2f}]\n--- Source: {doc_name} ---\n{content}"
+                )
+
+            if context_parts:
+                return "\n\n".join(context_parts)
+            return (
+                f"No relevant schema info found for '{query}'.\n"
+                f"Debug Logs: Redis Vector Search completed. Found {len(redis_results)} raw items; "
+                f"no hit above threshold {threshold}"
+            )
+        except Exception as ex:
+            logger.warning(
+                "[fetch_dataset_schema_core] Local Redis vector search failed: %s. Falling back to MySQL keyword search.",
+                ex,
+            )
+
+    if not query:
+        return "No relevant schema info found for ''.\nDebug Logs: local metadata query is empty"
+
+    found_datasets = await MetadataService.search_datasets(
+        session,
+        query=query,
+        user_id=user_id_eff,
+        is_admin=is_admin_eff,
+        status=1,
+    )
+    if not found_datasets:
+        return f"No relevant schema info found for '{query}'.\nDebug Logs: local MySQL keyword search returned 0 datasets"
+
     results = []
-    for ds in authorized_datasets:
+    for ds in found_datasets:
         yaml_text = await MetadataService.export_dataset_yaml(session, ds.id)
         results.append(f"--- Dataset: {ds.display_name} ({ds.name}) ---\n{yaml_text}")
 

--- a/docs/md/ai_agent_gating_contract.md
+++ b/docs/md/ai_agent_gating_contract.md
@@ -1,0 +1,211 @@
+# AI Agent 门控契约 v1
+
+本文档定义各类 Agent 在路由、工具调用、外部执行、数据真实性、SQL 安全和输出兜底上的门控契约。它的目标不是描述所有实现细节，而是把“哪些门控是必须的、哪些是不适用、哪些是当前缺口”显式写清楚，作为后续开发和测试验收的共同依据。
+
+## 适用范围
+
+当前契约覆盖以下执行路径：
+
+- ChatBI / DataQuery：`DataQueryExecutor` + `DataAgentRunner`
+- General Assistant：`AssistantExecutor` + `AssistantAgentRunner`
+- Knowledge Agent：`KnowledgeExecutor` + `KnowledgeAgentRunner`
+- RAGFlow 外部引擎：`RAGExecutor`
+- OpenClaw 外部引擎：`OpenClawExecutor`
+
+核心入口：
+
+- `app/services/ai/dispatcher.py`
+- `app/services/ai/agent_service.py`
+- `app/services/ai/data_query_turn_classifier.py`
+- `app/services/ai/runners/data_agent_runner.py`
+- `app/services/ai/runners/assistant_agent_runner.py`
+- `app/services/ai/runners/knowledge_agent_runner.py`
+- `app/services/ai/runtime/agentscope/tools.py`
+- `app/services/ai/runtime/agentscope/event_stream.py`
+
+## 门控矩阵
+
+| Agent 类型 | 路由/意图门控 | 工具权限门控 | 外部执行挂起 | 数据/知识真实性门控 | SQL 安全门控 | 输出安全/反幻觉 | 中断恢复 | 当前契约状态 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| ChatBI / DataQuery | 必须。外层只选 DataQuery，内部以 `DataQueryTurnClassifier` 为最终判定 | 必须。AgentScope runtime tool scope 统一处理 | 必须。支持 `external_execution_required` | 必须。schema、few-shot、结果复用、空结果、异常结果均需可观测 | 必须。只读 SQL、schema-before-sql、静态风险、重复 SQL、修复轮次、最终 guard | 必须。未完成查数不得直接回答 | 必须。pending snapshot 保存 data run state | 基本完整，需收口测试和少数边界顺序 |
+| General Assistant | 必须。使用会话级通用分类 | 必须。AgentScope runtime tool scope 统一处理 | 必须。支持 `external_execution_required` | 部分。无数据库连接时拦截疑似虚构业务数据 | 不适用 | 部分。拦截表格/IP 等疑似编造业务数据 | 必须。AgentScope pending 恢复 | 基础完整，不等同 ChatBI 强门控 |
+| Knowledge Agent | 必须。知识库问答可优先于普通对话 | 必须。AgentScope runtime tool scope 统一处理 | 必须。支持 `external_execution_required` | 必须。dataset 范围、自动检索、空召回、引用约束 | 不适用 | 必须。空召回或无引用事实回答要拦截 | 必须。AgentScope pending 恢复 | 基本完整，需明确 dataset 缺失与后续反幻觉测试关系 |
+| RAGFlow 外部引擎 | 弱。适配器内只做查询提取和日志 | 不适用。外部引擎不走本地 AgentScope 工具权限 | 不适用。当前无统一挂起恢复 | 依赖 RAGFlow 返回引用和错误 | 不适用 | 弱。无本地二次反幻觉审计 | 不适用 | 非统一门控路径，需明确为外部引擎自管或补统一适配 |
+| OpenClaw 外部引擎 | 弱。主要交给 OpenClaw 处理 | 不适用。外部引擎不走本地 AgentScope 工具权限 | 不适用。当前无统一挂起恢复 | 部分。透传用户可访问 dataset 给外部引擎 | 不适用 | 必须。输入和输出安全审计可配置 | 不适用 | 有安全审计，但非统一 AgentScope 门控 |
+
+## 通用 AgentScope 工具门控契约
+
+适用于 ChatBI、General Assistant、Knowledge Agent。
+
+1. Runtime tool 必须声明 `permission_scope`，可选值包括 `read`、`write`、`ask`、`dangerous`。
+2. `read` 工具默认允许自动执行。
+3. `dangerous` 工具必须拒绝执行。
+4. `write` / `ask` 工具默认必须触发用户确认，除非运行时 `approval_mode` 明确允许。
+5. AgentScope `REQUIRE_USER_CONFIRM` 必须映射为 SSE `permission_required`。
+6. AgentScope `REQUIRE_EXTERNAL_EXECUTION` 必须映射为 SSE `external_execution_required`。
+7. 挂起请求必须保存 `agent_state`、`stream_state`、`runner_context`、`tool_call` 和用户/会话信息。
+8. permission 恢复接口不得处理 external pending；external 恢复接口不得处理 permission pending。
+
+相关文件：
+
+- `app/services/ai/runtime/agentscope/tools.py`
+- `app/services/ai/runtime/agentscope/event_stream.py`
+- `app/services/ai/runtime/agentscope/pending_store.py`
+- `app/services/ai/runtime/agentscope/confirmations.py`
+- `app/services/ai/agent_service.py`
+
+## ChatBI / DataQuery 契约
+
+### 路由与分类
+
+1. 只要 Agent 配置包含 `data_query` capability，dispatcher 可以进入 `DataQueryExecutor`。
+2. 进入 `DataQueryExecutor` 后，ChatBI 内部行为必须以 `DataQueryTurnClassifier` 为最终判定，不能只依赖外层 router。
+3. 分类类型必须覆盖：
+   - `new_data_query`
+   - `reuse_previous_result`
+   - `context_action`
+   - `skill_execution`
+   - `clarification_or_non_data`
+4. 明显非查数、寒暄、指代过于模糊的问题必须进入 clarification，而不是强行查数。
+5. 复用上一轮结果必须同时满足：
+   - 当前会话存在上一轮结构化查询结果
+   - 最近对话仍有可信的数据结果上下文
+6. 如果 LLM 误判为复用，但当前问题包含明确新查询诉求，应改按新数据查询处理。
+
+### 新数据查询执行顺序
+
+1. 新数据查询必须先进行用户需求分析和 schema 检索词规划。
+2. 需要新 SQL 生成时必须进行 few-shot 案例检索；未命中或检索失败也必须有可观测日志。
+3. 必须先调用 `get_dataset_schema`，再允许调用 `execute_sql_query`。
+4. schema prefetch 失败时：
+   - 元数据服务不可用：终止
+   - 无授权数据集：终止
+   - 元数据未同步知识库：终止
+   - 连续 schema miss 达到阈值：终止
+5. schema 返回多个高置信候选且分数接近时，必须先澄清数据集或指标口径，禁止直接 SQL。
+
+### SQL 安全与修复
+
+1. 只允许只读查询，SQL 必须以 `SELECT` 或 `WITH` 开头。
+2. 禁止 `SELECT *`。
+3. JOIN 必须有明确 `ON` 条件。
+4. JOIN 明细查询必须有 `LIMIT` 或聚合约束。
+5. 非聚合明细查询必须有 `LIMIT` 或等价行数约束。
+6. 重复执行同一条已成功 SQL 时，应拦截重复调用，并复用首次成功结果进行最终回答。
+7. SQL 执行错误必须进入修复轮次，成功前不得回答。
+8. 空结果必须先诊断筛选条件、时间范围或 JOIN 条件；诊断 SQL 不能作为最终结论。
+9. 比率/占比异常必须触发对账复核。
+10. 时间差/时延/时长异常必须触发复核时间字段方向、时区或单位换算。
+11. 工具重复调用同参且无进展时必须触发循环熔断。
+12. 如果模型在完成查数顺序前输出自然语言结论，最终 guard 必须拦截。
+
+### 当前已知边界
+
+1. SQL 静态风险门控目前会先于重复 SQL 门控触发。测试和产品预期需要统一：高风险重复 SQL 应优先报静态风险，还是优先复用缓存结果。
+2. 部分 runner 测试未 mock 配置/数据库，容易在无 Redis/MySQL 的本地沙箱里失败；这些失败不应直接等同业务门控失败。
+
+### 测试映射
+
+- `tests/ai/test_turn_classifier.py`
+- `tests/ai/runners/test_data_agent_runner.py`
+- `tests/ai/tools/test_data_api.py`
+- `tests/ai/test_dispatcher_data_executor_boundary.py`
+- `tests/ai/runtime/test_event_stream_observability.py`
+- `tests/ai/runtime/test_external_execution_resume.py`
+
+## General Assistant 契约
+
+1. General Assistant 必须使用会话级通用分类结果，包括 data query 降级、knowledge、context action、skill execution、meta action、general。
+2. 如果当前 Agent 无 `data_query` capability，但用户问题被识别为数据查询，必须按通用助手处理，并保留降级语义。
+3. General Assistant 不得连接 ChatBI 数据库，也不得编造内部业务数据。
+4. 如果未调用实际业务工具却生成疑似业务数据表格、IP 列表或资产清单，必须拦截并提示用户使用 ChatBI。
+5. 绑定工具时必须走 AgentScope runtime tool 权限门控。
+6. 没有工具时走 simple synthesis，不适用工具权限/外部执行挂起。
+
+测试映射：
+
+- `tests/ai/executors/test_chat_executor.py`
+- `tests/ai/runtime/test_agentscope_tooling.py`
+- `tests/ai/runtime/test_event_stream_observability.py`
+
+## Knowledge Agent 契约
+
+1. 知识库问答必须确保 `search_knowledge_base` 工具可用。
+2. 执行 ReAct 前必须自动调用 `search_knowledge_base` 预检索。
+3. 检索范围必须来自显式参数、请求上下文、智能体绑定 dataset 或系统默认 dataset。
+4. 如果要求显式 dataset 但未提供，必须在检索前终止。
+5. 如果没有任何可用默认 dataset，也必须终止并提示管理员配置。
+6. 知识库服务不可用时必须终止，不得继续让模型脑补。
+7. 空召回时，如果模型输出长事实性回答，必须拦截。
+8. 有召回但最终事实性回答没有有效引用标记时，必须拦截。
+9. 模型输出中的无效引用标记必须过滤。
+10. 绑定业务工具时必须走 AgentScope runtime tool 权限门控。
+
+当前已知边界：
+
+1. dataset 缺失门控位于服务不可用/反幻觉门控之前。测试后续分支时需要显式 mock dataset 配置或上下文，否则会被前置 dataset gate 拦截。
+
+测试映射：
+
+- `tests/ai/executors/test_chat_executor.py`
+- `tests/ai/test_knowledge_utils.py`
+- `tests/ai/tools/test_knowledge_tool.py`
+
+## RAGFlow 外部引擎契约
+
+1. RAGFlow Agent 由 `engine_type == "RAGFLOW"` 直接进入 `RAGExecutor`。
+2. 当前路径不走本地 AgentScope runtime tool 权限门控。
+3. 当前路径不产生本地 `permission_required` 或 `external_execution_required`。
+4. 必须透出语义理解、知识库检索、引用和错误日志。
+5. 流式失败且尚未输出内容时可以重试；已输出内容后不得简单重试以免重复回答。
+6. 真实性主要依赖 RAGFlow 引擎返回内容和 citation，本地当前没有二次反幻觉审计。
+
+当前已知边界：
+
+1. 如果产品要求所有 agent 都统一支持工具确认、外部执行挂起和本地反幻觉审计，RAGFlow 需要新增适配层。
+2. 如果保持外部引擎自管，文档和测试必须明确它不适用本地 AgentScope 工具门控。
+
+## OpenClaw 外部引擎契约
+
+1. OpenClaw Agent 由 `engine_type == "OPENCLAW"` 直接进入 `OpenClawExecutor`。
+2. 当前路径不走本地 AgentScope runtime tool 权限门控。
+3. 当前路径不产生本地 `permission_required` 或 `external_execution_required`。
+4. 默认启用输入安全审计，除非配置关闭。
+5. 默认启用输出安全审计，发现不安全输出时必须发送 retraction。
+6. 如果存在用户信息，必须尽力解析并透传用户可访问的 RAGFlow metadata dataset。
+7. dataset 解析失败不能阻断 OpenClaw 主流程，但必须记录 warning。
+
+当前已知边界：
+
+1. OpenClaw 的工具执行、检索、推理安全主要依赖外部引擎。
+2. 如果要纳入统一门控，需要将外部工具调用事件标准化为本地 pending/permission 事件。
+
+## 验收规则
+
+新增或修改任一 Agent 门控时，至少满足以下要求：
+
+1. 文档矩阵必须同步更新。
+2. 明确该门控属于必需、不适用、外部自管或当前缺口。
+3. 必须有正向和拦截路径测试。
+4. ChatBI 新增门控必须覆盖：
+   - 正常查数不被误拦截
+   - 违规路径被拦截
+   - 关联日志或 trace 可见
+   - 修复或中断恢复路径不丢状态
+5. Knowledge 新增门控必须覆盖：
+   - dataset 缺失
+   - 空召回
+   - 服务不可用
+   - 有召回但无引用的事实性回答
+6. General 新增门控必须覆盖：
+   - 普通聊天不被误拦截
+   - 数据查询降级不编造数据
+   - 工具权限事件可恢复
+7. 外部引擎新增统一门控时，必须补充 RAGFlow/OpenClaw 与本地 SSE 事件的契约测试。
+
+## 当前建议优先级
+
+1. 收口 ChatBI runner 测试夹具，避免无 Redis/MySQL 环境下误报。
+2. 明确 SQL 静态风险门控和重复 SQL 门控的优先级，并同步测试。
+3. 为 Knowledge runner 的 dataset 前置门控补充独立测试，避免和服务不可用/反幻觉测试互相遮挡。
+4. 产品层决定 RAGFlow/OpenClaw 是“外部自管”还是“接入统一 AgentScope 门控适配层”。

--- a/frontend/src/components/RagFlowResourceSelector.vue
+++ b/frontend/src/components/RagFlowResourceSelector.vue
@@ -202,8 +202,9 @@ const formatDate = (ts?: number | string) => {
           ></span>
           <span class="font-medium whitespace-nowrap">{{ engineStatusText }}</span>
           <span class="text-gray-400">|</span>
-          <span class="truncate">
-            RAGFlow 地址：<span class="font-mono">{{ ragflowApiUrl }}</span>
+          <span class="flex items-center gap-1 min-w-0">
+            <span>RAGFlow 地址：</span>
+            <span :title="ragflowApiUrl" class="font-mono truncate max-w-[150px] sm:max-w-[250px] inline-block align-bottom">{{ ragflowApiUrl }}</span>
           </span>
         </div>
         <span
@@ -265,7 +266,7 @@ const formatDate = (ts?: number | string) => {
         <h3 class="text-lg font-bold text-gray-800">知识库引擎未连接</h3>
         <p class="text-sm text-gray-500 mt-1 max-w-md">{{ friendlyErrorMsg }}</p>
         <p class="text-xs text-gray-400 mt-3 max-w-md">
-          当前配置地址：<span class="font-mono">{{ ragflowApiUrl }}</span>
+          当前配置地址：<span :title="ragflowApiUrl" class="font-mono truncate max-w-[200px] sm:max-w-[300px] inline-block align-bottom">{{ ragflowApiUrl }}</span>
         </p>
         <p class="text-xs text-gray-400 mt-1 max-w-md">原始错误：{{ errorMsg }}</p>
         <button

--- a/frontend/src/views/AgentManagement.vue
+++ b/frontend/src/views/AgentManagement.vue
@@ -1085,7 +1085,17 @@ const formatDate = (dateStr: string) => {
   <div class="p-4 sm:p-6 max-w-7xl mx-auto space-y-4 sm:space-y-6">
     <div class="flex justify-between items-center">
       <div>
-        <h1 class="text-xl sm:text-2xl font-bold text-gray-900">智能体管理</h1>
+        <div class="flex items-center space-x-3">
+          <h1 class="text-xl sm:text-2xl font-bold text-gray-900">智能体管理</h1>
+          <!-- 「？」帮助按钮 -->
+          <button 
+            @click="showHelp = true"
+            class="flex items-center justify-center w-7 h-7 rounded-full bg-white text-blue-600 border border-gray-200 hover:border-blue-300 hover:bg-blue-50 transition-colors shadow-sm"
+            title="智能体调度与托管说明"
+          >
+            <span class="font-bold text-sm">?</span>
+          </button>
+        </div>
         <p v-if="!isMobile" class="text-gray-500 mt-1">
           管理并配置系统中的 AI 智能体及其运行策略
         </p>
@@ -1111,41 +1121,6 @@ const formatDate = (dateStr: string) => {
         </svg>
         新建智能体
       </button>
-    </div>
-
-    <!-- Collapsible Help Section -->
-    <div class="bg-blue-50/50 border border-blue-100 rounded-xl overflow-hidden transition-all duration-300">
-      <button
-        @click="showHelp = !showHelp"
-        class="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-blue-800 hover:bg-blue-100/50 transition-colors"
-      >
-        <div class="flex items-center">
-          <svg class="w-5 h-5 mr-2 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-          💡 智能体调度与托管说明
-        </div>
-        <svg
-          class="w-4 h-4 text-blue-500 transition-transform duration-200"
-          :class="showHelp ? 'rotate-180' : ''"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
-
-      <div v-show="showHelp" class="px-4 pb-4 text-sm text-blue-700/80 space-y-2 border-t border-blue-100/50 pt-3">
-        <div class="flex items-start">
-          <span class="mr-2 mt-0.5 text-blue-500 font-bold">1.</span>
-          <span>状态为 <span class="font-bold text-blue-800">启用</span> 且为 <span class="font-bold text-blue-800">SYSTEM</span> 的智能体才会被自动路由到。非 SYSTEM 的且是自己创建的智能体可以手动 <span class="font-mono bg-blue-100 px-1.5 py-0.5 rounded text-blue-800 text-xs">@</span> 访问。</span>
-        </div>
-        <div class="flex items-start">
-           <span class="mr-2 mt-0.5 text-blue-500 font-bold">2.</span>
-           <span>托管模式的智能体仅进行代理访问，具体智能体的编排开发要在 <span class="font-bold text-blue-800">RAGFlow</span> 中进行。</span>
-        </div>
-      </div>
     </div>
 
     <!-- Filters & Toolbar -->
@@ -2808,6 +2783,29 @@ const formatDate = (dateStr: string) => {
         >
           知道了
         </button>
+      </div>
+    </Modal>
+
+    <!-- 智能体调度与托管说明 Modal -->
+    <Modal
+      v-if="showHelp"
+      title="智能体调度与托管说明"
+      @close="showHelp = false"
+      size="max-w-lg"
+    >
+      <div class="space-y-4 text-sm text-gray-650 leading-relaxed py-1">
+        <div class="flex items-start">
+          <span class="mr-2.5 mt-0.5 text-blue-600 font-bold">1.</span>
+          <span>
+            状态为 <span class="font-bold text-gray-900">启用</span> 且为 <span class="font-bold text-gray-900">SYSTEM</span> 的智能体才会被自动路由到。非 SYSTEM 的且是自己创建的智能体可以手动 <span class="font-mono bg-blue-50 border border-blue-200 px-1.5 py-0.5 rounded text-blue-600 text-xs font-semibold">@</span> 访问。
+          </span>
+        </div>
+        <div class="flex items-start">
+          <span class="mr-2.5 mt-0.5 text-blue-600 font-bold">2.</span>
+          <span>
+            托管模式的智能体仅进行代理访问，具体智能体的编排开发要在 <span class="font-bold text-gray-900">RAGFlow</span> 中进行。
+          </span>
+        </div>
       </div>
     </Modal>
   </div>

--- a/frontend/src/views/ChatBIExampleManagement.vue
+++ b/frontend/src/views/ChatBIExampleManagement.vue
@@ -337,7 +337,7 @@ onMounted(async () => {
           </template>
           <template v-else>
             <span>当前 知识库引擎(RAGFlow)：</span>
-            <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" class="font-mono text-primary bg-gray-100 px-1.5 py-0.5 rounded hover:underline">{{ ragflowApiUrl }}</a>
+            <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" :title="ragflowApiUrl" class="font-mono text-primary bg-gray-100 px-1.5 py-0.5 rounded hover:underline truncate max-w-[200px] sm:max-w-[300px] inline-block align-bottom">{{ ragflowApiUrl }}</a>
             <span v-if="ragflowConfig && !ragflowConfig.api_key_configured" class="ml-2 text-amber-600 font-medium">⚠️ API Key 未配置</span>
           </template>
         </p>
@@ -374,7 +374,7 @@ onMounted(async () => {
         <div class="font-semibold text-amber-900">RAGFlow 服务连通性故障</div>
         <div class="mt-1 text-amber-800/90">{{ friendlyRagFlowError }}</div>
         <div class="mt-2 text-xs font-mono text-amber-700 bg-amber-100/50 p-2 rounded-lg">
-          <div>连接地址: <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" class="hover:underline">{{ ragflowApiUrl }}</a></div>
+          <div>连接地址: <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" :title="ragflowApiUrl" class="hover:underline truncate max-w-[200px] sm:max-w-[300px] inline-block align-bottom">{{ ragflowApiUrl }}</a></div>
           <div class="mt-0.5">错误日志: {{ errorMessage }}</div>
         </div>
       </div>

--- a/frontend/src/views/KnowledgeBaseManagement.vue
+++ b/frontend/src/views/KnowledgeBaseManagement.vue
@@ -715,7 +715,7 @@ onMounted(async () => {
         <p class="text-sm text-gray-500 mt-1">管理 RAGFlow 知识库、平台扩展元数据及一体化文档解析。</p>
         <p class="text-xs text-gray-400 mt-2 flex items-center gap-1">
           <span>当前 知识库引擎(RAGFlow)：</span>
-          <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" class="font-mono text-primary bg-gray-100 px-1.5 py-0.5 rounded hover:underline">{{ ragflowApiUrl }}</a>
+          <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" :title="ragflowApiUrl" class="font-mono text-primary bg-gray-100 px-1.5 py-0.5 rounded hover:underline truncate max-w-[200px] sm:max-w-[300px] inline-block align-bottom">{{ ragflowApiUrl }}</a>
           <span v-if="ragflowConfig && !ragflowConfig.api_key_configured" class="ml-2 text-amber-600 font-medium">⚠️ API Key 未配置</span>
         </p>
       </div>
@@ -768,7 +768,7 @@ onMounted(async () => {
         <div class="font-semibold text-amber-900">RAGFlow 服务连通性故障</div>
         <div class="mt-1 text-amber-800/90">{{ friendlyRagFlowError }}</div>
         <div class="mt-2 text-xs font-mono text-amber-700 bg-amber-100/50 p-2 rounded-lg">
-          <div>连接地址: <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" class="hover:underline">{{ ragflowApiUrl }}</a></div>
+          <div>连接地址: <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" :title="ragflowApiUrl" class="hover:underline truncate max-w-[200px] sm:max-w-[300px] inline-block align-bottom">{{ ragflowApiUrl }}</a></div>
           <div class="mt-0.5">错误日志: {{ errorMessage }}</div>
         </div>
       </div>

--- a/frontend/src/views/KnowledgeRetrievalTest.vue
+++ b/frontend/src/views/KnowledgeRetrievalTest.vue
@@ -149,7 +149,7 @@ onMounted(fetchRagFlowConfig)
         <p class="text-sm text-gray-500 mt-1">直接调用 RAGFlow Retrieval API，验证知识库 chunk 命中质量。</p>
         <p class="text-xs text-gray-400 mt-1.5">
           当前 RAGFlow 地址：
-          <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" class="font-mono text-primary hover:underline">{{ ragflowApiUrl }}</a>
+          <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" :title="ragflowApiUrl" class="font-mono text-primary hover:underline truncate max-w-[200px] sm:max-w-[300px] inline-block align-bottom">{{ ragflowApiUrl }}</a>
           <span v-if="ragflowConfig && !ragflowConfig.api_key_configured" class="ml-2 text-amber-600">API Key 未配置</span>
         </p>
       </div>
@@ -245,7 +245,7 @@ onMounted(fetchRagFlowConfig)
           <div class="font-semibold">RAGFlow 暂时不可用</div>
           <div class="mt-1">{{ friendlyRagFlowError }}</div>
           <div class="mt-2 text-xs text-amber-700">
-            配置地址：<a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" class="font-mono hover:underline">{{ ragflowApiUrl }}</a>
+            配置地址：<a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" :title="ragflowApiUrl" class="font-mono hover:underline truncate max-w-[200px] sm:max-w-[300px] inline-block align-bottom">{{ ragflowApiUrl }}</a>
           </div>
           <div class="mt-1 text-xs text-amber-600">原始错误：{{ errorMessage }}</div>
         </div>

--- a/frontend/src/views/MetadataDatasets.vue
+++ b/frontend/src/views/MetadataDatasets.vue
@@ -880,7 +880,7 @@ onMounted(async () => {
           </template>
           <template v-else>
             <span>当前 知识库引擎(RAGFlow)：</span>
-            <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" class="font-mono text-primary bg-gray-100 px-1.5 py-0.5 rounded hover:underline">{{ ragflowApiUrl }}</a>
+            <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" :title="ragflowApiUrl" class="font-mono text-primary bg-gray-100 px-1.5 py-0.5 rounded hover:underline truncate max-w-[200px] sm:max-w-[300px] inline-block align-bottom">{{ ragflowApiUrl }}</a>
             <span v-if="ragflowConfig && !ragflowConfig.api_key_configured" class="ml-2 text-amber-600 font-medium">⚠️ API Key 未配置</span>
           </template>
         </p>
@@ -947,7 +947,7 @@ onMounted(async () => {
         <div class="font-semibold text-amber-900">RAGFlow 服务连通性故障</div>
         <div class="mt-1 text-amber-800/90">{{ friendlyRagFlowError }}</div>
         <div class="mt-2 text-xs font-mono text-amber-700 bg-amber-100/50 p-2 rounded-lg">
-          <div>连接地址: <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" class="hover:underline">{{ ragflowApiUrl }}</a></div>
+          <div>连接地址: <a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" :title="ragflowApiUrl" class="hover:underline truncate max-w-[200px] sm:max-w-[300px] inline-block align-bottom">{{ ragflowApiUrl }}</a></div>
           <div class="mt-0.5">错误日志: {{ errorMessage }}</div>
         </div>
       </div>

--- a/frontend/src/views/MetadataDatasets.vue
+++ b/frontend/src/views/MetadataDatasets.vue
@@ -507,7 +507,14 @@ const tempTopK = ref(5)
 const tempThreshold = ref(0.2)
 const tempVectorWeight = ref(0.3)
 
-const showRagParams = computed(() => tempProvider.value === 'ragflow' || tempProvider.value === 'default')
+const actualProvider = computed(() => {
+  if (tempProvider.value === 'default') {
+    return (ragflowConfig.value?.metadata_provider === 'local') ? 'local' : 'ragflow'
+  }
+  return tempProvider.value
+})
+
+const showVectorWeight = computed(() => actualProvider.value === 'ragflow')
 
 const newDataset = ref({
   name: '',
@@ -910,14 +917,14 @@ onMounted(async () => {
           class="bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 px-4 py-2 rounded-lg transition-all flex items-center gap-2 font-medium"
         >
           <svg class="w-5 h-5 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
-          检索测试
+          测试
         </button>
         <button 
           @click="showSpecModal = true"
           class="border border-purple-200 text-purple-600 hover:bg-purple-50 px-4 py-2 rounded-lg transition-all flex items-center gap-2 font-medium"
         >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 17.5 5s3.332.477 4.5 1.253v13C20.832 18.477 19.246 18 17.5 18c-1.746 0-3.332.477-4.5 1.253"/></svg>
-          设计规范
+          规范
         </button>
         <button 
           v-has-perm="'element:metadata:import'"
@@ -1423,13 +1430,13 @@ onMounted(async () => {
                 </div>
 
                 <!-- Top K -->
-                <div v-if="showRagParams" class="flex items-center gap-3">
+                <div class="flex items-center gap-3">
                   <span class="w-24 text-gray-600 font-medium shrink-0 flex items-center gap-1">
                     Top K 数量:
                     <span class="group relative cursor-pointer text-gray-400 hover:text-gray-600">
                       <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
                       <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 hidden group-hover:block w-48 bg-slate-900 text-white text-[10px] p-2 rounded shadow-xl leading-normal z-50">
-                        RAGFlow 元数据检索时返回的 Top K 数量，控制 AI 可感知的表结构上限
+                        元数据检索时返回的 Top K 数量，控制 AI 可感知的表结构上限 (对应配置: ragflow_metadata_top_k)
                       </span>
                     </span>
                   </span>
@@ -1444,13 +1451,13 @@ onMounted(async () => {
                 </div>
 
                 <!-- Similarity Threshold -->
-                <div v-if="showRagParams" class="flex items-center gap-3">
+                <div class="flex items-center gap-3">
                   <span class="w-24 text-gray-600 font-medium shrink-0 flex items-center gap-1">
                     相似度阈值:
                     <span class="group relative cursor-pointer text-gray-400 hover:text-gray-600">
                       <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
                       <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 hidden group-hover:block w-48 bg-slate-900 text-white text-[10px] p-2 rounded shadow-xl leading-normal z-50">
-                        RAGFlow 语义检索的最低相似度阈值 (0-1)，越低召回率越高但越不精准
+                        语义检索的最低相似度阈值 (0-1)，低于此阈值的匹配项将被忽略，越低召回率越高但越不精准 (对应配置: ragflow_similarity_threshold)
                       </span>
                     </span>
                   </span>
@@ -1465,13 +1472,13 @@ onMounted(async () => {
                 </div>
 
                 <!-- Vector Weight -->
-                <div v-if="showRagParams" class="flex items-center gap-3">
+                <div v-if="showVectorWeight" class="flex items-center gap-3">
                   <span class="w-24 text-gray-600 font-medium shrink-0 flex items-center gap-1">
                     向量检索权重:
                     <span class="group relative cursor-pointer text-gray-400 hover:text-gray-600">
                       <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
                       <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 hidden group-hover:block w-48 bg-slate-900 text-white text-[10px] p-2 rounded shadow-xl leading-normal z-50">
-                        RAGFlow 混合检索中向量检索的权重 (0-1)，剩余为全文检索权重
+                        RAGFlow 混合检索中向量检索的权重 (0-1)，剩余为全文检索权重 (对应配置: ragflow_vector_weight)
                       </span>
                     </span>
                   </span>

--- a/frontend/src/views/MetadataDatasets.vue
+++ b/frontend/src/views/MetadataDatasets.vue
@@ -914,14 +914,14 @@ onMounted(async () => {
         </div>
         <button 
           @click="showTestModal = true"
-          class="bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 px-4 py-2 rounded-lg transition-all flex items-center gap-2 font-medium"
+          class="bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 px-4 py-2 rounded-lg transition-all flex items-center gap-2 text-sm font-medium"
         >
           <svg class="w-5 h-5 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
           测试
         </button>
         <button 
           @click="showSpecModal = true"
-          class="border border-purple-200 text-purple-600 hover:bg-purple-50 px-4 py-2 rounded-lg transition-all flex items-center gap-2 font-medium"
+          class="border border-purple-200 text-purple-600 hover:bg-purple-50 px-4 py-2 rounded-lg transition-all flex items-center gap-2 text-sm font-medium"
         >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 17.5 5s3.332.477 4.5 1.253v13C20.832 18.477 19.246 18 17.5 18c-1.746 0-3.332.477-4.5 1.253"/></svg>
           规范
@@ -929,7 +929,7 @@ onMounted(async () => {
         <button 
           v-has-perm="'element:metadata:import'"
           @click="showImportModal = true" 
-          class="flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg shadow-lg shadow-indigo-200 transition-all active:scale-95 text-sm font-bold tracking-wide"
+          class="flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg shadow-md transition-all active:scale-95 text-sm font-medium"
         >
           <svg class="w-5 h-5 text-indigo-100" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
           智能导入 (DDL)
@@ -937,7 +937,7 @@ onMounted(async () => {
         <button 
           @click="showCreateModal = true"
           v-if="hasPermission('element:metadata:edit')"
-          class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-all shadow-md flex items-center gap-2 font-medium"
+          class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-all shadow-md flex items-center gap-2 text-sm font-medium"
         >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
           新建数据集

--- a/frontend/src/views/SystemConfig.vue
+++ b/frontend/src/views/SystemConfig.vue
@@ -403,14 +403,72 @@ const getCategoryTip = (key: string) => {
     'ragflow_api_url': '对接的 RAGFlow 语义检索平台后端 API 服务地址。',
     'ragflow_api_key': '用于与 RAGFlow 进行安全 API 调用的身份验证令牌（API Key）。',
     'ragflow_dataset_ids': '与当前数据平台关联绑定的 RAGFlow 知识库 ID（可多选），用于通过语义搜索表/字段的匹配描述。',
-    'ragflow_similarity_threshold': 'RAG 检索时的向量相似度阈值（0.0 至 1.0）。数值越高，检索出的元数据与提问的相关性要求越严苛，建议为 0.4。',
-    'ragflow_vector_weight': '检索时的向量相似度权重占比（0.0 至 1.0），其余权重为全文关键词检索。值为 0.85 表示偏向于向量语义匹配。',
+    'ragflow_similarity_threshold': `【相似度阈值 (ragflow_similarity_threshold)】
+这个参数是一个过滤器（门槛），用来决定什么样的表/字段元数据片段“足够相关”，可以被送给大模型。
+
+在 RAGFlow（或者大多数先进的 RAG 检索系统）中，混合检索（Hybrid Search）通常结合了全文检索（Sparse Retrieval，如 BM25）和向量检索（Dense Retrieval，如 Vector Embeddings）。这个参数就是用来控制如何筛选这两种检索结果的核心阈值。
+
+* 原理：系统计算出元数据和用户提问的相似度分数（如余弦相似度）后，只有分数大于或等于该阈值的片段才会被保留，低于该分数的全部被丢弃。
+* 取值范围：0.0 到 1.0 之间。
+* 通俗解释：
+  - 0.0：没有任何门槛。系统会把检索出的相关表结构描述全部喂给大模型，不管它们是否相关。（容易引入大量不相关干扰信息，导致大模型混淆或胡说八道）。
+  - 0.9：门槛极高。只有和问题中表述极其相似、几乎一模一样的元数据描述才能通过。（极易导致大模型找不到任何参考表结构，回答“无法获取相关信息”）。
+
+💡 调优建议：
+* 一般推荐设置在 0.4 到 0.6 之间作为起步（平台默认建议 0.40）。
+* 如果发现大模型经常瞎编不存在的表或字段名，说明阈值太低了混入了杂音，需要调高。
+* 如果发现大模型经常明明有对应的表，却回答“找不到相关表结构”，说明门槛太高了，需要调低。`,
+    'ragflow_vector_weight': `【向量权重 (ragflow_vector_weight)】
+该参数决定了在进行元数据混合检索时，向量语义检索结果所占的分数权重。
+
+在 RAGFlow（或者大多数先进的 RAG 检索系统）中，混合检索（Hybrid Search）通常结合了全文检索（Sparse Retrieval，如 BM25）和向量检索（Dense Retrieval，如 Vector Embeddings）。这个参数就是用来平衡这两种检索结果的核心权重。
+
+* 原理：混合检索的最终得分通常是通过公式计算的：
+  最终得分 = (向量检索得分 * vector_weight) + (全文检索得分 * (1 - vector_weight))
+* 取值范围：0.0 到 1.0 之间。
+* 通俗解释：
+  - 1.0：只看语义相关度（向量检索），完全忽略关键词的完全匹配。
+  - 0.0：只看关键词匹配（全文检索），完全忽略同义词或相近语义的理解。
+  - 0.70 / 0.85（默认值）：代表系统更倾向于语义理解，但同时保留 15%~30% 的权重给精确的关键词/表名匹配。
+
+💡 调优建议：
+* 如果你的数据集多为行业术语、字母缩写、特定型号、人名或股票代码等需要精准字面匹配的场景，调低该值（如 0.3 ~ 0.4）。
+* 如果用户提问多为口语化日常表达、长句描述，或包含大量同义词（如“查找”与“搜索”），调高该值（如 0.7 ~ 0.85）。`,
     'ragflow_metadata_top_k': '检索数据库表/字段描述时，最大召回的候选文档数量。值越大，召回的内容越多，但会增加 Token 消耗。',
     'sql_execution_mode': '控制生成的 SQL 查询的执行位置。remote 表示通过安全的远程微服务沙箱执行，local 表示直连本地配置好的数据源连接池执行。',
     'chatbi_sample_knowledge_base': 'ChatBI 经验库在 RAGFlow 中自动创建和同步对应的知识库 ID（由系统自动校验与测试连接生成，不可手动修改）。',
     'chatbi_sample_top_k': '检索用户提问时召回的最相似问答案例（Few-shot）最大限制条数。值越大参考条数越多，但会占据更多的 Prompt 上下文。',
-    'chatbi_sample_similarity_threshold': '匹配用户提问与 ChatBI 历史案例时的相似度过滤阈值，推荐配置为 0.65，过滤不相关的参考案例。',
-    'chatbi_sample_vector_similarity_weight': '案例匹配时向量语义距离的权重（推荐 0.85），可与关键词全文检索进行混合比例平衡。',
+    'chatbi_sample_similarity_threshold': `【匹配相似度阈值 (chatbi_sample_similarity_threshold)】
+这个参数是一个过滤器（门槛），用来决定什么样的历史查数案例（Few-shot）“足够相似”，可以用来参考。
+
+在 RAGFlow（或者大多数先进的 RAG 检索系统）中，混合检索（Hybrid Search）通常结合了全文检索（Sparse Retrieval，如 BM25）和向量检索（Dense Retrieval，如 Vector Embeddings）。这个参数就是用来控制如何筛选这两种检索结果的核心阈值。
+
+* 原理：计算当前提问与历史案例的相似度后，只有相似度大于或等于该阈值的案例才会被作为 Prompt 参考样本提供给大模型。
+* 取值范围：0.0 到 1.0 之间。
+* 通俗解释：
+  - 0.0：无任何过滤。无论是否相关，最相似的几个案例都会全部作为 Few-shot 喂给大模型。（可能误导大模型套用错误模板，引入大量噪音导致大模型胡说八道）。
+  - 0.9：门槛极高。只有和历史案例极其吻合的提问才能匹配上，参考难度极大。（容易导致大模型找不到任何参考案例）。
+
+💡 调优建议：
+* 一般推荐设置在 0.5 到 0.7 之间作为起步（平台默认建议 0.65，在本地模式下建议 0.40）。
+* 若大模型经常乱套用历史案例的 SQL 模板，说明阈值太低了混入了杂音，需要调高。
+* 若明明有相似案例大模型却无法参考，说明门槛太高了，需要调低。`,
+    'chatbi_sample_vector_similarity_weight': `【案例向量权重 (chatbi_sample_vector_similarity_weight)】
+此权重用于控制匹配 ChatBI 案例时，向量语义相似度分数的占比权重。
+
+在 RAGFlow（或者大多数先进的 RAG 检索系统）中，混合检索（Hybrid Search）通常结合了全文检索（Sparse Retrieval，如 BM25）和向量检索（Dense Retrieval，如 Vector Embeddings）。这个参数就是用来平衡这两种检索结果的核心权重。
+
+* 原理：混合检索的最终得分通常是通过公式计算的：
+  最终得分 = (向量检索得分 * vector_weight) + (全文检索得分 * (1 - vector_weight))
+* 取值范围：0.0 到 1.0 之间。
+* 通俗解释：
+  - 1.0：只以语义相似度进行案例搜索（向量检索），完全忽略关键词的精确字面匹配。
+  - 0.0：只以字面关键词匹配进行案例搜索（全文检索），完全忽略同义词或相近语义的理解。
+  - 0.85（默认值）：更倾向于语义匹配，保证在追问或同义表达时仍能稳定匹配到相应的查数案例（保留 15% 权重给关键词精确匹配）。
+
+💡 调优建议：
+* 如果案例中包含大量行业术语、人名、股票代码或特定型号等需要精准字面匹配的词，调低该值（如 0.3 ~ 0.5）。
+* 如果用户提问多为日常用语、描述性问题或包含大量同义词，调高该值（如 0.7 ~ 0.85）。`,
     'embedchat_watermark_enabled': '开启后，将在嵌入式对话界面（EmbedChat）背景中平铺渲染防止信息截屏泄露的安全审计水印。',
     'embedchat_watermark_style': '水印的文字样式方案。可以选择【用户名 + 时间戳】或【自定义文字 + 时间戳】（两者均会自动附加当前时间戳）。',
     'embedchat_watermark_text': '当水印样式为【自定义文字 + 时间戳】时，在对话背景中平铺显示的自定义文本，末尾会自动追加时间戳。',
@@ -423,8 +481,37 @@ const getCategoryTip = (key: string) => {
     'knowledge_ragflow_api_url': '对接的 RAGFlow 语义检索平台后端 API 服务地址，用于常规智能体的知识库问答检索。',
     'knowledge_ragflow_api_key': '用于与 RAGFlow 知识库服务进行安全 API 调用的身份验证令牌（API Key）。',
     'knowledge_ragflow_dataset_ids': '当前系统关联绑定的默认知识库 ID（可多选），用于为智能体问答检索背景文档和常识参考。',
-    'knowledge_ragflow_similarity_threshold': '知识库问答检索时的最低相似度阈值（0.0 至 1.0），过滤相关性低于该设定的文档片段。建议为 0.20。',
-    'knowledge_ragflow_vector_weight': '知识库问答检索时向量相似度的权重比例（0.0 至 1.0），其余为全文关键词检索。值为 0.30 表示混合偏向关键词组合。',
+    'knowledge_ragflow_similarity_threshold': `【相似度阈值 (knowledge_ragflow_similarity_threshold)】
+这个参数是一个过滤器（门槛），用来决定什么样的知识库文档片段“足够相关”，可以被送给大模型。
+
+在 RAGFlow（或者大多数先进的 RAG 检索系统）中，混合检索（Hybrid Search）通常结合了全文检索（Sparse Retrieval，如 BM25）和向量检索（Dense Retrieval，如 Vector Embeddings）。这个参数就是用来控制如何筛选这两种检索结果的核心阈值。
+
+* 原理：系统计算出文档和用户问题的相似度分数（如余弦相似度）后，只有分数大于或等于该阈值的文档片段才会被保留，低于该分数的全部被丢弃。
+* 取值范围：0.0 到 1.0 之间。
+* 通俗解释：
+  - 0.0：没有任何门槛。系统会把检索出的所有文档段落全部喂给大模型，不管它们是否真的相关。（容易引入大量噪音，导致大模型胡说八道）。
+  - 0.9：门槛极高。只有和提问几乎一模一样的文档段落才能通过。（极易导致大模型找不到任何参考资料，回答“不知道”）。
+
+💡 调优建议：
+* 一般推荐设置在 0.2 到 0.4 之间作为起步（平台默认建议 0.20）。
+* 如果发现大模型经常瞎编无关事实，说明阈值太低了混入了杂音，需要调高。
+* 如果发现大模型经常明明有对应的知识，却回答“知识库中没有相关信息”，说明门槛太高了，需要调低。`,
+    'knowledge_ragflow_vector_weight': `【向量权重 (knowledge_ragflow_vector_weight)】
+该参数决定了在进行知识库混合检索时，向量语义检索结果所占的分数权重。
+
+在 RAGFlow（或者大多数先进的 RAG 检索系统）中，混合检索（Hybrid Search）通常结合了全文检索（Sparse Retrieval，如 BM25）和向量检索（Dense Retrieval，如 Vector Embeddings）。这个参数就是用来平衡这两种检索结果的核心权重。
+
+* 原理：混合检索的最终得分通常是通过公式计算的：
+  最终得分 = (向量检索得分 * vector_weight) + (全文检索得分 * (1 - vector_weight))
+* 取值范围：0.0 到 1.0 之间。
+* 通俗解释：
+  - 1.0：只看语义相关度（向量检索），完全忽略关键词的精确字面匹配。
+  - 0.0：只看关键词匹配（全文检索），完全忽略同义词或相近语义的理解。
+  - 0.30（默认值）：代表知识库检索更倾向于全文关键词匹配（占 70% 权重），对精准度要求较高。
+
+💡 调优建议：
+* 如果知识库多为技术文档、规格手册或包含大量专业代号，调低该值（如 0.2 ~ 0.3）。
+* 如果问题比较多样化、偏口语表述，调高该值（如 0.6 ~ 0.7）以强化语义召回。`,
     'knowledge_ragflow_metadata_top_k': '知识库问答检索时，最大召回匹配的候选文档片段数。值越大参考条数越多，但会消耗更多的模型 Token。'
   }
   return tips[key] || ''
@@ -1326,9 +1413,19 @@ onMounted(() => {
                                         class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-primary disabled:opacity-50"
                                       />
                                       <div class="flex justify-between text-xs text-gray-400 mt-1 font-mono">
-                                          <span class="flex items-center">0.0<span v-if="item.key === 'llm_temperature'" class="text-[10px] text-gray-500 font-sans ml-1 select-none">(更严谨/精准)</span></span>
+                                          <span class="flex items-center">
+                                            0.0
+                                            <span v-if="item.key === 'llm_temperature'" class="text-[10px] text-gray-500 font-sans ml-1 select-none">(更严谨/精准)</span>
+                                            <span v-else-if="['ragflow_similarity_threshold', 'chatbi_sample_similarity_threshold', 'knowledge_ragflow_similarity_threshold'].includes(item.key)" class="text-[10px] text-gray-500 font-sans ml-1 select-none">(无门槛)</span>
+                                            <span v-else-if="['ragflow_vector_weight', 'chatbi_sample_vector_similarity_weight', 'knowledge_ragflow_vector_weight'].includes(item.key)" class="text-[10px] text-gray-500 font-sans ml-1 select-none">(只看关键词)</span>
+                                          </span>
                                           <span>0.5</span>
-                                          <span class="flex items-center">1.0<span v-if="item.key === 'llm_temperature'" class="text-[10px] text-gray-500 font-sans ml-1 select-none">(更随机/发散)</span></span>
+                                          <span class="flex items-center">
+                                            1.0
+                                            <span v-if="item.key === 'llm_temperature'" class="text-[10px] text-gray-500 font-sans ml-1 select-none">(更随机/发散)</span>
+                                            <span v-else-if="['ragflow_similarity_threshold', 'chatbi_sample_similarity_threshold', 'knowledge_ragflow_similarity_threshold'].includes(item.key)" class="text-[10px] text-gray-500 font-sans ml-1 select-none">(极高门槛)</span>
+                                            <span v-else-if="['ragflow_vector_weight', 'chatbi_sample_vector_similarity_weight', 'knowledge_ragflow_vector_weight'].includes(item.key)" class="text-[10px] text-gray-500 font-sans ml-1 select-none">(只看语义)</span>
+                                          </span>
                                       </div>
                                   </div>
                                   <div class="w-16">
@@ -1588,9 +1685,9 @@ onMounted(() => {
 
     <!-- Generic Config Explanation Modal -->
     <div v-if="activeExplanationItem" class="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm" @click.self="activeExplanationItem = null">
-      <div class="bg-white rounded-2xl shadow-2xl max-w-md w-full overflow-hidden scale-100 transition-all duration-200 border border-gray-100 flex flex-col">
+      <div class="bg-white rounded-2xl shadow-2xl max-w-md w-full max-h-[85vh] overflow-hidden scale-100 transition-all duration-200 border border-gray-100 flex flex-col">
         <!-- Header -->
-        <div class="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50/50">
+        <div class="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50/50 shrink-0">
           <div class="flex items-center space-x-2.5">
             <div class="p-2 bg-primary/10 rounded-xl text-primary">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
@@ -1609,10 +1706,10 @@ onMounted(() => {
           </button>
         </div>
         <!-- Content -->
-        <div class="p-6 space-y-4 text-sm text-gray-600">
+        <div class="p-6 space-y-4 text-sm text-gray-600 overflow-y-auto custom-scrollbar flex-1">
           <div class="space-y-2">
             <span class="text-xs font-bold text-gray-400 uppercase tracking-wider font-mono">功能描述</span>
-            <p class="text-gray-700 leading-relaxed bg-gray-50 p-4 rounded-xl border border-gray-100">
+            <p class="text-gray-700 leading-relaxed bg-gray-50 p-4 rounded-xl border border-gray-100 whitespace-pre-wrap">
               {{ activeExplanationItem.description || '暂无描述信息。' }}
             </p>
           </div>
@@ -1620,13 +1717,13 @@ onMounted(() => {
           <!-- Category specific tips -->
           <div class="space-y-2" v-if="getCategoryTip(activeExplanationItem.key)">
             <span class="text-xs font-bold text-gray-400 uppercase tracking-wider font-mono">使用建议</span>
-            <p class="text-xs text-gray-600 leading-relaxed bg-indigo-50/50 p-4 rounded-xl border border-indigo-100/50 text-indigo-950">
+            <p class="text-xs text-gray-600 leading-relaxed bg-indigo-50/50 p-4 rounded-xl border border-indigo-100/50 text-indigo-950 whitespace-pre-wrap">
               {{ getCategoryTip(activeExplanationItem.key) }}
             </p>
           </div>
         </div>
         <!-- Footer -->
-        <div class="bg-gray-50 px-6 py-4 flex justify-end border-t border-gray-100">
+        <div class="bg-gray-50 px-6 py-4 flex justify-end border-t border-gray-100 shrink-0">
           <button 
             @click="activeExplanationItem = null" 
             type="button" 

--- a/tests/ai/runners/test_data_agent_runner.py
+++ b/tests/ai/runners/test_data_agent_runner.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from pydantic import BaseModel
 
@@ -51,6 +52,44 @@ def isolate_data_agent_runtime(monkeypatch):
     monkeypatch.setattr(
         "app.services.ai.runners.data_agent_runner.agent_state_store.save",
         AsyncMock(return_value=None),
+    )
+
+    async def fake_config_get(key, default=None):
+        if key == "agent_max_iterations":
+            return "5"
+        return default
+
+    fake_llm_handle = SimpleNamespace(
+        native_model=SimpleNamespace(model="fake-native-data"),
+        model_name="fake-native-data",
+        temperature=0.0,
+        streaming=True,
+    )
+
+    monkeypatch.setattr(
+        "app.services.ai.runners.data_agent_runner.ConfigService.get",
+        fake_config_get,
+    )
+    monkeypatch.setattr(
+        "app.services.ai.runners.data_agent_runner.AgentConfigProvider.get_configured_llm",
+        AsyncMock(return_value=fake_llm_handle),
+    )
+
+    async def fake_schema(**kwargs):
+        return "table_name: demo\ncolumns: id, status, count, total"
+
+    async def fake_sql(**kwargs):
+        return [{"id": 1}]
+
+    monkeypatch.setitem(
+        __import__("app.services.ai.tools.registry", fromlist=["ToolRegistry"]).ToolRegistry._registry,
+        "get_dataset_schema",
+        fake_schema,
+    )
+    monkeypatch.setitem(
+        __import__("app.services.ai.tools.registry", fromlist=["ToolRegistry"]).ToolRegistry._registry,
+        "execute_sql_query",
+        fake_sql,
     )
 
 
@@ -857,11 +896,13 @@ async def test_data_agent_runner_execute_streams_agentscope_native_text(
 
         async def _call_api(self, model_name, messages, tools=None, tool_choice=None, **kwargs):
             assert tools
-            assert [tool["function"]["name"] for tool in tools] == [
+            tool_names = [tool["function"]["name"] for tool in tools]
+            assert tool_names[:3] == [
                 "update_dashboard_context",
                 "get_dataset_schema",
                 "execute_sql_query",
             ]
+            assert "get_current_time" in tool_names
             tool_results = [
                 block
                 for msg in messages
@@ -884,7 +925,7 @@ async def test_data_agent_runner_execute_streams_agentscope_native_text(
                         ToolCallBlock(
                             id="call_sql",
                             name="execute_sql_query",
-                            input='{"sql": "SELECT 1", "data_source": "mysql_aiagent", "dataset_name": "demo"}',
+                            input='{"sql": "SELECT id FROM demo LIMIT 1", "data_source": "mysql_aiagent", "dataset_name": "demo"}',
                         )
                     ],
                     is_last=True,
@@ -1244,7 +1285,7 @@ async def test_data_agent_runner_injects_few_shot_examples(
         events.append(chunk)
 
     mock_search.assert_awaited_once()
-    assert mock_search.await_args.kwargs["top_k"] == 5
+    assert mock_search.await_args.kwargs["top_k"] is None
     assert any("命中经验库案例" in str(chunk.get("title", "")) for chunk in events)
     mock_record.assert_awaited_once()
     assert any(chunk.get("content") == "参考案例查好了" for chunk in events)
@@ -1397,7 +1438,7 @@ async def test_data_agent_runner_rewrites_contextual_query_and_plans_schema_keyw
                         ToolCallBlock(
                             id="call_sql",
                             name="execute_sql_query",
-                            input='{"sql": "SELECT 1", "data_source": "mysql_oa", "dataset_name": "pue"}',
+                            input='{"sql": "SELECT id FROM pue LIMIT 1", "data_source": "mysql_oa", "dataset_name": "pue"}',
                         )
                     ],
                     is_last=True,
@@ -1785,6 +1826,38 @@ def test_high_confidence_schema_candidates_require_clarification(data_config):
     assert "多个高置信度" in runner._build_repair_message(state)
 
 
+def test_schema_success_after_misses_recovers_schema_state(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-schema-recover", trace_buffer=[])
+    state = _DataRunState(requires_fresh_data=True)
+
+    runner._apply_schema_tool_result(state, "No relevant schema info found for '用户 注册'.")
+    runner._apply_schema_tool_result(state, "No relevant schema info found for '用户 注册 数据集'.")
+    assert state.schema_miss_count == 2
+    assert runner._is_schema_fatal(state) is True
+
+    runner._apply_schema_tool_result(
+        state,
+        "[置信度: 0.75]\n"
+        "--- Source: ai_agent_users.txt ---\n"
+        "table_name: ai_agent_users\n"
+        "dataset: ai_agent_meta\n"
+        "data_source: mysql_aiagent\n"
+        "columns:\n"
+        "- name: id\n"
+        "  type: Int64\n"
+        "- name: username\n"
+        "  type: String\n",
+    )
+
+    assert state.schema_miss is False
+    assert state.schema_miss_count == 0
+    assert state.schema_completed is True
+    assert runner._is_schema_fatal(state) is False
+    assert runner._resolve_force_execute_sql_tool_choice(state).mode == "execute_sql_query"
+
+
 def test_diagnostic_sql_success_requires_final_sql_before_answer(data_config):
     from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
 
@@ -2008,14 +2081,14 @@ async def test_data_agent_runner_schema_gate_blocks_sql_tool(data_config):
     wrapped = runner._wrap_tools_with_schema_gate([spec], state)[0]
 
     result = await wrapped.invoke(
-        {"sql": "SELECT 1", "data_source": "mysql_aiagent", "dataset_name": "demo"}
+        {"sql": "SELECT id FROM demo LIMIT 1", "data_source": "mysql_aiagent", "dataset_name": "demo"}
     )
 
     assert invoked is False
     assert "[SCHEMA_GATE]" in str(result)
     state.schema_completed = True
     result2 = await wrapped.invoke(
-        {"sql": "SELECT 1", "data_source": "mysql_aiagent", "dataset_name": "demo"}
+        {"sql": "SELECT id FROM demo LIMIT 1", "data_source": "mysql_aiagent", "dataset_name": "demo"}
     )
     assert invoked is True
     assert result2 == [{"ok": 1}]
@@ -2048,15 +2121,58 @@ async def test_data_agent_runner_sql_repeat_gate_blocks_second_sql(data_config):
         empty_sql_result=False,
         sql_error=False,
     )
+    state.successful_sqls["select id from demo limit 10"] = '{"columns": [{"name": "id"}], "items": [[1]]}'
     runner = DataAgentRunner(config=data_config, trace_id="trace-sql-repeat-gate", trace_buffer=[])
     wrapped = runner._wrap_tools_with_schema_gate([spec], state)[0]
 
     result = await wrapped.invoke(
-        {"sql": "SELECT 2", "data_source": "mysql_aiagent", "dataset_name": "demo"}
+        {"sql": "SELECT id FROM demo LIMIT 10", "data_source": "mysql_aiagent", "dataset_name": "demo"}
     )
 
     assert call_count == 0
     assert "[SQL_REPEAT_GATE]" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_data_agent_runner_sql_static_gate_takes_precedence_over_repeat_cache(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
+    from app.services.ai.runtime.agentscope.tools import RuntimeToolSpec
+
+    call_count = 0
+
+    async def fake_sql(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        return '{"columns": [{"name": "id"}], "items": [[1]]}'
+
+    spec = RuntimeToolSpec(
+        name="execute_sql_query",
+        description="sql",
+        parameters_schema={"type": "object", "properties": {}},
+        source_type="static",
+        callable=fake_sql,
+        permission_scope="read",
+    )
+    state = _DataRunState(
+        requires_fresh_data=True,
+        schema_completed=True,
+        sql_completed=True,
+        empty_sql_result=False,
+        sql_error=False,
+    )
+    state.successful_sqls["select id from demo"] = '{"columns": [{"name": "id"}], "items": [[1]]}'
+    runner = DataAgentRunner(config=data_config, trace_id="trace-static-before-repeat", trace_buffer=[])
+    wrapped = runner._wrap_tools_with_schema_gate([spec], state)[0]
+
+    result = await wrapped.invoke(
+        {"sql": "SELECT id FROM demo", "data_source": "mysql_aiagent", "dataset_name": "demo"}
+    )
+
+    assert call_count == 0
+    assert "[SQL_STATIC_GATE]" in str(result)
+    assert "[SQL_REPEAT_GATE]" not in str(result)
+    assert state.sql_static_risk is True
+    assert state.sql_repeat_gate_block is False
 
 
 @pytest.mark.asyncio
@@ -2083,9 +2199,246 @@ async def test_data_agent_runner_sql_repeat_gate_updates_state_completed(data_co
     )
 
     assert state.sql_completed is True
+    assert state.sql_repeat_gate_block is True
     assert state.last_successful_sql_output == '{"columns": [{"name": "id"}], "items": [[1]]}'
     assert parsed == {"columns": [{"name": "id"}], "items": [[1]]}
     assert should_save is False
+
+
+@pytest.mark.asyncio
+async def test_data_agent_runner_synthesizes_after_repeated_sql_gate(
+    data_config,
+    monkeypatch,
+):
+    from agentscope.credential import CredentialBase
+    from agentscope.message import ToolCallBlock
+    from agentscope.model import ChatModelBase, ChatResponse
+
+    from app.core.llm.client import AgentScopeLLMHandle
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner
+
+    class FakeCredential(CredentialBase):
+        @classmethod
+        def get_chat_model_class(cls):
+            return FakeModel
+
+    class FakeModel(ChatModelBase):
+        class Parameters(BaseModel):
+            pass
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.calls = 0
+
+        async def _call_api(self, model_name, messages, tools=None, tool_choice=None, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return ChatResponse(
+                    content=[
+                        ToolCallBlock(
+                            id="call_schema",
+                            name="get_dataset_schema",
+                            input='{"keywords": "demo"}',
+                        )
+                    ],
+                    is_last=True,
+                )
+            return ChatResponse(
+                content=[
+                    ToolCallBlock(
+                        id=f"call_sql_{self.calls}",
+                        name="execute_sql_query",
+                        input='{"sql": "SELECT id FROM demo LIMIT 100", "data_source": "mysql_aiagent", "dataset_name": "demo"}',
+                    )
+                ],
+                is_last=True,
+            )
+
+    class FakeSynthesisLLM:
+        model_name = "synthesis-model"
+
+        async def astream(self, messages):
+            assert "重复调用相同 SQL" in messages[-1].content
+            yield AIMessage(content="已基于首次 SQL 结果完成回答。")
+
+    async def fake_load_context_config():
+        return None
+
+    async def fake_build_model_config(**kwargs):
+        return None
+
+    async def fake_config_get(key):
+        return "8"
+
+    fake_model = FakeModel(
+        credential=FakeCredential(),
+        model="fake-native-data",
+        parameters=FakeModel.Parameters(),
+        stream=False,
+        max_retries=0,
+    )
+    handle = AgentScopeLLMHandle(
+        native_model=fake_model,
+        model_name="fake-native-data",
+        temperature=0.0,
+        streaming=True,
+    )
+
+    async def fake_get_configured_llm(**kwargs):
+        return handle
+
+    async def fake_schema(keywords=None):
+        return "table_name: demo\ncolumns: id"
+
+    sql_calls = 0
+
+    async def fake_sql(sql, data_source, dataset_name):
+        nonlocal sql_calls
+        sql_calls += 1
+        return {"columns": [{"name": "id"}], "items": [[1]]}
+
+    monkeypatch.setattr(
+        "app.services.ai.runners.data_agent_runner.AgentConfigProvider.get_configured_llm",
+        fake_get_configured_llm,
+    )
+    monkeypatch.setattr(
+        "app.services.ai.runners.data_agent_runner.AgentConfigProvider.get_synthesis_llm",
+        AsyncMock(return_value=FakeSynthesisLLM()),
+    )
+    monkeypatch.setattr(
+        "app.services.ai.runners.data_agent_runner.load_context_config",
+        fake_load_context_config,
+    )
+    monkeypatch.setattr(
+        "app.services.ai.runners.data_agent_runner.build_model_config",
+        fake_build_model_config,
+    )
+    monkeypatch.setattr(
+        "app.services.ai.runners.data_agent_runner.ConfigService.get",
+        fake_config_get,
+    )
+
+    from app.services.ai.tools.registry import ToolRegistry
+
+    monkeypatch.setitem(ToolRegistry._registry, "get_dataset_schema", fake_schema)
+    monkeypatch.setitem(ToolRegistry._registry, "execute_sql_query", fake_sql)
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-repeat-synth", trace_buffer=[])
+
+    events = []
+    async for chunk in runner.execute([{"role": "user", "content": "查 demo"}]):
+        events.append(chunk)
+
+    content = "".join(event["content"] for event in events if "content" in event and "type" not in event)
+    assert content == "已基于首次 SQL 结果完成回答。"
+    assert sql_calls == 1
+    assert fake_model.calls < 8
+    assert any(event.get("title") == "复用已执行 SQL 结果" for event in events if isinstance(event, dict))
+
+
+def test_data_agent_runner_tool_loop_fuse_triggers_on_repeated_same_tool_args(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-tool-loop-fuse", trace_buffer=[])
+    state = _DataRunState()
+
+    for _ in range(2):
+        runner._record_tool_call_signature(state, "get_dataset_schema", {"keywords": "机房"})
+        assert state.tool_loop_fuse_triggered is False
+
+    runner._record_tool_call_signature(state, "get_dataset_schema", {"keywords": "机房"})
+
+    assert state.tool_loop_fuse_triggered is True
+    assert state.halt_current_react is True
+    assert "get_dataset_schema" in state.tool_loop_fuse_reason
+    assert runner._current_repair_kind(state) == "tool_loop_fuse"
+
+
+def test_tool_loop_fuse_does_not_trigger_after_schema_progress(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-schema-progress-fuse", trace_buffer=[])
+    state = _DataRunState(requires_fresh_data=True)
+    tool_args = {"keywords": "用户 注册"}
+
+    for output in (
+        "No relevant schema info found for '用户 注册'.",
+        "No relevant schema info found for '用户 注册 数据集'.",
+    ):
+        runner._apply_schema_tool_result(state, output)
+        runner._record_tool_call_signature(state, "get_dataset_schema", tool_args)
+
+    runner._apply_schema_tool_result(
+        state,
+        "[置信度: 0.75]\n"
+        "--- Source: ai_agent_users.txt ---\n"
+        "table_name: ai_agent_users\n"
+        "columns:\n"
+        "- name: id\n"
+        "  type: Int64\n",
+    )
+    runner._record_tool_call_signature(state, "get_dataset_schema", tool_args)
+
+    assert state.schema_completed is True
+    assert state.tool_loop_fuse_triggered is False
+    assert state.tool_call_signatures == {}
+
+
+def test_data_agent_runner_detects_negative_duration_anomaly(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-duration-anomaly", trace_buffer=[])
+    state = _DataRunState(requires_fresh_data=True, schema_completed=True)
+    payload = {
+        "columns": [
+            {"name": "datacenter_id"},
+            {"name": "last_update_time"},
+            {"name": "interval_seconds"},
+        ],
+        "items": [["BJ_YF_01", "2026-06-14T10:00:00", -31400679]],
+    }
+
+    parsed, should_save = runner._apply_sql_tool_result(
+        state,
+        tool_args={
+            "sql": "SELECT datacenter_id, last_update_time, interval_seconds FROM demo LIMIT 20",
+        },
+        output=json.dumps(payload, ensure_ascii=False),
+    )
+
+    assert parsed == payload
+    assert should_save is False
+    assert state.duration_anomaly is True
+    assert state.ready_to_answer is False
+    assert runner._current_repair_kind(state) == "duration_anomaly"
+    assert "interval_seconds" in state.duration_anomaly_reason
+    assert "时间差/时延" in runner._build_repair_message(state)
+
+
+def test_data_agent_runner_detects_extreme_delay_seconds_anomaly(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-delay-anomaly", trace_buffer=[])
+
+    abnormal, reason = runner._detect_duration_anomaly(
+        [{"dc": "SH", "latency_seconds": 60 * 60 * 24 * 30}]
+    )
+
+    assert abnormal is True
+    assert "latency_seconds" in reason
+
+
+def test_data_agent_runner_allows_normal_duration_values(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-duration-normal", trace_buffer=[])
+
+    abnormal, reason = runner._detect_duration_anomaly(
+        {"columns": [{"name": "duration_seconds"}], "items": [[3600]]}
+    )
+
+    assert abnormal is False
+    assert reason == ""
 
 
 @pytest.mark.asyncio
@@ -2120,7 +2473,7 @@ async def test_data_agent_runner_sql_repeat_gate_allows_after_empty_result(data_
     wrapped = runner._wrap_tools_with_schema_gate([spec], state)[0]
 
     result = await wrapped.invoke(
-        {"sql": "SELECT 1", "data_source": "mysql_aiagent", "dataset_name": "demo"}
+        {"sql": "SELECT id FROM demo LIMIT 10", "data_source": "mysql_aiagent", "dataset_name": "demo"}
     )
 
     assert call_count == 1
@@ -2266,7 +2619,7 @@ async def test_data_agent_runner_marks_schema_miss_and_blocks_sql_before_schema(
 
 
 @pytest.mark.asyncio
-async def test_data_agent_runner_marks_no_authorized_schema_and_sql_error(data_config):
+async def test_data_agent_runner_marks_no_authorized_schema_and_blocks_sql_before_schema(data_config):
     from types import SimpleNamespace
 
     from app.services.ai.runners.data_agent_runner import DataAgentRunner
@@ -2279,7 +2632,7 @@ async def test_data_agent_runner_marks_no_authorized_schema_and_sql_error(data_c
         yield SimpleNamespace(
             type="TOOL_CALL_DELTA",
             tool_call_id="call_sql",
-            delta='{"sql": "SELECT bad_col FROM demo", "data_source": "mysql_aiagent", "dataset_name": "demo"}',
+            delta='{"sql": "SELECT bad_col FROM demo LIMIT 10", "data_source": "mysql_aiagent", "dataset_name": "demo"}',
         )
         yield SimpleNamespace(type="TOOL_RESULT_TEXT_DELTA", tool_call_id="call_sql", delta="Unknown column 'bad_col'")
         yield SimpleNamespace(type="TOOL_RESULT_END", tool_call_id="call_sql")
@@ -2296,8 +2649,8 @@ async def test_data_agent_runner_marks_no_authorized_schema_and_sql_error(data_c
     assert runner._last_run_state.no_authorized_schema is True
     assert runner._last_run_state.schema_completed is False
     assert runner._is_schema_fatal(runner._last_run_state) is True
-    assert runner._last_run_state.sql_error is True
-    assert "Unknown column" in runner._last_run_state.sql_error_message
+    assert runner._last_run_state.sql_before_schema is True
+    assert runner._last_run_state.sql_error is False
 
 
 def test_format_tool_details_truncates_long_output(data_config):
@@ -2792,7 +3145,7 @@ async def test_data_agent_runner_execute_repairs_sql_error_before_final_answer(
                         ToolCallBlock(
                             id="call_bad_sql",
                             name="execute_sql_query",
-                            input='{"sql": "SELECT bad_col FROM demo", "data_source": "mysql_aiagent", "dataset_name": "demo"}',
+                            input='{"sql": "SELECT bad_col FROM demo LIMIT 10", "data_source": "mysql_aiagent", "dataset_name": "demo"}',
                         )
                     ],
                     is_last=True,

--- a/tests/ai/runtime/test_agentscope_runtime_foundation.py
+++ b/tests/ai/runtime/test_agentscope_runtime_foundation.py
@@ -124,6 +124,47 @@ def test_runtime_error_envelope_normalizes_unknown_errors():
 
 
 @pytest.mark.asyncio
+async def test_model_call_stats_middleware_handles_keyerror_getattr_response(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from app.services.ai.runtime.agentscope.middleware import ModelCallStatsMiddleware
+
+    class KeyErrorGetattrResponse:
+        content = []
+        text = "ok"
+        usage = None
+
+        def __getattr__(self, name):
+            raise KeyError(name)
+
+    async def next_handler(**kwargs):
+        return KeyErrorGetattrResponse()
+
+    monkeypatch.setattr(
+        "app.services.ai.runtime.agentscope.middleware._append_stat_to_redis",
+        AsyncMock(),
+    )
+    middleware = ModelCallStatsMiddleware(
+        user_id="u1",
+        conversation_id="c1",
+        agent_name="DataAgent",
+        trace_id="trace-1",
+    )
+
+    result = await middleware.on_model_call(
+        agent=None,
+        input_kwargs={
+            "current_model": types.SimpleNamespace(model="fake-model"),
+            "messages": [],
+            "tools": [],
+        },
+        next_handler=next_handler,
+    )
+
+    assert result.text == "ok"
+
+
+@pytest.mark.asyncio
 async def test_model_factory_requires_api_key_for_openai_compatible_model(monkeypatch):
     from app.services.ai.runtime.agentscope.models import AgentScopeModelConfig, create_openai_chat_model
 

--- a/tests/ai/test_turn_classifier.py
+++ b/tests/ai/test_turn_classifier.py
@@ -384,6 +384,87 @@ async def test_data_query_turn_classifier_requires_recent_context_for_reuse():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "我要看各机房数据采集是否延迟",
+        "我要看各门店库存是否异常",
+        "检查各客户订单同步状态",
+        "查看各项目回款是否延迟",
+        "确认各渠道线索是否断流",
+    ],
+)
+async def test_data_query_turn_classifier_rescues_business_status_query_from_stale_reuse(query):
+    llm = object()
+    chat_client = _mock_chat_client('{"turn_type":"reuse_previous_result","reasoning":"误判为基于上一轮结果继续分析"}')
+
+    stale_history = [
+        {"role": "user", "content": "查询用户列表"},
+        {"role": "assistant", "content": "已返回用户列表。"},
+        {"role": "user", "content": "你好"},
+        {"role": "assistant", "content": "你好。"},
+        {"role": "user", "content": "你是谁"},
+        {"role": "assistant", "content": "我是助手。"},
+        {"role": "user", "content": "帮我写个说明"},
+        {"role": "assistant", "content": "好的。"},
+        {"role": "user", "content": query},
+    ]
+
+    with patch(
+        "app.services.ai.config.AgentConfigProvider.get_configured_llm",
+        AsyncMock(return_value=llm),
+    ), patch(
+        "app.services.ai.data_query_turn_classifier.chat_client_from_handle",
+        return_value=chat_client,
+    ):
+        classification, _, _ = await resolve_data_query_turn_classification(
+            query,
+            stale_history,
+            has_last_data_result=True,
+        )
+
+    assert classification.turn_type == DataQueryTurnType.NEW_DATA_QUERY
+    assert classification.requires_fresh_data is True
+    assert classification.requires_few_shot is True
+    assert "明确新数据查询" in classification.reasoning
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query", ["帮我看看这个状态", "这个是否正常"])
+async def test_data_query_turn_classifier_keeps_vague_status_followup_as_clarification(query):
+    llm = object()
+    chat_client = _mock_chat_client('{"turn_type":"reuse_previous_result","reasoning":"用户像是在追问上一轮状态"}')
+
+    stale_history = [
+        {"role": "user", "content": "查询用户列表"},
+        {"role": "assistant", "content": "已返回用户列表。"},
+        {"role": "user", "content": "你好"},
+        {"role": "assistant", "content": "你好。"},
+        {"role": "user", "content": "你是谁"},
+        {"role": "assistant", "content": "我是助手。"},
+        {"role": "user", "content": "帮我写个说明"},
+        {"role": "assistant", "content": "好的。"},
+        {"role": "user", "content": query},
+    ]
+
+    with patch(
+        "app.services.ai.config.AgentConfigProvider.get_configured_llm",
+        AsyncMock(return_value=llm),
+    ), patch(
+        "app.services.ai.data_query_turn_classifier.chat_client_from_handle",
+        return_value=chat_client,
+    ):
+        classification, _, _ = await resolve_data_query_turn_classification(
+            query,
+            stale_history,
+            has_last_data_result=True,
+        )
+
+    assert classification.turn_type == DataQueryTurnType.CLARIFICATION_OR_NON_DATA
+    assert "最近对话" in classification.reasoning
+
+
+@pytest.mark.asyncio
 async def test_data_query_turn_classifier_allows_polite_followup_with_reusable_result():
     llm = object()
     chat_client = _mock_chat_client('{"turn_type":"reuse_previous_result","reasoning":"用户礼貌地要求分析当前数据结果"}')

--- a/tests/ai/tools/test_data_api.py
+++ b/tests/ai/tools/test_data_api.py
@@ -1,7 +1,7 @@
 import pytest
 import json
 import httpx
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import ANY, MagicMock, AsyncMock, patch
 from app.services.ai.tools.data_api import (
     validate_sql, 
     call_external_sql_api, 
@@ -51,7 +51,7 @@ async def test_call_external_sql_api_success():
     
     with patch("app.services.config_service.ConfigService.get", new_callable=AsyncMock) as mock_config, \
          patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
-        
+
         mock_config.side_effect = lambda k, **kwargs: {
             "external_sql_api_url": "http://api/sql",
             "external_sql_api_key": "key123",
@@ -115,30 +115,95 @@ async def test_call_ragflow_api_success():
 # --- Tool Integration Tests ---
 
 @pytest.mark.asyncio
+@pytest.mark.no_infrastructure
 async def test_get_dataset_schema_tool():
-    """测试元数据查询工具 (使用 .invoke)"""
+    """local 模式优先走本地向量检索，而不是返回全量授权 YAML。"""
     mock_ds = MagicMock()
-    mock_ds.id = "ds_1"
+    mock_ds.id = 1
     mock_ds.display_name = "User Stats"
     mock_ds.name = "user_stats"
-    
+
     with patch("app.core.orm.AsyncSessionLocal", new_callable=MagicMock), \
          patch("app.services.config_service.ConfigService.get", new_callable=AsyncMock) as mock_config, \
          patch("app.services.metadata_service.MetadataService.search_datasets", new_callable=AsyncMock) as mock_search, \
-         patch("app.services.metadata_service.MetadataService.get_dataset_by_id", new_callable=AsyncMock) as mock_get_id, \
-         patch("app.services.metadata_service.MetadataService.export_dataset_yaml", new_callable=AsyncMock) as mock_export:
-        
-        # Force local provider
-        mock_config.return_value = "local"
-        
+         patch("app.services.metadata_service.MetadataService.export_dataset_yaml", new_callable=AsyncMock) as mock_export, \
+         patch("app.services.ai.embedding_client.EmbeddingClient.embed_text", new_callable=AsyncMock) as mock_embed, \
+         patch("app.services.ai.metadata_index_service.MetadataIndexService.search_knn", new_callable=AsyncMock) as mock_search_knn:
+
+        async def config_get(key, default=None):
+            return {
+                "metadata_provider": "local",
+                "ragflow_similarity_threshold": "0.2",
+                "ragflow_metadata_top_k": "5",
+            }.get(key, default)
+
+        mock_config.side_effect = config_get
         mock_search.return_value = [mock_ds]
-        mock_get_id.return_value = mock_ds
         mock_export.return_value = "tables: [users]"
+        mock_embed.return_value = [0.1] * 1536
+        mock_search_knn.return_value = [
+            {
+                "dataset_id": "1",
+                "doc_name": "user_stats.users.txt",
+                "content": "table users schema chunk",
+                "similarity": 0.86,
+            }
+        ]
         
-        # 使用 invoke 调用工具
         result = await get_dataset_schema.ainvoke({"keywords": "user_stats"})
-        assert "--- Dataset: User Stats (user_stats) ---" in result
-        assert "tables: [users]" in result
+
+        assert "[置信度: 0.86]" in result
+        assert "--- Source: user_stats.users.txt ---" in result
+        assert "table users schema chunk" in result
+        mock_embed.assert_awaited_once_with("user_stats", use_global=True)
+        mock_search_knn.assert_awaited_once_with(
+            query_embedding=[0.1] * 1536,
+            authorized_dataset_ids=[1],
+            top_k=5,
+        )
+        mock_export.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_get_dataset_schema_tool_local_falls_back_to_mysql_like_when_vector_fails():
+    """local 向量检索异常时，降级为 MySQL LIKE 命中数据集后导出 YAML。"""
+    authorized_ds = MagicMock()
+    authorized_ds.id = 1
+    authorized_ds.display_name = "User Stats"
+    authorized_ds.name = "user_stats"
+    matched_ds = MagicMock()
+    matched_ds.id = 2
+    matched_ds.display_name = "Order Stats"
+    matched_ds.name = "order_stats"
+
+    with patch("app.core.orm.AsyncSessionLocal", new_callable=MagicMock), \
+         patch("app.services.config_service.ConfigService.get", new_callable=AsyncMock) as mock_config, \
+         patch("app.services.metadata_service.MetadataService.search_datasets", new_callable=AsyncMock) as mock_search, \
+         patch("app.services.metadata_service.MetadataService.export_dataset_yaml", new_callable=AsyncMock) as mock_export, \
+         patch("app.services.ai.embedding_client.EmbeddingClient.embed_text", new_callable=AsyncMock) as mock_embed, \
+         patch("app.services.ai.metadata_index_service.MetadataIndexService.search_knn", new_callable=AsyncMock) as mock_search_knn:
+
+        async def config_get(key, default=None):
+            return {
+                "metadata_provider": "local",
+                "ragflow_similarity_threshold": "0.2",
+                "ragflow_metadata_top_k": "5",
+            }.get(key, default)
+
+        mock_config.side_effect = config_get
+        mock_search.side_effect = [[authorized_ds], [matched_ds]]
+        mock_embed.return_value = [0.1] * 1536
+        mock_search_knn.side_effect = RuntimeError("redis unavailable")
+        mock_export.return_value = "tables: [orders]"
+
+        result = await get_dataset_schema.ainvoke({"keywords": "order"})
+
+        assert "--- Dataset: Order Stats (order_stats) ---" in result
+        assert "tables: [orders]" in result
+        assert mock_search.await_args_list[0].kwargs["query"] is None
+        assert mock_search.await_args_list[1].kwargs["query"] == "order"
+        mock_export.assert_awaited_once_with(ANY, 2)
 
 @pytest.mark.asyncio
 async def test_execute_sql_query_tool_dry_run():


### PR DESCRIPTION

## 概要 (Overview)
本次 PR 主要优化了智能客服/数据分析 Agent 的轮次分类与元数据检索表现，同时修复了 Redis FT.INFO 报错并美化了前端配置界面。
主要包括三部分修改：
1. **分类与检索性能优化**：后端优化分类器对追问情况的判定，并在 `local` 模式下引入 Redis KNN 本地向量检索（及 MySQL LIKE 兜底）。
2. **记忆库稳定性修复**：防止 Redis FT.INFO 中存在 `NaN` 导致的 JSON 序列化崩溃。
3. **前端体验与视觉对齐**：前端 Agent、数据集与系统参数交互优化与中文参数详细指南说明，元数据管理页头部按钮高度和字重对齐。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)
- [x] **后端 `local` 检索新增向量检索 (KNN) 机制**：不再一味返回全量已授权的 Schema YAML，而是优先使用本地向量检索，以防 Agent 上下文超出 token 限制。
- [x] **MySQL 降级兜底逻辑**：当本地 Redis 向量查询异常或无命中结果时，自动降级为传统的 MySQL LIKE 检索并按需导出 YAML。
- [x] **分类器追问判定优化**：[data_query_turn_classifier.py](file:///Users/chenxiaolong/workspace/yovole-yunshu-ai-agent-platform/app/services/ai/data_query_turn_classifier.py) 增强了对“帮我看看这个状态”等模糊追问句的判定，将其合理分类为 `CLARIFICATION_OR_NON_DATA`，复用上一轮数据而非误判为新数据查询。

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)
- [x] **精细化参数中文指南**：在 Agent、数据集、系统参数配置界面对滑动条的高级参数（如 `llm_temperature`、`ragflow_similarity_threshold` 等）补充了通俗易懂的极值说明（如 "无门槛" vs "极高门槛"，"只看关键词" vs "只看语义"）以及实用的调优建议。
- [x] **参数详情弹窗滚动优化**：为 `Generic Config Explanation Modal` 弹窗添加了最大高度限制，内容过多时能自适应滚动并保留行换行排版。
- [x] **元数据页头部按钮对齐**：统一了元数据管理页中“测试”、“规范”、“智能导入”及“新建数据集”四个按钮的高度、字重（统一为 `font-medium`）及字体大小（`text-sm`）。

### 3. 🐞 关键修复 (Bug Fixes)
- [x] **Redis 序列化 NaN 崩溃修复**：修复了记忆管理中心获取 `FT.INFO` 时返回 NaN 浮点数导致后端 JSON 序列化失败的问题。通过在 [memory_index_service.py](file:///Users/chenxiaolong/workspace/yovole-yunshu-ai-agent-platform/app/services/ai/memory_index_service.py) 中实现对象扫描器，清洗可能包含非标准浮点数的结构（将 `NaN`/`Infinity` 降级为 `None`）。

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `4c4da91` | `feat: 优化轮次分类与本地向量检索及降级机制，更新相关单测与文档` |
| `3662fca` | `fix: 修复记忆管理中心FT.INFO结果中包含NaN导致的JSON序列化报错，并对齐元数据管理页头部按钮的高度与字重风格` |
| `7eef8eb` | `style(frontend): 优化Agent、数据集和系统参数配置相关界面的交互与提示信息` |

---

## 测试覆盖 (Testing)
- [x] **UI 兼容性**: 已验证不同屏幕比例下参数说明模态弹窗的垂直滚动支持，多行排版格式正常。
- [x] **核心功能**: 关键业务流程的单测已更新且通过，具体见 [test_turn_classifier.py](file:///Users/chenxiaolong/workspace/yovole-yunshu-ai-agent-platform/tests/ai/test_turn_classifier.py) 和 [test_data_api.py](file:///Users/chenxiaolong/workspace/yovole-yunshu-ai-agent-platform/tests/ai/tools/test_data_api.py)。
- [x] **回归测试**: 确保了本次优化未引入回归问题。

> [!IMPORTANT]
> 提交前已确认并更新了 `tests/CHECKLIST.md` 中的自动化测试清单。

---

## 其他备注 (Notes)
- 向量检索需要依赖 Redis Vector 扩展。本地未安装时系统会自动执行 MySQL `LIKE` 兜底，不会影响服务正常运行。