### PR TITLE
Pull Request: ChatBI 数据门户体验升级、表级推荐提问与澄清回复优化

### DIFF
--- a/app/api/v1/endpoints/chat.py
+++ b/app/api/v1/endpoints/chat.py
@@ -112,6 +112,20 @@ class DatasetGroupRefreshRequest(BaseModel):
     tables: List[str] = Field(..., description="关联的数据表术语列表")
 
 
+class DatasetTableColumnInfo(BaseModel):
+    name: str = Field(..., description="物理字段名")
+    term: str = Field(default="", description="业务字段名")
+    type: str = Field(default="", description="字段类型")
+    description: str = Field(default="", description="字段描述")
+
+
+class DatasetTableRecommendRequest(BaseModel):
+    table: str = Field(..., description="数据表业务术语名")
+    physical_table_name: Optional[str] = Field(default=None, description="物理表名")
+    dataset_name: Optional[str] = Field(default=None, description="所属数据集名称")
+    columns: List[DatasetTableColumnInfo] = Field(default_factory=list, description="门户已下发的字段定义")
+
+
 class DatasetGroupQuestion(BaseModel):
     label: str = Field(..., description="问题短标签")
     query: str = Field(..., description="点击触发的完整查询指令")
@@ -205,6 +219,29 @@ async def refresh_group_questions(
         db,
         group_title=request.group_title,
         tables=request.tables,
+    )
+    return StandardResponse(data=DatasetGroupRefreshResponse(questions=questions))
+
+
+@router.post(
+    "/dataset-menu/recommend-table-questions",
+    response_model=StandardResponse[DatasetGroupRefreshResponse],
+    summary="基于单表字段定义生成推荐提问",
+    description="数据门户表级「推荐提问」专用接口：仅依据字段元数据生成 quick 按钮，不触发 ChatBI 查数。",
+)
+async def recommend_table_questions(
+    request: DatasetTableRecommendRequest,
+    db: AsyncSession = Depends(get_db_session),
+    user_info: Dict[str, Any] = Depends(require_api_key),
+):
+    from app.services.dataset_navigation_service import DatasetNavigationService
+
+    questions = await DatasetNavigationService.recommend_table_questions(
+        db,
+        table=request.table,
+        physical_table_name=request.physical_table_name or "",
+        dataset_name=request.dataset_name or "",
+        columns=[col.model_dump() for col in request.columns],
     )
     return StandardResponse(data=DatasetGroupRefreshResponse(questions=questions))
 

--- a/app/services/ai/agent_service.py
+++ b/app/services/ai/agent_service.py
@@ -259,6 +259,8 @@ class AgentService:
         agent_config = None
         full_response_content = ""
         execution_status = "success"
+        has_data_output = False
+        executor = None
 
         try:
             # 2. Context Preparation (Loading Config)
@@ -801,6 +803,10 @@ class AgentService:
                         execution_status = "error"
                     yield chunk
 
+                resolve_has_data_output = getattr(executor, "resolve_has_data_output", None)
+                if callable(resolve_has_data_output):
+                    has_data_output = bool(resolve_has_data_output())
+
             # --- 空响应兜底：本轮成功但模型未产出任何可见文本时，发一条兜底话术，避免前端空白 ---
             if (
                 execution_status == "success"
@@ -827,6 +833,9 @@ class AgentService:
                     "total_tokens": t_tokens
                 }
 
+            if has_data_output and execution_status == "success":
+                yield {"type": "meta", "has_data_output": True}
+
             # 5. Save Assistant Response to Memory
             if conversation_id and full_response_content:
                 u_id = user_info.get("user_id") if user_info else None
@@ -840,7 +849,8 @@ class AgentService:
                     trace_id=trace_id, 
                     agent_name=handled_by,
                     prompt_tokens=p_tokens,
-                    completion_tokens=c_tokens
+                    completion_tokens=c_tokens,
+                    has_data_output=has_data_output or None,
                 ))
 
         except Exception as e:

--- a/app/services/ai/executors/data_executor.py
+++ b/app/services/ai/executors/data_executor.py
@@ -11,6 +11,10 @@ from app.services.ai.runtime.agentscope.data_runtime import DATA_QUERY_MAX_STEPS
 class DataQueryExecutor(BaseExecutor):
     """ChatBI/DataQuery executor backed by AgentScope native Agent + Toolkit."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._runner: DataAgentRunner | None = None
+
     async def execute(
         self,
         history: List[Dict[str, str]],
@@ -24,9 +28,15 @@ class DataQueryExecutor(BaseExecutor):
             user_info=self.user_info,
             conversation_id=self.conversation_id,
         )
+        self._runner = runner
         async for chunk in runner.execute(history):
             yield chunk
         self.step_counter = runner.step_counter
+
+    def resolve_has_data_output(self) -> bool:
+        if self._runner is None:
+            return False
+        return self._runner.resolve_has_data_output()
 
 
 __all__ = ["DATA_QUERY_MAX_STEPS_CAP", "DataQueryExecutor"]

--- a/app/services/ai/executors/prompts.py
+++ b/app/services/ai/executors/prompts.py
@@ -381,50 +381,84 @@ class DataQueryPrompts:
 
     @classmethod
     def build_dataset_navigation_groups(cls, dataset_menu: str) -> list[dict[str, Any]]:
-        groups: list[dict[str, Any]] = []
+        """按业务场景标题合并数据集，避免多个数据集命中同一场景时出现重复卡片。"""
+        grouped_blocks: dict[str, list[dict[str, Any]]] = {}
+        group_order: list[str] = []
+
         for block in cls._parse_dataset_blocks(dataset_menu):
-            tables = [t for t in (block.get("tables") or []) if str(t.get("term") or "").strip()]
-            metrics = [str(m).strip() for m in (block.get("metrics") or []) if str(m).strip()]
-            scene = cls._infer_dataset_scene(block)
-            name = str(block.get("name") or "").strip()
-            display_name = str(block.get("display_name") or "").strip() or name or "未命名数据集"
-            scene_id = cls._slugify_scene_id(f"{name}_{scene['title']}")
-            table_terms = [str(t.get("term") or "").strip() for t in tables if str(t.get("term") or "").strip()]
-            table_descriptions = [
-                {
-                    "name": str(t.get("term") or "").strip(),
-                    "description": str(t.get("desc") or "").strip(),
-                }
-                for t in tables
-                if str(t.get("term") or "").strip()
-            ]
+            scene_title = cls._infer_dataset_scene(block)["title"]
+            if scene_title not in grouped_blocks:
+                grouped_blocks[scene_title] = []
+                group_order.append(scene_title)
+            grouped_blocks[scene_title].append(block)
+
+        groups: list[dict[str, Any]] = []
+        for scene_title in group_order:
+            blocks = grouped_blocks[scene_title]
+            scene = cls._infer_dataset_scene(blocks[0])
+
+            merged_tables: list[dict[str, Any]] = []
+            seen_table_terms: set[str] = set()
+            merged_metrics: list[str] = []
+            seen_metrics: set[str] = set()
+            related_data: list[dict[str, Any]] = []
+
+            for block in blocks:
+                name = str(block.get("name") or "").strip()
+                display_name = str(block.get("display_name") or "").strip() or name or "未命名数据集"
+                tables = [t for t in (block.get("tables") or []) if str(t.get("term") or "").strip()]
+                metrics = [str(m).strip() for m in (block.get("metrics") or []) if str(m).strip()]
+
+                table_terms: list[str] = []
+                table_descriptions: list[dict[str, str]] = []
+                for table in tables:
+                    term = str(table.get("term") or "").strip()
+                    if not term or term in seen_table_terms:
+                        continue
+                    seen_table_terms.add(term)
+                    merged_tables.append(table)
+                    table_terms.append(term)
+                    table_descriptions.append(
+                        {
+                            "name": term,
+                            "description": str(table.get("desc") or "").strip(),
+                        }
+                    )
+
+                for metric in metrics:
+                    if metric not in seen_metrics:
+                        seen_metrics.add(metric)
+                        merged_metrics.append(metric)
+
+                related_data.append(
+                    {
+                        "dataset": name,
+                        "display_name": display_name,
+                        "tables": table_terms,
+                        "table_descriptions": table_descriptions,
+                    }
+                )
+
             groups.append(
                 {
-                    "id": scene_id,
-                    "title": scene["title"],
+                    "id": cls._slugify_scene_id(scene_title),
+                    "title": scene_title,
                     "summary": scene["summary"],
                     "tags": scene["tags"],
                     "questions": cls._question_templates_for_group(
-                        scene_title=scene["title"],
-                        tables=tables,
-                        metrics=metrics,
+                        scene_title=scene_title,
+                        tables=merged_tables,
+                        metrics=merged_metrics,
                     ),
-                    "related_data": [
-                        {
-                            "dataset": name,
-                            "display_name": display_name,
-                            "tables": table_terms,
-                            "table_descriptions": table_descriptions,
-                        }
-                    ],
+                    "related_data": related_data,
                     "followups": [
                         {
                             "label": "更多问题",
-                            "query": f"围绕{scene['title']}，推荐我还能问哪些数据问题",
+                            "query": f"围绕{scene_title}，推荐我还能问哪些数据问题",
                         },
                         {
                             "label": "字段说明",
-                            "query": f"说明{display_name}里有哪些可查询字段和适合的分析口径",
+                            "query": f"说明{scene_title}相关数据里有哪些可查询字段和适合的分析口径",
                         },
                     ],
                 }
@@ -432,33 +466,8 @@ class DataQueryPrompts:
         return groups
 
     @classmethod
-    def _fallback_dataset_section(cls, block: dict[str, Any]) -> list[str]:
+    def _render_group_fallback_section(cls, group: dict[str, Any]) -> list[str]:
         """单个业务场景卡片：标题 + 示例问题 + 相关数据 + 继续追问。"""
-        groups = cls.build_dataset_navigation_groups(
-            "\n".join(
-                [
-                    f"- Dataset: {block.get('name') or ''}",
-                    f"  Display Name: {block.get('display_name') or ''}",
-                    f"  Description: {block.get('description') or ''}",
-                    "  Includes Tables: "
-                    + ", ".join(str(t.get("term") or "") for t in block.get("tables") or []),
-                    "  Table Details:",
-                    *[
-                        f"    - {t.get('term')}: {t.get('desc')}"
-                        for t in block.get("tables") or []
-                        if str(t.get("term") or "").strip()
-                    ],
-                    "  Metrics: " + ", ".join(str(m) for m in block.get("metrics") or []),
-                ]
-            )
-        )
-        if not groups:
-            return []
-        group = groups[0]
-        related = group["related_data"][0]
-        related_name = related.get("display_name") or related.get("dataset") or "相关数据"
-        dataset_name = related.get("dataset") or ""
-        tables = related.get("tables") or []
         lines: list[str] = [f"#### {group['title']}"]
         lines.append(f"> {group['summary']}")
         if group.get("tags"):
@@ -468,14 +477,25 @@ class DataQueryPrompts:
         for question in group.get("questions") or []:
             lines.append(cls.quick_button(question.get("label") or "提问", question.get("query") or ""))
         lines.append("")
-        related_title = f"{related_name} ({dataset_name})" if dataset_name and dataset_name != related_name else related_name
-        lines.append(f"**相关数据：** {related_title}")
-        for table in related.get("table_descriptions") or []:
-            desc = str(table.get("description") or "").strip()
-            suffix = f"：{cls._sanitize_table_cell(desc, max_len=80)}" if desc else ""
-            lines.append(f"- {table.get('name')}{suffix}")
-        if not tables:
+        lines.append("**相关数据：**")
+        related_items = group.get("related_data") or []
+        if not related_items:
             lines.append("- 暂无表信息")
+        for related in related_items:
+            related_name = related.get("display_name") or related.get("dataset") or "相关数据"
+            dataset_name = related.get("dataset") or ""
+            related_title = (
+                f"{related_name} ({dataset_name})"
+                if dataset_name and dataset_name != related_name
+                else related_name
+            )
+            lines.append(f"- {related_title}")
+            for table in related.get("table_descriptions") or []:
+                desc = str(table.get("description") or "").strip()
+                suffix = f"：{cls._sanitize_table_cell(desc, max_len=80)}" if desc else ""
+                lines.append(f"  - {table.get('name')}{suffix}")
+            if not related.get("tables"):
+                lines.append("  - 暂无表信息")
         lines.append("")
         lines.append("**继续追问：**")
         for followup in group.get("followups") or []:
@@ -506,8 +526,8 @@ class DataQueryPrompts:
                 + (f"主要覆盖：{scene_titles}。" if scene_titles else ""),
                 "",
             ]
-            for block in blocks:
-                lines.extend(cls._fallback_dataset_section(block))
+            for group in groups:
+                lines.extend(cls._render_group_fallback_section(group))
                 lines.append("")
 
             lines.extend(

--- a/app/services/ai/executors/prompts.py
+++ b/app/services/ai/executors/prompts.py
@@ -76,10 +76,10 @@ class DataQueryPrompts:
     # 缺少可复用查询结果时的回复
     NO_REUSABLE_RESULT = "当前会话没有可复用的上一轮查询结果，请先完成一次数据查询后再进行可视化或分析。"
 
-    # ChatBI 入口没有足够查数意图时的回复（仅作 LLM/规则生成失败兜底）
-    CLARIFICATION_OR_NON_DATA = (
-        "请告诉我想查询的业务数据、指标、维度或时间范围。"
-        "例如：查询本月各机房 PUE 趋势、统计最近一周告警记录，或基于刚才的查询结果继续分析。"
+    # 纯寒暄/能力咨询时的兜底引导（仅当用户未提出具体业务问题时使用）
+    CLARIFICATION_CAPABILITY_ONBOARDING = (
+        "我可以帮您查询业务数据、统计分析，或基于查询结果做可视化。"
+        "请告诉我您想看的数据对象、指标和时间范围："
     )
 
     @staticmethod
@@ -125,15 +125,20 @@ class DataQueryPrompts:
         return f"""你是 ChatBI 数据查询助手的澄清引导模块。
 
 用户当前问题还不足以直接查数，或无法安全复用上一轮结果。请结合最近对话和系统判断原因：
-1. 用 1-2 句话说明**具体还缺什么信息**或**为什么需要用户补充**（不要泛泛而谈）。
-2. 给出 2-3 个结合上下文的追问建议，供用户一键点击发送。
+1. **必须先输出** `### ℹ️ 为什么需要补充信息` 区块，用 3 条列表说明：
+   - **触发原因：** 一句话说明系统为何没有直接查数（例如：非明确查数、缺少可复用结果、时间/指代模糊等）。
+   - **具体情况：** 结合【当前用户问题】和【系统判断原因】解释还缺什么。
+   - **您可以这样改：** 告诉用户应在原问题中补充哪些信息。
+2. 再用 1 句话引导用户选择下方建议或补充说明。
+3. 给出 2-3 个**围绕当前用户问题**的追问建议，供用户一键点击发送。
 
 输出要求：
 - 只输出 Markdown，不要 JSON，不要代码块包裹全文。
-- 正文后必须包含标题 `### 💬 您可以这样继续`。
+- 必须以 `### ℹ️ 为什么需要补充信息` 开头，然后再写引导语与 `### 💬 您可以这样继续`。
 - 每个建议必须是列表项，格式严格为：`- [🙋 简短标签](quick:完整可发送问题)`。
-- `quick:` 括号内必须是完整、可直接发送的中文问题，可包含具体业务对象/指标/时间范围。
-- 优先结合最近对话中的业务对象、指标、时间范围定制建议；没有上下文时再给通用查数示例。
+- `quick:` 括号内必须是完整、可直接发送的中文问题，应是对【当前用户问题】的改写、补全或口径澄清。
+- **禁止**输出与用户当前问题无关的其他业务域示例（例如用户问 Token 时不得推荐 PUE/告警等无关问题）。
+- 优先结合最近对话中的业务对象、指标、时间范围定制建议；仅当用户只是寒暄且未提出具体问题时，才可给通用查数能力示例。
 - 不要编造对话中未出现的具体数值。
 - quick 追问按钮区块必须放在整段回答最末尾，位于所有图表之后。
 
@@ -590,6 +595,315 @@ class DataQueryPrompts:
             f"{cls.quick_button('重新查看数据门户', '/dataset_menu')}\n"
         )
 
+    @staticmethod
+    def _sanitize_reasoning_for_user(reasoning: str) -> str:
+        text = re.sub(r"\s+", " ", str(reasoning or "")).strip()
+        for prefix in (
+            "请求类别 LLM 未返回有效结果；",
+            "ChatBI 请求类别由大模型兜底识别",
+        ):
+            if text.startswith(prefix):
+                text = text[len(prefix):].strip()
+        return text
+
+    @classmethod
+    def _explain_clarification_trigger(cls, user_question: str, reasoning: str) -> dict[str, str]:
+        q = str(user_question or "").strip()
+        reasoning_text = cls._sanitize_reasoning_for_user(reasoning)
+        gaps = cls._infer_clarification_gaps(q, reasoning_text)
+        gap_text = "、".join(gaps)
+        topic = cls._truncate_for_display(q, 40)
+
+        trigger_rules: list[tuple[tuple[str, ...], dict[str, str]]] = [
+            (
+                ("不是明确", "查数请求", "打招呼"),
+                {
+                    "title": "尚未识别为明确的数据查询",
+                    "detail": (
+                        "您的问题更接近闲聊或能力咨询，尚未包含可直接查数的"
+                        "业务对象、指标和时间范围。"
+                    ),
+                    "fix": "请在问题中写明要查什么数据、看什么指标、覆盖哪段时间。",
+                },
+            ),
+            (
+                ("可复用", "结构化查询结果", "结果追问"),
+                {
+                    "title": "想基于上一轮结果继续，但会话中没有可复用的查询结果",
+                    "detail": (
+                        "您像是在对上一轮数据做可视化、分析或总结，"
+                        "但当前会话尚未保存或展示可供复用的结构化查数结果。"
+                    ),
+                    "fix": "先完成一次数据查询，或明确说明要基于哪一次查询的结果继续。",
+                },
+            ),
+            (
+                ("最近对话", "上下文"),
+                {
+                    "title": "对话上下文不足以安全复用上一轮结果",
+                    "detail": (
+                        "最近几轮对话里没有足够清晰的数据查询结果，"
+                        "系统无法判断应基于哪份数据继续。"
+                    ),
+                    "fix": "请重新说明要分析的对象和时间范围，或先发一次完整的数据查询。",
+                },
+            ),
+        ]
+
+        for keywords, payload in trigger_rules:
+            if any(keyword in reasoning_text for keyword in keywords):
+                result = dict(payload)
+                if gap_text and gap_text not in result["detail"]:
+                    result["detail"] = f"{result['detail']}此外，当前表述还缺少：{gap_text}。"
+                return result
+
+        if cls._looks_like_greeting_or_capability_question(q, reasoning_text):
+            return {
+                "title": "尚未识别为明确的数据查询",
+                "detail": "您还没有说明要查询的业务数据、指标或时间范围。",
+                "fix": "请直接描述想查的对象、指标和时间段，例如「查询本月某指标趋势」。",
+            }
+
+        if reasoning_text and reasoning_text not in {"需要用户补充查数信息"}:
+            return {
+                "title": "系统判断当前问题尚不足以直接执行查数",
+                "detail": (
+                    f"{reasoning_text}"
+                    + (f" 当前还缺少：{gap_text}。" if gap_text else "")
+                ),
+                "fix": (
+                    f"请在原问题「{topic}」中补充上述缺失信息，"
+                    "或点选下方已根据您的问题生成的改写建议。"
+                    if topic
+                    else "请补充统计对象、指标口径和时间范围，或点选下方建议。"
+                ),
+            }
+
+        return {
+            "title": "问题信息尚不完整，无法安全执行查数",
+            "detail": f"当前表述还缺少：{gap_text}。" if gap_text else "当前问题缺少执行查数所需的关键信息。",
+            "fix": (
+                f"请在原问题「{topic}」中补充上述信息；下方按钮已根据您的问题生成可一键发送的改写版本。"
+                if topic
+                else "请补充统计对象、指标口径和时间范围，或点选下方建议。"
+            ),
+        }
+
+    @classmethod
+    def _format_clarification_reason_block(cls, user_question: str, reasoning: str) -> str:
+        expl = cls._explain_clarification_trigger(user_question, reasoning)
+        return (
+            "### ℹ️ 为什么需要补充信息\n"
+            f"- **触发原因：** {expl['title']}\n"
+            f"- **具体情况：** {expl['detail']}\n"
+            f"- **您可以这样改：** {expl['fix']}\n"
+        )
+
+    @classmethod
+    def ensure_clarification_reason_block(
+        cls,
+        content: str,
+        user_question: str,
+        reasoning: str,
+    ) -> str:
+        body = str(content or "").strip()
+        if "### ℹ️ 为什么需要补充信息" in body:
+            return body
+        reason_block = cls._format_clarification_reason_block(user_question, reasoning)
+        if not body:
+            return reason_block.strip()
+        return f"{reason_block}\n{body}"
+
+    @staticmethod
+    def _truncate_for_display(text: str, max_len: int = 48) -> str:
+        cleaned = re.sub(r"\s+", " ", str(text or "")).strip()
+        if not cleaned:
+            return ""
+        if len(cleaned) <= max_len:
+            return cleaned
+        return cleaned[: max_len - 1] + "…"
+
+    @classmethod
+    def _looks_like_greeting_or_capability_question(cls, user_question: str, reasoning: str) -> bool:
+        q = str(user_question or "").strip()
+        q_lower = q.lower()
+        if not q_lower:
+            return True
+        greeting_signals = ["你好", "您好", "你是谁", "你能做什么", "谢谢", "感谢", "辛苦了"]
+        if any(signal in q_lower for signal in greeting_signals) and len(q_lower) <= 16:
+            return True
+        reasoning_text = str(reasoning or "")
+        if any(keyword in reasoning_text for keyword in ("打招呼", "不是明确", "查数请求")):
+            return len(q_lower) <= 12
+        return False
+
+    @classmethod
+    def _infer_clarification_gaps(cls, user_question: str, reasoning: str) -> list[str]:
+        q = str(user_question or "").strip().lower()
+        reasoning_text = str(reasoning or "")
+        gaps: list[str] = []
+
+        if any(keyword in reasoning_text for keyword in ("结果追问", "可复用", "结构化查询结果")):
+            gaps.append("要基于哪一份查询结果继续分析")
+        if any(keyword in reasoning_text for keyword in ("最近对话", "上下文")):
+            gaps.append("要继续分析的业务对象")
+
+        vague_time_signals = ("最近", "上次", "上一次", "近期", "这段时间", "刚才", "刚刚")
+        concrete_time_signals = (
+            "今天", "昨天", "本周", "上周", "本月", "上月", "今年", "去年",
+            "天内", "月内", "季度", "年度", "20", "19",
+        )
+        if any(signal in q for signal in vague_time_signals) and not any(
+            signal in q for signal in concrete_time_signals
+        ):
+            gaps.append("时间范围")
+
+        vague_ref_signals = ("这个", "那个", "这些", "那些", "上面", "前述", "最近一次")
+        if any(signal in q for signal in vague_ref_signals):
+            gaps.append("具体对象或指代范围")
+
+        metric_signals = ("多少", "趋势", "占比", "排名", "对比", "统计", "汇总", "消耗", "用量")
+        object_signals = ("各", "每", "所有", "全部", "部门", "机房", "用户", "智能体", "对话")
+        if any(signal in q for signal in metric_signals) and not any(
+            signal in q for signal in object_signals
+        ):
+            gaps.append("统计对象或指标口径")
+
+        if not gaps:
+            gaps = ["统计对象", "指标口径", "时间范围"]
+        deduped: list[str] = []
+        for gap in gaps:
+            if gap not in deduped:
+                deduped.append(gap)
+        return deduped[:3]
+
+    @classmethod
+    def _build_contextual_clarification_lead(cls, user_question: str, reasoning: str) -> str:
+        q = str(user_question or "").strip()
+        topic = cls._truncate_for_display(q, 56)
+        reasoning_text = str(reasoning or "")
+
+        if any(keyword in reasoning_text for keyword in ("结果追问", "可复用", "结构化查询结果")):
+            if topic:
+                return (
+                    f"您提到「{topic}」，但当前会话里还没有可复用的查询结果。"
+                    "请说明要基于哪份数据继续，或先完成一次查询："
+                )
+            return "当前还不确定要基于哪一份查询结果继续分析，请补充说明或先完成一次数据查询："
+
+        if any(keyword in reasoning_text for keyword in ("最近对话", "上下文")):
+            if topic:
+                return (
+                    f"关于「{topic}」，最近对话里暂时没有足够明确的数据上下文。"
+                    "请补充要分析的对象或时间范围："
+                )
+            return "最近对话里暂时没有足够明确的数据上下文，请补充您想分析的对象或时间范围："
+
+        if cls._looks_like_greeting_or_capability_question(q, reasoning_text):
+            return cls.CLARIFICATION_CAPABILITY_ONBOARDING
+
+        gap_text = "、".join(cls._infer_clarification_gaps(q, reasoning_text))
+        if topic:
+            return (
+                f"关于「{topic}」，还需要确认{gap_text}后才能继续。"
+                "您可以补充说明，或直接点选下面的建议："
+            )
+        return f"还需要确认{gap_text}后才能继续。您可以补充说明，或直接点选下面的建议："
+
+    @classmethod
+    def _build_contextual_clarification_quick_variants(
+        cls,
+        user_question: str,
+        reasoning: str,
+        history_excerpt: str,
+    ) -> list[tuple[str, str]]:
+        q = str(user_question or "").strip()
+        reasoning_text = str(reasoning or "")
+        last_topic = cls._extract_last_user_topic(history_excerpt, q)
+        topic_label = cls._truncate_for_display(q, 24) or "当前问题"
+        variants: list[tuple[str, str]] = []
+
+        def add(label: str, target: str) -> None:
+            target = str(target or "").strip()
+            if not target:
+                return
+            label = cls._truncate_for_display(label, 32)
+            if any(existing == target for _, existing in variants):
+                return
+            variants.append((label, target))
+
+        if any(keyword in reasoning_text for keyword in ("结果追问", "可复用", "结构化查询结果")):
+            if last_topic:
+                add(
+                    f"基于「{cls._truncate_for_display(last_topic, 16)}」继续",
+                    f"基于刚才关于{last_topic}的查询结果，{q or '继续分析'}",
+                )
+            add("基于上一轮查询结果", f"基于刚才的查询结果，{q or '继续分析'}")
+            if q:
+                add(f"先查数再分析：{topic_label}", f"请先完成一次数据查询，再{q}")
+            return variants[:3]
+
+        if any(keyword in reasoning_text for keyword in ("最近对话", "上下文")):
+            if last_topic:
+                add(
+                    f"重新查询「{cls._truncate_for_display(last_topic, 16)}」",
+                    f"查询{last_topic}",
+                )
+            if q:
+                add(f"明确对象后重问：{topic_label}", f"请明确要分析的对象和时间范围：{q}")
+                add(f"按原问题继续：{topic_label}", q)
+            return variants[:3]
+
+        if cls._looks_like_greeting_or_capability_question(q, reasoning_text):
+            add("查询本月业务指标趋势", "查询本月核心业务指标趋势")
+            add("统计最近一周关键记录", "统计最近一周关键业务记录")
+            add("查看数据门户", "/dataset_menu")
+            return variants[:3]
+
+        if not q:
+            add("打开数据门户选表提问", "/dataset_menu")
+            return variants[:3]
+
+        gaps = cls._infer_clarification_gaps(q, reasoning_text)
+        if "时间范围" in gaps:
+            add(f"补充时间：{topic_label}", f"{q}（时间范围：本月）")
+        if "具体对象或指代范围" in gaps:
+            add(f"补充指代范围：{topic_label}", f"请明确「{q}」中的对象范围和时间范围")
+        if "要基于哪一份查询结果继续分析" in gaps and last_topic:
+            add(
+                f"基于「{cls._truncate_for_display(last_topic, 16)}」",
+                f"基于刚才关于{last_topic}的查询结果，{q}",
+            )
+        if "统计对象或指标口径" in gaps or "指标口径" in gaps:
+            add(f"补充指标口径：{topic_label}", f"请补充具体指标和统计口径后回答：{q}")
+        if "统计对象" in gaps:
+            add(f"补充统计对象：{topic_label}", f"请明确统计对象后回答：{q}")
+        add(f"按原问题重试：{topic_label}", q)
+        return variants[:3]
+
+    @classmethod
+    def append_contextual_quick_suggestions(
+        cls,
+        text: str,
+        user_question: str,
+        reasoning: str,
+        history_excerpt: str = "",
+    ) -> str:
+        body = str(text or "").strip()
+        if cls.has_quick_suggestions(body):
+            return body
+        variants = cls._build_contextual_clarification_quick_variants(
+            user_question,
+            reasoning,
+            history_excerpt,
+        )
+        if not variants:
+            return body
+        buttons = [cls.quick_button(label, target) for label, target in variants]
+        if "### 💬" in body:
+            return f"{body}\n" + "\n".join(buttons)
+        return f"{body}\n\n### 💬 您可以这样继续\n" + "\n".join(buttons)
+
     @classmethod
     def build_clarification_fallback(
         cls,
@@ -597,83 +911,34 @@ class DataQueryPrompts:
         reasoning: str,
         history_excerpt: str = "",
     ) -> str:
-        reasoning_text = str(reasoning or "")
-        history_text = str(history_excerpt or "")
-        last_user_topic = cls._extract_last_user_topic(history_text, user_question)
-        buttons: list[str] = []
+        lead = cls._build_contextual_clarification_lead(user_question, reasoning)
+        variants = cls._build_contextual_clarification_quick_variants(
+            user_question,
+            reasoning,
+            history_excerpt,
+        )
+        buttons = [cls.quick_button(label, target) for label, target in variants]
+        suggestions = "\n".join(buttons[:3])
+        reason_block = cls._format_clarification_reason_block(user_question, reasoning)
+        return f"{reason_block}\n{lead}\n\n### 💬 您可以这样继续\n{suggestions}"
 
-        if any(keyword in reasoning_text for keyword in ("结果追问", "可复用", "结构化查询结果")):
-            lead = (
-                "我还不太确定您想基于哪份数据继续分析或可视化。"
-                "您可以补充具体指标/图表类型，或直接选择下面的建议："
-            )
-            if last_user_topic:
-                buttons.append(
-                    cls.quick_button(
-                        f"基于刚才关于「{last_user_topic}」的结果可视化",
-                        f"对刚才关于{last_user_topic}的查询结果做可视化分析",
-                    )
-                )
-            buttons.extend([
-                cls.quick_button("基于刚才的查询结果继续分析", "基于刚才的查询结果继续分析"),
-                cls.quick_button("查询本月业务指标趋势", "查询本月核心业务指标趋势"),
-            ])
-        elif any(keyword in reasoning_text for keyword in ("最近对话", "上下文")):
-            lead = (
-                "最近对话里暂时没有足够明确的数据结果上下文，"
-                "请告诉我您想继续分析的对象，或重新发起一次查询："
-            )
-            if last_user_topic:
-                buttons.append(
-                    cls.quick_button(
-                        f"重新查询「{last_user_topic}」",
-                        f"查询{last_user_topic}",
-                    )
-                )
-            buttons.extend([
-                cls.quick_button("查询本月各机房 PUE 趋势", "查询本月各机房 PUE 趋势"),
-                cls.quick_button("统计最近一周告警记录", "统计最近一周告警记录"),
-            ])
-        elif any(keyword in reasoning_text for keyword in ("不是明确", "打招呼", "查数请求")):
-            lead = (
-                "我可以帮您查询业务数据、统计分析或基于结果做可视化。"
-                "请告诉我您想看的数据对象、指标和时间范围："
-            )
-            buttons.extend([
-                cls.quick_button("查询本月各机房 PUE 趋势", "查询本月各机房 PUE 趋势"),
-                cls.quick_button("统计最近一周告警记录", "统计最近一周告警记录"),
-                cls.quick_button("查看部门收入与回款对比", "查询各部门本季度收入与回款对比"),
-            ])
-        else:
-            lead = cls.CLARIFICATION_OR_NON_DATA
-            buttons.extend([
-                cls.quick_button("查询本月各机房 PUE 趋势", "查询本月各机房 PUE 趋势"),
-                cls.quick_button("统计最近一周告警记录", "统计最近一周告警记录"),
-                cls.quick_button("基于刚才的查询结果继续分析", "基于刚才的查询结果继续分析"),
-            ])
-
-        unique_buttons: list[str] = []
-        seen_targets: set[str] = set()
-        for button in buttons:
-            match = re.search(r"\(quick:([^)]+)\)", button)
-            target = match.group(1).strip() if match else button
-            if target in seen_targets:
-                continue
-            seen_targets.add(target)
-            unique_buttons.append(button)
-
-        suggestions = "\n".join(unique_buttons[:3])
-        return f"{lead}\n\n### 💬 您可以这样继续\n{suggestions}"
-
-    @staticmethod
-    def build_missing_reusable_result_fallback(history_excerpt: str = "") -> str:
-        last_topic = DataQueryPrompts._extract_last_user_topic(history_excerpt, "")
+    @classmethod
+    def build_missing_reusable_result_fallback(
+        cls,
+        history_excerpt: str = "",
+        user_question: str = "",
+    ) -> str:
+        last_topic = cls._extract_last_user_topic(history_excerpt, user_question)
+        reasoning = (
+            "检测到本轮是基于上一轮结果的分析/可视化请求，"
+            "但当前会话没有保存的结构化查询结果。"
+        )
         buttons = [
-            DataQueryPrompts.quick_button(
+            cls.quick_button(
                 "基于刚才的查询结果继续分析",
                 "基于刚才的查询结果继续分析",
             ),
-            DataQueryPrompts.quick_button(
+            cls.quick_button(
                 "对刚才的结果做可视化",
                 "对刚刚的查询结果做可视化分析",
             ),
@@ -681,7 +946,7 @@ class DataQueryPrompts:
         if last_topic:
             buttons.insert(
                 0,
-                DataQueryPrompts.quick_button(
+                cls.quick_button(
                     f"重新查询「{last_topic}」",
                     f"查询{last_topic}",
                 ),
@@ -690,7 +955,8 @@ class DataQueryPrompts:
             "当前会话还没有可复用的结构化查询结果，无法直接基于上一轮数据出图或分析。"
             "您可以先完成一次查询，或选择下面的建议："
         )
-        return f"{lead}\n\n### 💬 您可以这样继续\n" + "\n".join(buttons[:3])
+        reason_block = cls._format_clarification_reason_block(user_question, reasoning)
+        return f"{reason_block}\n{lead}\n\n### 💬 您可以这样继续\n" + "\n".join(buttons[:3])
 
     @staticmethod
     def _extract_last_user_topic(history_excerpt: str, current_question: str) -> str:

--- a/app/services/ai/executors/prompts.py
+++ b/app/services/ai/executors/prompts.py
@@ -262,6 +262,39 @@ class DataQueryPrompts:
         return cleaned
 
     @staticmethod
+    def build_table_questions_recommend_prompt(
+        *,
+        table: str,
+        columns: list[dict[str, Any]],
+        physical_table_name: str = "",
+        dataset_name: str = "",
+    ) -> str:
+        physical_str = f"（物理表名：{physical_table_name}）" if physical_table_name else ""
+        dataset_line = f"【所属数据集】：{dataset_name}\n" if dataset_name else ""
+        ctx = ""
+        for col in columns:
+            desc_str = f" ({col['description']})" if col.get("description") else ""
+            ctx += (
+                f"  * {col.get('name', '')} ({col.get('term', '')}){desc_str}"
+                f" - 类型: {col.get('type', '')}\n"
+            )
+        if not ctx.strip():
+            ctx = "  * (暂无字段定义)\n"
+
+        return (
+            "你是一个专业的 ChatBI 数据分析专家。\n"
+            "请仅根据以下数据表的字段定义，推荐 3 个最适合的业务分析提问。\n"
+            "禁止执行 SQL、禁止编造真实数据值；只基于字段语义构思用户可一键发起的查数问题。\n\n"
+            f"{dataset_line}"
+            f"【数据表】：'{table}'{physical_str}\n"
+            f"【字段定义】：\n{ctx}\n"
+            "【输出格式要求】：\n"
+            "生成的问题要具体、贴合上述字段设计。以 `- [🙋 推荐问题描述](quick:提问具体指令)` 的格式输出这 3 个问题，以便我一键点击触发提问。例如：\n"
+            "- [🙋 统计最近7天的每日请求次数趋势](quick:请展示最近7天各智能体的每日请求次数趋势)\n\n"
+            "不要输出任何前言、总结或无关的 Markdown 标题，只输出这 3 行问题格式。"
+        )
+
+    @staticmethod
     def build_group_questions_refresh_prompt(
         *,
         group_title: str,

--- a/app/services/ai/memory_service.py
+++ b/app/services/ai/memory_service.py
@@ -83,7 +83,7 @@ class MemoryService:
 
         return history
 
-    async def add_message(self, user_id: str, conversation_id: str, role: str, content: str, trace_id: Optional[str] = None, files: Optional[List[Dict[str, Any]]] = None, agent_name: Optional[str] = None, prompt_tokens: Optional[int] = 0, completion_tokens: Optional[int] = 0):
+    async def add_message(self, user_id: str, conversation_id: str, role: str, content: str, trace_id: Optional[str] = None, files: Optional[List[Dict[str, Any]]] = None, agent_name: Optional[str] = None, prompt_tokens: Optional[int] = 0, completion_tokens: Optional[int] = 0, has_data_output: Optional[bool] = None):
         """
         Append a single message to the conversation history.
         Now supports trace_id, attachment files, and token usage values.
@@ -111,6 +111,8 @@ class MemoryService:
             message["agent_name"] = agent_name
         message["prompt_tokens"] = int(prompt_tokens or 0)
         message["completion_tokens"] = int(completion_tokens or 0)
+        if has_data_output:
+            message["has_data_output"] = True
 
         
         # Push to list

--- a/app/services/ai/runners/data_agent_runner.py
+++ b/app/services/ai/runners/data_agent_runner.py
@@ -204,6 +204,7 @@ class _DataRunState:
     controlled_schema_retry_keywords: str = ""
     last_applied_schema_retry_keywords: str = ""
     pending_schema_retry: bool = False   # 修复轮受控重试标记（不随 _reset_state_for_repair 清除）
+    followup_data_saved: bool = False    # 本轮是否已将结构化 SQL 结果写入 last_data_result
 
     @property
     def has_successful_nonempty_sql(self) -> bool:
@@ -431,8 +432,18 @@ class DataAgentRunner(BaseExecutor):
             from app.services.ai.memory_service import memory_service
 
             await memory_service.set_last_data_result(user_id, self.conversation_id, payload)
+            state = self._last_run_state
+            if state is not None:
+                state.followup_data_saved = True
         except Exception as e:
             logger.warning("[DataAgentRunner] Failed to save last data result: %s", e)
+
+    def resolve_has_data_output(self) -> bool:
+        """本轮 ChatBI 是否产出了可复用的结构化查数结果（供前端展示「可视化分析」入口）。"""
+        state = self._last_run_state
+        if not state or not state.requires_fresh_data:
+            return False
+        return bool(state.followup_data_saved)
 
     async def _resolve_runtime_tools_from_config(self) -> list[RuntimeToolSpec]:
         _, specs = await build_chatbi_toolkit(self.config.tools)

--- a/app/services/ai/runners/data_agent_runner.py
+++ b/app/services/ai/runners/data_agent_runner.py
@@ -897,7 +897,10 @@ class DataAgentRunner(BaseExecutor):
                 ):
                     yield chunk
             else:
-                async for chunk in self._yield_missing_reusable_result_clarification(history):
+                async for chunk in self._yield_missing_reusable_result_clarification(
+                    history,
+                    user_question=user_question,
+                ):
                     yield chunk
             return
 
@@ -1790,10 +1793,40 @@ class DataAgentRunner(BaseExecutor):
             )
             cleaned = str(content or "").strip()
             if cleaned and DataQueryPrompts.has_quick_suggestions(cleaned):
-                return finalize_visible_reply(cleaned, collapse_duplicates=False)
+                return finalize_visible_reply(
+                    DataQueryPrompts.ensure_clarification_reason_block(
+                        cleaned,
+                        user_question,
+                        reasoning,
+                    ),
+                    collapse_duplicates=False,
+                )
+            if cleaned:
+                merged = DataQueryPrompts.append_contextual_quick_suggestions(
+                    cleaned,
+                    user_question,
+                    reasoning,
+                    history_excerpt,
+                )
+                if DataQueryPrompts.has_quick_suggestions(merged):
+                    return finalize_visible_reply(
+                        DataQueryPrompts.ensure_clarification_reason_block(
+                            merged,
+                            user_question,
+                            reasoning,
+                        ),
+                        collapse_duplicates=False,
+                    )
         except Exception as e:
             logger.warning("[DataAgentRunner] Contextual clarification generation failed: %s", e)
-        return finalize_visible_reply(fallback, collapse_duplicates=False)
+        return finalize_visible_reply(
+            DataQueryPrompts.ensure_clarification_reason_block(
+                fallback,
+                user_question,
+                reasoning,
+            ),
+            collapse_duplicates=False,
+        )
 
     async def _yield_contextual_clarification(
         self,
@@ -1820,17 +1853,26 @@ class DataAgentRunner(BaseExecutor):
     async def _yield_missing_reusable_result_clarification(
         self,
         history: List[Dict[str, str]],
+        *,
+        user_question: str = "",
     ) -> AsyncGenerator[Dict[str, Any], None]:
         history_excerpt = DataQueryPrompts.format_clarification_history(history)
+        reasoning = (
+            "检测到本轮是基于上一轮结果的分析/可视化请求，"
+            "但当前会话没有保存的结构化查询结果。"
+        )
         yield {
             "type": "log",
             "id": f"reuse_miss_{uuid.uuid4().hex[:8]}",
             "title": "缺少可复用查询结果",
-            "details": "检测到本轮是基于上一轮结果的分析/可视化请求，但当前会话没有保存的结构化查询结果。",
+            "details": reasoning,
             "status": "error",
         }
         yield {
-            "content": DataQueryPrompts.build_missing_reusable_result_fallback(history_excerpt),
+            "content": DataQueryPrompts.build_missing_reusable_result_fallback(
+                history_excerpt,
+                user_question=user_question,
+            ),
             "status": "success",
         }
 

--- a/app/services/ai/runners/data_agent_runner.py
+++ b/app/services/ai/runners/data_agent_runner.py
@@ -86,7 +86,7 @@ DATA_REPAIR_BUDGETS = {
     "schema_ambiguous": 1,
     "sql_plan_missing": 1,
     "sql_static_risk": 1,
-    "sql_error": 2,
+    "sql_error": 5,
     "empty_sql_result": 1,
     "ratio_anomaly": 1,
     "duration_anomaly": 1,

--- a/app/services/audit_service.py
+++ b/app/services/audit_service.py
@@ -17,7 +17,7 @@ class AuditService:
     # API Endpoint to Feature Name Mapping
     FEATURE_MAP = {
         "/api/portal/auth/login": "用户登录",
-        "/api/portal/agents": "智能体管理",
+        "/api/portal/agents": "智能体中心",
         "/api/portal/prompts": "提示词工程",
         "/api/portal/models": "模型管理",
         "/api/portal/tools": "工具中心",

--- a/app/services/dataset_navigation_service.py
+++ b/app/services/dataset_navigation_service.py
@@ -293,10 +293,15 @@ class DatasetNavigationService:
             matched_group = None
             clean_title = clean_str(title)
             for g in groups:
-                clean_g_title = clean_str(g.get("title") or "")
-                if clean_title == clean_g_title or clean_title in clean_g_title or clean_g_title in clean_title:
+                if clean_str(g.get("title") or "") == clean_title:
                     matched_group = g
                     break
+            if not matched_group:
+                for g in groups:
+                    clean_g_title = clean_str(g.get("title") or "")
+                    if clean_title == clean_g_title or clean_title in clean_g_title or clean_g_title in clean_title:
+                        matched_group = g
+                        break
 
             if not matched_group:
                 continue

--- a/app/services/dataset_navigation_service.py
+++ b/app/services/dataset_navigation_service.py
@@ -508,62 +508,35 @@ class DatasetNavigationService:
         tables: list[str],
     ) -> list[dict[str, Any]]:
         """针对特定的卡片场景 (group_title) 和关联表列表 (tables)，在线实时调用大模型生成 3 个新问题"""
-        table_physical_names = {}
-        table_to_columns = {}
+        table_physical_names, table_to_columns = await DatasetNavigationService._load_table_metadata(db, tables)
 
-        if tables:
-            try:
-                from sqlalchemy import select
-                from app.models.metadata import MetaTable, MetaColumn
-
-                # 1. 批量拉取物理表名映射
-                t_stmt = select(MetaTable.term, MetaTable.physical_name).where(
-                    MetaTable.term.in_(tables),
-                    MetaTable.status == 1
-                )
-                t_res = await db.execute(t_stmt)
-                for t_row in t_res.all():
-                    table_physical_names[str(t_row.term).strip()] = str(t_row.physical_name).strip()
-
-                # 2. 批量拉取列定义
-                stmt = (
-                    select(
-                        MetaTable.term.label("table_term"),
-                        MetaColumn.physical_name,
-                        MetaColumn.term.label("column_term"),
-                        MetaColumn.type,
-                        MetaColumn.description,
-                    )
-                    .join(MetaColumn, MetaTable.id == MetaColumn.table_id)
-                    .where(MetaTable.term.in_(tables))
-                    .where(MetaTable.status == 1)
-                    .order_by(MetaColumn.id.asc())
-                )
-                res = await db.execute(stmt)
-                rows = res.all()
-
-                for row in rows:
-                    t_term = str(row.table_term).strip()
-                    if t_term not in table_to_columns:
-                        table_to_columns[t_term] = []
-                    table_to_columns[t_term].append({
-                        "name": row.physical_name,
-                        "term": row.column_term,
-                        "type": row.type or "",
-                        "description": row.description or "",
-                    })
-            except Exception as e:
-                logger.warning("Failed to fetch metadata columns or table physical names for refresh: %s", e)
-
-        # 3. 构造 prompt 并调用大模型
         prompt = DataQueryPrompts.build_group_questions_refresh_prompt(
             group_title=group_title,
             tables=tables,
             table_to_columns=table_to_columns,
             table_physical_names=table_physical_names,
         )
+        return await DatasetNavigationService._generate_questions_via_llm(prompt)
 
-        questions = []
+    @staticmethod
+    def _parse_quick_questions_from_llm(content: str) -> list[dict[str, Any]]:
+        cleaned = str(content or "").strip()
+        questions: list[dict[str, Any]] = []
+        pattern = r"-\s*\[(?:[^\]]*🙋\s*)?([^\]]+)\]\(quick:([^\)]+)\)"
+        for match in re.finditer(pattern, cleaned):
+            label = match.group(1).strip()
+            query = match.group(2).strip()
+            if "/dataset_menu" in query or "重新查看" in label:
+                continue
+            questions.append({
+                "label": label,
+                "query": query,
+                "type": "dynamic",
+            })
+        return questions
+
+    @staticmethod
+    async def _generate_questions_via_llm(prompt: str) -> list[dict[str, Any]]:
         try:
             llm = await AgentConfigProvider.get_configured_llm(streaming=False)
             chat_client = chat_client_from_handle(llm)
@@ -571,31 +544,107 @@ class DatasetNavigationService:
                 [
                     RuntimeMessage(
                         role="system",
-                        content=[
-                            RuntimeContentBlock(
-                                type="text",
-                                text=prompt,
-                            )
-                        ],
+                        content=[RuntimeContentBlock(type="text", text=prompt)],
                     )
                 ]
             )
-            cleaned = str(content or "").strip()
+            return DatasetNavigationService._parse_quick_questions_from_llm(content)
+        except Exception as e:
+            logger.warning("Failed to generate dataset menu questions via LLM: %s", e)
+            return []
 
-            # 从返回结果解析问题
-            pattern = r"-\s*\[(?:[^\]]*🙋\s*)?([^\]]+)\]\(quick:([^\)]+)\)"
-            for match in re.finditer(pattern, cleaned):
-                label = match.group(1).strip()
-                query = match.group(2).strip()
-                if "/dataset_menu" in query or "重新查看" in label:
-                    continue
-                questions.append({
-                    "label": label,
-                    "query": query,
-                    "type": "dynamic",
+    @staticmethod
+    async def _load_table_metadata(
+        db: AsyncSession,
+        tables: list[str],
+    ) -> tuple[dict[str, str], dict[str, list[dict[str, Any]]]]:
+        table_physical_names: dict[str, str] = {}
+        table_to_columns: dict[str, list[dict[str, Any]]] = {}
+        if not tables:
+            return table_physical_names, table_to_columns
+
+        try:
+            from sqlalchemy import select
+            from app.models.metadata import MetaTable, MetaColumn
+
+            t_stmt = select(MetaTable.term, MetaTable.physical_name).where(
+                MetaTable.term.in_(tables),
+                MetaTable.status == 1,
+            )
+            t_res = await db.execute(t_stmt)
+            for t_row in t_res.all():
+                table_physical_names[str(t_row.term).strip()] = str(t_row.physical_name).strip()
+
+            stmt = (
+                select(
+                    MetaTable.term.label("table_term"),
+                    MetaColumn.physical_name,
+                    MetaColumn.term.label("column_term"),
+                    MetaColumn.type,
+                    MetaColumn.description,
+                )
+                .join(MetaColumn, MetaTable.id == MetaColumn.table_id)
+                .where(MetaTable.term.in_(tables))
+                .where(MetaTable.status == 1)
+                .order_by(MetaColumn.id.asc())
+            )
+            res = await db.execute(stmt)
+            for row in res.all():
+                t_term = str(row.table_term).strip()
+                if t_term not in table_to_columns:
+                    table_to_columns[t_term] = []
+                table_to_columns[t_term].append({
+                    "name": row.physical_name,
+                    "term": row.column_term,
+                    "type": row.type or "",
+                    "description": row.description or "",
                 })
         except Exception as e:
-            logger.warning("Failed to refresh group questions via LLM: %s", e)
+            logger.warning("Failed to fetch metadata columns or table physical names: %s", e)
 
-        return questions
+        return table_physical_names, table_to_columns
+
+    @staticmethod
+    async def recommend_table_questions(
+        db: AsyncSession,
+        *,
+        table: str,
+        physical_table_name: str = "",
+        dataset_name: str = "",
+        columns: Optional[list[dict[str, Any]]] = None,
+    ) -> list[dict[str, Any]]:
+        """基于单表字段定义在线生成推荐提问，不触发 ChatBI 查数链路。"""
+        table_term = str(table or "").strip()
+        if not table_term:
+            return []
+
+        normalized_columns = [
+            {
+                "name": str(col.get("name") or "").strip(),
+                "term": str(col.get("term") or "").strip(),
+                "type": str(col.get("type") or "").strip(),
+                "description": str(col.get("description") or "").strip(),
+            }
+            for col in (columns or [])
+            if str(col.get("name") or col.get("term") or "").strip()
+        ]
+
+        physical_name = str(physical_table_name or "").strip()
+        if not normalized_columns or not physical_name:
+            table_physical_names, table_to_columns = await DatasetNavigationService._load_table_metadata(
+                db,
+                [table_term],
+            )
+            if not physical_name:
+                physical_name = table_physical_names.get(table_term, "")
+            if not normalized_columns:
+                normalized_columns = table_to_columns.get(table_term, [])
+
+        prompt = DataQueryPrompts.build_table_questions_recommend_prompt(
+            table=table_term,
+            columns=normalized_columns,
+            physical_table_name=physical_name,
+            dataset_name=str(dataset_name or "").strip(),
+        )
+        return await DatasetNavigationService._generate_questions_via_llm(prompt)
 

--- a/app/services/permission_service.py
+++ b/app/services/permission_service.py
@@ -249,36 +249,36 @@ class PermissionService:
             'ai_chat': '智能助手',
             'metadata': '元数据管理',
             'Metadata': '元数据管理',
-            'agent_management': '智能体管理',
-            'Agent_management': '智能体管理',
-            'skills_management': '技能管理',
-            'agent_debug': '智能体测试',
-            'playground': 'API调试',
+            'agent_management': '智能体中心',
+            'Agent_management': '智能体中心',
+            'skills_management': '技能工作台',
+            'agent_debug': '智能体测评',
+            'playground': '接口调试台',
             'chat_logs': '聊天日志',
             'chatbi_examples': '用户反馈管理',
             'users': '用户管理',
             'roles': '角色管理',
             'config': '系统配置',
             'audit': '审计日志',
-            'prompts': '提示词工作室',
-            'widget_debug': '组件测试',
-            'task_center': '任务调度中心',
+            'prompts': '提示词工坊',
+            'widget_debug': '组件调试台',
+            'task_center': '任务调度台',
             'knowledge_management': '知识库管理',
             'knowledge_retrieval_test': '检索测试',
-            'memory_management': '记忆管理中心'
+            'memory_management': '记忆工作台'
         }
         
         element_module_mapping = {
             'metadata': '元数据管理',
-            'agent': '智能体管理',
+            'agent': '智能体中心',
             'chat_logs': '聊天日志',
-            'prompts': '提示词工作室',
+            'prompts': '提示词工坊',
             'user': '用户管理',
             'role': '角色管理',
             'system': '系统管理',
             'chatbi_example': '用户反馈管理',
             'knowledge': '知识库开发平台',
-            'memory': '记忆管理中心'
+            'memory': '记忆工作台'
         }
         
         element_action_mapping = {

--- a/frontend/scripts/chartRenderer.test.ts
+++ b/frontend/scripts/chartRenderer.test.ts
@@ -48,6 +48,25 @@ const bar = mergeChartDefaults({
 assert.equal("xAxis" in bar, true);
 assert.equal("yAxis" in bar, true);
 assert.equal("grid" in bar, true);
+assert.equal(bar.xAxis.axisLabel.color, "#6b7280");
+
+const lightAxis = mergeChartDefaults({
+  xAxis: {
+    data: ["2026-06-11"],
+    axisLabel: { color: "#f3f4f6" },
+  },
+  series: [{ type: "line", data: [1] }],
+});
+assert.equal(lightAxis.xAxis.axisLabel.color, "#6b7280");
+
+const nestedTextStyle = mergeChartDefaults({
+  xAxis: {
+    data: ["A"],
+    axisLabel: { textStyle: { color: "#eeeeee" } },
+  },
+  series: [{ type: "line", data: [1] }],
+});
+assert.equal(nestedTextStyle.xAxis.axisLabel.textStyle.color, "#6b7280");
 
 const parseSse = createSseLineParser();
 assert.deepEqual(parseSse.feed("data: {\"content\":\"hel"), []);

--- a/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
+++ b/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
@@ -1,10 +1,24 @@
 <template>
   <section ref="menuContainer" class="space-y-4">
+    <!-- 状态条 -->
+    <div
+      v-if="portalStatus !== 'ready' || showReadyBanner"
+      class="rounded-xl border px-3 py-2 text-[11px] leading-relaxed flex items-start gap-2"
+      :class="statusBannerClass"
+    >
+      <svg v-if="portalStatus === 'loading'" class="w-4 h-4 animate-spin flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+      </svg>
+      <span v-else class="flex-shrink-0">{{ statusBannerIcon }}</span>
+      <span>{{ statusBannerText }}</span>
+    </div>
+
     <!-- Header -->
     <div class="bg-gray-50/40 dark:bg-gray-800/10 backdrop-blur-sm border border-gray-150 dark:border-gray-800/80 rounded-xl p-3 flex flex-col sm:flex-row justify-between sm:items-center gap-3">
-      <div class="flex items-center gap-2.5">
+      <div class="flex items-center gap-2.5 min-w-0">
         <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-blue-600 dark:bg-blue-500 text-white shadow-sm flex-shrink-0">
-          <svg class="w-4.5 h-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2v-4z"/>
           </svg>
         </div>
@@ -17,15 +31,9 @@
             >
               {{ payload.dataset_count }} 个数据集
             </span>
-            <span class="text-gray-300 dark:text-gray-700">|</span>
-            <span v-if="payload.generated_at" class="text-gray-500 dark:text-gray-400">
-              更新时间 {{ formattedGeneratedAt }}
-            </span>
-            <template v-if="payload.dataset_menu_hash">
+            <template v-if="payload.generated_at">
               <span class="text-gray-300 dark:text-gray-700">|</span>
-              <span class="text-gray-400 dark:text-gray-500 font-mono">
-                {{ payload.dataset_menu_hash.slice(0, 8) }}
-              </span>
+              <span class="text-gray-500 dark:text-gray-400">更新 {{ formattedGeneratedAt }}</span>
             </template>
           </div>
         </div>
@@ -33,12 +41,12 @@
       <button
         type="button"
         class="w-8 h-8 flex-shrink-0 flex items-center justify-center rounded-lg border border-transparent bg-gray-100 hover:bg-gray-200/70 dark:bg-gray-800 dark:hover:bg-gray-750 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-all active:scale-90 cursor-pointer"
-        title="刷新数据门户"
+        :title="refreshButtonTitle"
         @click="handleRefreshClick"
       >
         <svg 
           class="w-4 h-4 transition-transform duration-700"
-          :class="{ 'animate-spin': isRefreshing }"
+          :class="{ 'animate-spin': showRefreshBusy }"
           fill="none" stroke="currentColor" viewBox="0 0 24 24"
         >
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
@@ -48,7 +56,6 @@
 
     <!-- Search and Filter Bar -->
     <div class="space-y-2.5">
-      <!-- Search Input -->
       <div class="relative">
         <span class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-400 dark:text-gray-500">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -56,6 +63,7 @@
           </svg>
         </span>
         <input
+          ref="searchInputRef"
           v-model="searchQuery"
           type="text"
           placeholder="搜索场景、表名或指标..."
@@ -73,8 +81,10 @@
         </button>
       </div>
 
-      <!-- Scrollable Tags Filter -->
-      <div v-if="allTags.length" class="flex items-center gap-1.5 overflow-x-auto no-scrollbar pb-1 -mx-0.5">
+      <div v-if="allTags.length" class="relative">
+        <div class="pointer-events-none absolute inset-y-0 left-0 w-4 bg-gradient-to-r from-white dark:from-gray-900 to-transparent z-10 sm:hidden"></div>
+        <div class="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-white dark:from-gray-900 to-transparent z-10 sm:hidden"></div>
+        <div class="flex items-center gap-1.5 overflow-x-auto no-scrollbar pb-1 -mx-0.5 scroll-smooth">
         <button
           type="button"
           class="px-2.5 py-1 text-[10px] font-bold rounded-lg border transition-all whitespace-nowrap cursor-pointer active:scale-95"
@@ -90,18 +100,54 @@
           :key="tag"
           type="button"
           class="px-2.5 py-1 text-[10px] font-bold rounded-lg border transition-all whitespace-nowrap cursor-pointer active:scale-95"
-          :class="selectedTag === tag
-            ? 'bg-blue-600 border-transparent text-white shadow-xs'
-            : 'bg-gray-50 dark:bg-gray-800/40 border-gray-150 dark:border-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'"
+          :class="tagFilterClass(tag)"
           @click="selectedTag = tag"
         >
           {{ tag }}
         </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- 我常问 -->
+    <div
+      v-if="showFrequentSection"
+      class="rounded-xl border border-amber-100/80 dark:border-amber-900/40 bg-amber-50/40 dark:bg-amber-950/20 p-3 space-y-2"
+    >
+      <div class="text-[10px] font-bold text-amber-700/90 dark:text-amber-300/90 uppercase tracking-wider flex items-center gap-1">
+        <span>🔥</span> 我常问
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <button
+          v-for="item in frequentQuestions"
+          :key="item.question.query"
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-lg border border-amber-200/70 dark:border-amber-800/50 bg-white/80 dark:bg-gray-900/40 px-2.5 py-1.5 text-left text-[11px] font-semibold text-amber-900 dark:text-amber-100 hover:bg-amber-50 dark:hover:bg-amber-950/40 transition-all active:scale-95"
+          @click="handleFrequentQuestionClick(item)"
+        >
+          <span class="truncate max-w-[220px]">{{ item.question.label }}</span>
+          <span class="text-[9px] font-bold text-amber-600 dark:text-amber-400">{{ item.question.click_count }}次</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- 首屏骨架 -->
+    <div v-if="initialLoading" class="grid gap-4">
+      <div v-for="i in 3" :key="`sk-${i}`" class="portal-skeleton-card rounded-xl border border-gray-150 dark:border-gray-800 p-4 space-y-3">
+        <div class="flex items-center gap-2">
+          <div class="portal-skeleton-shimmer w-9 h-9 rounded-xl"></div>
+          <div class="portal-skeleton-shimmer h-4 w-32 rounded"></div>
+        </div>
+        <div class="portal-skeleton-shimmer h-12 w-full rounded-lg"></div>
+        <div class="flex gap-2">
+          <div class="portal-skeleton-shimmer h-8 w-24 rounded-lg"></div>
+          <div class="portal-skeleton-shimmer h-8 w-28 rounded-lg"></div>
+        </div>
       </div>
     </div>
 
     <!-- Cards Grid Container with Loading Overlay -->
-    <div class="relative">
+    <div v-else class="relative">
       <!-- Loading Overlay -->
       <transition
         enter-active-class="transition-opacity duration-200"
@@ -112,7 +158,7 @@
         leave-to-class="opacity-0"
       >
         <div 
-          v-if="isRefreshing" 
+          v-if="showRefreshBusy" 
           class="absolute inset-0 bg-white/60 dark:bg-gray-900/60 backdrop-blur-[2px] z-20 rounded-xl flex items-start justify-center pt-24 pointer-events-auto"
         >
           <div class="flex flex-col items-center gap-2">
@@ -125,64 +171,81 @@
         </div>
       </transition>
 
-      <div class="grid gap-4" :class="{ 'pointer-events-none select-none': isRefreshing }">
+      <div class="grid gap-4" :class="{ 'pointer-events-none select-none': showRefreshBusy }">
         <article
-          v-for="(group, idx) in filteredGroups"
+          v-for="{ group, visuals } in displayGroups"
           :key="group.id || group.title"
-          class="group/card rounded-xl border border-gray-150 dark:border-gray-800/80 bg-white dark:bg-gray-900/30 p-3.5 sm:p-4 shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-300"
+          class="group/card relative overflow-hidden rounded-xl border p-3.5 sm:p-4 shadow-sm hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300"
+          :class="[visuals.card, visuals.cardBorder, visuals.cardHover]"
         >
-          <!-- Card Title -->
-          <div class="flex flex-col sm:flex-row sm:items-start justify-between gap-2.5">
-            <div class="flex items-start gap-2.5 min-w-0">
-              <!-- Icon -->
-              <div 
-                class="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-lg shadow-sm border"
-                :class="[
-                  getGroupVisuals(idx, group.title).bg,
-                  getGroupVisuals(idx, group.title).text,
-                  getGroupVisuals(idx, group.title).border
-                ]"
-                v-html="getGroupVisuals(idx, group.title).icon"
-              ></div>
-              <div class="min-w-0">
-                <h4 class="text-sm font-bold text-gray-900 dark:text-gray-100 leading-normal flex items-center gap-1.5">
+          <div
+            class="pointer-events-none absolute -right-10 -top-10 h-28 w-28 rounded-full opacity-[0.18] blur-2xl transition-opacity duration-300 group-hover/card:opacity-[0.28]"
+            :class="visuals.decor"
+          />
+          <div
+            class="pointer-events-none absolute -left-6 bottom-0 h-20 w-20 rounded-full opacity-[0.08] blur-xl"
+            :class="visuals.decor"
+          />
+
+          <!-- Card Header -->
+          <div class="relative space-y-2.5">
+            <div class="flex flex-col sm:flex-row sm:items-start justify-between gap-2.5">
+              <div class="flex items-start gap-2.5 min-w-0 flex-1">
+                <!-- Icon -->
+                <div 
+                  class="portal-card-icon flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-xl shadow-sm border text-white"
+                  :class="visuals.iconBorder"
+                  :data-theme="visuals.key"
+                  v-html="visuals.icon"
+                ></div>
+                <h4 class="text-sm font-bold leading-normal pt-1.5" :class="visuals.title">
                   {{ group.title }}
                 </h4>
-                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 leading-normal">
-                  {{ group.summary }}
-                </p>
+              </div>
+              
+              <!-- Tags -->
+              <div v-if="group.tags?.length" class="flex flex-wrap gap-1 sm:justify-end flex-shrink-0">
+                <span
+                  v-for="tag in group.tags.slice(0, 3)"
+                  :key="tag"
+                  class="rounded-full border px-2 py-0.5 text-[9px] font-bold"
+                  :class="visuals.tag"
+                >
+                  {{ tag }}
+                </span>
               </div>
             </div>
-            
-            <!-- Tags -->
-            <div v-if="group.tags?.length" class="flex flex-wrap gap-1 mt-1 sm:mt-0 sm:justify-end flex-shrink-0 ml-10.5 sm:ml-0">
-              <span
-                v-for="tag in group.tags.slice(0, 3)"
-                :key="tag"
-                class="rounded-full bg-gray-50 dark:bg-gray-800/80 border border-gray-100 dark:border-gray-700/60 px-2 py-0.5 text-[9px] font-bold text-gray-500 dark:text-gray-400"
-              >
-                {{ tag }}
-              </span>
-            </div>
+
+            <blockquote
+              v-if="group.summary"
+              class="portal-card-summary relative w-full m-0 px-3.5 py-2.5 text-xs leading-relaxed rounded-r-lg border-l-[3px]"
+              :class="visuals.quote"
+              :style="{ '--summary-strong': visuals.strongColor }"
+              v-html="formatGroupSummary(group.summary)"
+            />
           </div>
 
           <!-- You Can Ask Section -->
-          <div v-if="group.questions?.length" class="mt-4">
+          <div v-if="group.questions?.length" class="relative mt-4">
             <div class="mb-2 flex items-center justify-between select-none">
-              <span class="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider flex items-center gap-1">
-                <svg class="w-3.5 h-3.5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <span
+                class="text-[10px] font-bold uppercase tracking-wider flex items-center gap-1"
+                :class="visuals.sectionLabel"
+              >
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                 </svg>
                 你可以这样问
               </span>
               <button
                 type="button"
-                class="inline-flex items-center gap-1 text-[10px] font-bold text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-all duration-200 cursor-pointer active:scale-95 bg-blue-50/50 hover:bg-blue-50 dark:bg-blue-950/20 dark:hover:bg-blue-950/40 px-2 py-0.5 rounded-md border border-blue-100/30 dark:border-blue-900/30 disabled:opacity-50"
+                class="inline-flex items-center gap-1 text-[10px] font-bold transition-all duration-200 cursor-pointer active:scale-95 px-2 py-0.5 rounded-md border disabled:opacity-50"
+                :class="visuals.refreshBtn"
                 :disabled="refreshingGroupIds[group.id || group.title]"
                 @click.stop="handleRefreshGroupQuestions(group)"
               >
                 <svg
-                  class="w-3 h-3 text-blue-500/80 group-hover:text-blue-600 dark:text-blue-400/60 dark:group-hover:text-blue-300"
+                  class="w-3 h-3 opacity-70"
                   :class="{ 'animate-spin': refreshingGroupIds[group.id || group.title] }"
                   fill="none" stroke="currentColor" viewBox="0 0 24 24"
                 >
@@ -193,17 +256,26 @@
             </div>
 
             <div v-if="refreshingGroupIds[group.id || group.title]" class="flex flex-wrap gap-2 animate-pulse-slow">
-              <div v-for="i in 3" :key="i" class="inline-flex items-center h-8 w-32 bg-blue-50/30 dark:bg-blue-950/10 border border-blue-100/10 dark:border-blue-900/10 rounded-lg"></div>
+              <div
+                v-for="i in 3"
+                :key="i"
+                class="inline-flex items-center h-8 w-32 rounded-lg border"
+                :class="visuals.questionSkeleton"
+              ></div>
             </div>
             <div v-else class="flex flex-wrap gap-2">
               <button
-                v-for="question in group.questions"
+                v-for="question in sortedQuestions(group.questions)"
                 :key="question.query"
                 type="button"
-                class="group/btn relative inline-flex items-center gap-1.5 rounded-lg border border-blue-100 dark:border-blue-900/30 bg-blue-50/30 dark:bg-blue-950/20 px-3 py-2 text-left text-xs font-semibold text-blue-700 dark:text-blue-300 transition-all hover:bg-blue-50 hover:border-blue-300/60 dark:hover:bg-blue-900/40 hover:-translate-y-0.5 active:translate-y-0 shadow-sm"
+                class="group/btn relative inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-left text-xs font-semibold transition-all hover:-translate-y-0.5 active:translate-y-0 shadow-sm"
+                :class="visuals.questionBtn"
                 @click="handleQuestionClick(question, group)"
               >
-                <svg class="w-3.5 h-3.5 text-blue-400/80 group-hover/btn:text-blue-500 dark:text-blue-400/60 dark:group-hover/btn:text-blue-300 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg
+                  class="w-3.5 h-3.5 flex-shrink-0 opacity-80 group-hover/btn:opacity-100"
+                  fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                >
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
                 </svg>
                 <span>{{ question.label }}</span>
@@ -219,7 +291,11 @@
 
 
           <!-- Related Data Section -->
-          <div v-if="group.related_data?.length" class="mt-4 border-t border-gray-100 dark:border-gray-800/80 pt-3">
+          <div
+            v-if="group.related_data?.length"
+            class="relative mt-4 border-t pt-3"
+            :class="visuals.divider"
+          >
             <button
               type="button"
               class="flex items-center justify-between w-full text-left text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider hover:text-gray-600 dark:hover:text-gray-300 transition-colors select-none"
@@ -230,6 +306,9 @@
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
                 </svg>
                 相关数据
+                <span class="rounded-full px-1.5 py-0.5 text-[9px] font-bold bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 normal-case tracking-normal">
+                  {{ countRelatedTables(group) }} 张表
+                </span>
               </span>
               <svg
                 class="w-3.5 h-3.5 transform transition-transform duration-300"
@@ -390,7 +469,18 @@
           </svg>
         </div>
         <h4 class="text-xs font-bold text-gray-500 dark:text-gray-400">未找到相关数据场景</h4>
-        <p class="text-[10px] text-gray-400 dark:text-gray-500 max-w-[200px]">尝试精简搜索词，或切换其他分类标签</p>
+        <p class="text-[10px] text-gray-400 dark:text-gray-500 max-w-[240px]">尝试精简搜索词，或切换其他分类标签</p>
+        <div v-if="emptySearchSuggestions.length" class="flex flex-wrap gap-1.5 justify-center pt-1">
+          <button
+            v-for="tag in emptySearchSuggestions"
+            :key="tag"
+            type="button"
+            class="px-2 py-0.5 text-[10px] rounded-full border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:border-primary/40 hover:text-primary transition-colors"
+            @click="applyEmptySearchSuggestion(tag)"
+          >
+            试试：{{ tag }}
+          </button>
+        </div>
       </div>
 
     </div>
@@ -398,7 +488,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed, onMounted, onUnmounted } from "vue";
+import { ref, watch, computed, onMounted, onUnmounted, nextTick } from "vue";
 import axios from "@/utils/axios";
 
 interface DatasetCapabilityQuestion {
@@ -441,11 +531,25 @@ interface DatasetNavigationPayload {
   generated_at?: string;
   groups?: DatasetCapabilityGroup[];
   markdown?: string;
+  is_fallback?: boolean;
 }
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   payload: DatasetNavigationPayload;
-}>();
+  initialLoading?: boolean;
+  backgroundRefreshing?: boolean;
+}>(), {
+  initialLoading: false,
+  backgroundRefreshing: false,
+});
+
+const formatGroupSummary = (text: string): string => {
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return escaped.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+};
 
 const emit = defineEmits<{
   (event: "quick-question", query: string): void;
@@ -454,7 +558,19 @@ const emit = defineEmits<{
 }>();
 
 const menuContainer = ref<HTMLElement | null>(null);
+const searchInputRef = ref<HTMLInputElement | null>(null);
 const isRefreshing = ref(false);
+let refreshSafetyTimer: ReturnType<typeof setTimeout> | null = null;
+
+const showRefreshBusy = computed(() => isRefreshing.value || props.backgroundRefreshing);
+
+const clearRefreshBusy = () => {
+  isRefreshing.value = false;
+  if (refreshSafetyTimer) {
+    clearTimeout(refreshSafetyTimer);
+    refreshSafetyTimer = null;
+  }
+};
 const expandedGroups = ref<Record<string, boolean>>({});
 const refreshingGroupIds = ref<Record<string, boolean>>({});
 const activeTableDictionary = ref<string | null>(null);
@@ -552,6 +668,120 @@ onUnmounted(() => {
 const searchQuery = ref("");
 const selectedTag = ref("All");
 
+const groupPopularityScore = (group: DatasetCapabilityGroup): number => {
+  const questions = group.questions || [];
+  return questions.reduce((max, q) => Math.max(max, q.click_count || 0), 0);
+};
+
+const sortedQuestions = (questions?: DatasetCapabilityQuestion[]) => {
+  return [...(questions || [])].sort((a, b) => (b.click_count || 0) - (a.click_count || 0));
+};
+
+const countRelatedTables = (group: DatasetCapabilityGroup): number => {
+  return (group.related_data || []).reduce((sum, item) => sum + (item.tables?.length || 0), 0);
+};
+
+const portalStatus = computed(() => {
+  if (props.initialLoading) return "loading";
+  if (props.backgroundRefreshing) return "refreshing";
+  if (props.payload?.is_fallback) return "fallback";
+  return "ready";
+});
+
+const formattedGeneratedAt = computed(() => {
+  if (!props.payload.generated_at) return "";
+  const date = new Date(props.payload.generated_at);
+  if (Number.isNaN(date.getTime())) return props.payload.generated_at;
+  return date.toLocaleString();
+});
+
+const showReadyBanner = computed(() => false);
+
+const statusBannerClass = computed(() => {
+  switch (portalStatus.value) {
+    case "loading":
+      return "border-blue-100 bg-blue-50/70 text-blue-700 dark:border-blue-900/40 dark:bg-blue-950/30 dark:text-blue-200";
+    case "refreshing":
+      return "border-blue-100 bg-blue-50/50 text-blue-600 dark:border-blue-900/40 dark:bg-blue-950/20 dark:text-blue-300";
+    case "fallback":
+      return "border-amber-100 bg-amber-50/70 text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200";
+    default:
+      return "border-emerald-100 bg-emerald-50/60 text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300";
+  }
+});
+
+const statusBannerIcon = computed(() => {
+  if (portalStatus.value === "fallback") return "⚠️";
+  if (portalStatus.value === "ready") return "✓";
+  return "…";
+});
+
+const statusBannerText = computed(() => {
+  switch (portalStatus.value) {
+    case "loading":
+      return "正在生成数据门户，首次加载约需 15–30 秒，请稍候…";
+    case "refreshing":
+      return "正在后台刷新完整门户内容…";
+    case "fallback":
+      return "当前为基础场景目录，完整 AI 场景卡片正在后台生成，可先点击问题开始查数。";
+    default:
+      return `门户已就绪${props.payload?.generated_at ? `（${formattedGeneratedAt.value}）` : ""}`;
+  }
+});
+
+const refreshButtonTitle = computed(() => {
+  const hash = props.payload?.dataset_menu_hash?.slice(0, 8);
+  return hash ? `刷新数据门户（缓存版本 ${hash}）` : "刷新数据门户";
+});
+
+const frequentQuestions = computed(() => {
+  const merged = new Map<string, { question: DatasetCapabilityQuestion; group: DatasetCapabilityGroup }>();
+  for (const group of props.payload.groups || []) {
+    for (const question of group.questions || []) {
+      const query = String(question.query || "").trim();
+      const clicks = question.click_count || 0;
+      if (!query || clicks <= 0) continue;
+      const existing = merged.get(query);
+      if (!existing || clicks > (existing.question.click_count || 0)) {
+        merged.set(query, { question, group });
+      }
+    }
+  }
+  return Array.from(merged.values())
+    .sort((a, b) => (b.question.click_count || 0) - (a.question.click_count || 0))
+    .slice(0, 5);
+});
+
+const showFrequentSection = computed(() => {
+  return !searchQuery.value.trim() && selectedTag.value === "All" && frequentQuestions.value.length > 0;
+});
+
+const emptySearchSuggestions = computed(() => allTags.value.slice(0, 3));
+
+const tagFilterClass = (tag: string) => {
+  if (selectedTag.value !== tag) {
+    return "bg-gray-50 dark:bg-gray-800/40 border-gray-150 dark:border-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800";
+  }
+  const owner = (props.payload.groups || []).find((group) => (group.tags || []).includes(tag));
+  const theme = getGroupVisuals(0, owner?.title || tag);
+  return `${theme.tag} ring-1 ring-current/20 shadow-xs`;
+};
+
+const applyEmptySearchSuggestion = (tag: string) => {
+  selectedTag.value = tag;
+  searchQuery.value = "";
+};
+
+const handleFrequentQuestionClick = (item: { question: DatasetCapabilityQuestion; group: DatasetCapabilityGroup }) => {
+  handleQuestionClick(item.question, item.group);
+};
+
+const focusSearch = () => {
+  nextTick(() => searchInputRef.value?.focus());
+};
+
+defineExpose({ focusSearch });
+
 // 动态去重提取出当前有权访问的所有卡片 tags
 const allTags = computed(() => {
   const tagsSet = new Set<string>();
@@ -568,6 +798,153 @@ const allTags = computed(() => {
   }
   return Array.from(tagsSet);
 });
+
+// 图标与视觉主题定义
+interface GroupVisualTheme {
+  key: string;
+  card: string;
+  cardBorder: string;
+  cardHover: string;
+  decor: string;
+  iconBorder: string;
+  icon: string;
+  title: string;
+  tag: string;
+  quote: string;
+  strongColor: string;
+  sectionLabel: string;
+  refreshBtn: string;
+  questionBtn: string;
+  questionSkeleton: string;
+  divider: string;
+}
+
+const CARD_THEMES: GroupVisualTheme[] = [
+  {
+    key: "blue",
+    card: "bg-gradient-to-br from-blue-50/95 via-white to-sky-50/50 dark:from-blue-950/35 dark:via-gray-900/50 dark:to-sky-950/15",
+    cardBorder: "border-blue-100/90 dark:border-blue-900/45",
+    cardHover: "hover:border-blue-200 dark:hover:border-blue-700/60",
+    decor: "bg-blue-400",
+    iconBorder: "border-blue-400/20",
+    icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>`,
+    title: "text-blue-950 dark:text-blue-100",
+    tag: "bg-blue-100/90 text-blue-700 border-blue-200/70 dark:bg-blue-900/50 dark:text-blue-200 dark:border-blue-800/60",
+    quote: "border-l-blue-500 bg-blue-50/70 text-blue-900/75 dark:bg-blue-950/35 dark:text-blue-200/90 dark:border-l-blue-400",
+    strongColor: "#1d4ed8",
+    sectionLabel: "text-blue-500/80 dark:text-blue-400/80",
+    refreshBtn: "text-blue-700 bg-white/70 border-blue-200/70 hover:bg-blue-50 dark:text-blue-300 dark:bg-blue-950/40 dark:border-blue-800/50 dark:hover:bg-blue-900/50",
+    questionBtn: "border-blue-200/80 bg-white/80 text-blue-800 hover:bg-blue-50 hover:border-blue-300 dark:border-blue-800/50 dark:bg-blue-950/25 dark:text-blue-200 dark:hover:bg-blue-900/40",
+    questionSkeleton: "bg-blue-50/40 border-blue-100/30 dark:bg-blue-950/15 dark:border-blue-900/20",
+    divider: "border-blue-100/80 dark:border-blue-900/35",
+  },
+  {
+    key: "violet",
+    card: "bg-gradient-to-br from-violet-50/95 via-white to-purple-50/40 dark:from-violet-950/35 dark:via-gray-900/50 dark:to-purple-950/15",
+    cardBorder: "border-violet-100/90 dark:border-violet-900/45",
+    cardHover: "hover:border-violet-200 dark:hover:border-violet-700/60",
+    decor: "bg-violet-400",
+    iconBorder: "border-violet-400/20",
+    icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>`,
+    title: "text-violet-950 dark:text-violet-100",
+    tag: "bg-violet-100/90 text-violet-700 border-violet-200/70 dark:bg-violet-900/50 dark:text-violet-200 dark:border-violet-800/60",
+    quote: "border-l-violet-500 bg-violet-50/70 text-violet-900/75 dark:bg-violet-950/35 dark:text-violet-200/90 dark:border-l-violet-400",
+    strongColor: "#6d28d9",
+    sectionLabel: "text-violet-500/80 dark:text-violet-400/80",
+    refreshBtn: "text-violet-700 bg-white/70 border-violet-200/70 hover:bg-violet-50 dark:text-violet-300 dark:bg-violet-950/40 dark:border-violet-800/50 dark:hover:bg-violet-900/50",
+    questionBtn: "border-violet-200/80 bg-white/80 text-violet-800 hover:bg-violet-50 hover:border-violet-300 dark:border-violet-800/50 dark:bg-violet-950/25 dark:text-violet-200 dark:hover:bg-violet-900/40",
+    questionSkeleton: "bg-violet-50/40 border-violet-100/30 dark:bg-violet-950/15 dark:border-violet-900/20",
+    divider: "border-violet-100/80 dark:border-violet-900/35",
+  },
+  {
+    key: "emerald",
+    card: "bg-gradient-to-br from-emerald-50/95 via-white to-teal-50/40 dark:from-emerald-950/35 dark:via-gray-900/50 dark:to-teal-950/15",
+    cardBorder: "border-emerald-100/90 dark:border-emerald-900/45",
+    cardHover: "hover:border-emerald-200 dark:hover:border-emerald-700/60",
+    decor: "bg-emerald-400",
+    iconBorder: "border-emerald-400/20",
+    icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>`,
+    title: "text-emerald-950 dark:text-emerald-100",
+    tag: "bg-emerald-100/90 text-emerald-700 border-emerald-200/70 dark:bg-emerald-900/50 dark:text-emerald-200 dark:border-emerald-800/60",
+    quote: "border-l-emerald-500 bg-emerald-50/70 text-emerald-900/75 dark:bg-emerald-950/35 dark:text-emerald-200/90 dark:border-l-emerald-400",
+    strongColor: "#047857",
+    sectionLabel: "text-emerald-500/80 dark:text-emerald-400/80",
+    refreshBtn: "text-emerald-700 bg-white/70 border-emerald-200/70 hover:bg-emerald-50 dark:text-emerald-300 dark:bg-emerald-950/40 dark:border-emerald-800/50 dark:hover:bg-emerald-900/50",
+    questionBtn: "border-emerald-200/80 bg-white/80 text-emerald-800 hover:bg-emerald-50 hover:border-emerald-300 dark:border-emerald-800/50 dark:bg-emerald-950/25 dark:text-emerald-200 dark:hover:bg-emerald-900/40",
+    questionSkeleton: "bg-emerald-50/40 border-emerald-100/30 dark:bg-emerald-950/15 dark:border-emerald-900/20",
+    divider: "border-emerald-100/80 dark:border-emerald-900/35",
+  },
+  {
+    key: "amber",
+    card: "bg-gradient-to-br from-amber-50/95 via-white to-orange-50/35 dark:from-amber-950/30 dark:via-gray-900/50 dark:to-orange-950/15",
+    cardBorder: "border-amber-100/90 dark:border-amber-900/45",
+    cardHover: "hover:border-amber-200 dark:hover:border-amber-700/60",
+    decor: "bg-amber-400",
+    iconBorder: "border-amber-400/20",
+    icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>`,
+    title: "text-amber-950 dark:text-amber-100",
+    tag: "bg-amber-100/90 text-amber-800 border-amber-200/70 dark:bg-amber-900/50 dark:text-amber-200 dark:border-amber-800/60",
+    quote: "border-l-amber-500 bg-amber-50/70 text-amber-900/75 dark:bg-amber-950/35 dark:text-amber-200/90 dark:border-l-amber-400",
+    strongColor: "#b45309",
+    sectionLabel: "text-amber-600/80 dark:text-amber-400/80",
+    refreshBtn: "text-amber-800 bg-white/70 border-amber-200/70 hover:bg-amber-50 dark:text-amber-300 dark:bg-amber-950/40 dark:border-amber-800/50 dark:hover:bg-amber-900/50",
+    questionBtn: "border-amber-200/80 bg-white/80 text-amber-900 hover:bg-amber-50 hover:border-amber-300 dark:border-amber-800/50 dark:bg-amber-950/25 dark:text-amber-200 dark:hover:bg-amber-900/40",
+    questionSkeleton: "bg-amber-50/40 border-amber-100/30 dark:bg-amber-950/15 dark:border-amber-900/20",
+    divider: "border-amber-100/80 dark:border-amber-900/35",
+  },
+  {
+    key: "rose",
+    card: "bg-gradient-to-br from-rose-50/95 via-white to-pink-50/35 dark:from-rose-950/30 dark:via-gray-900/50 dark:to-pink-950/15",
+    cardBorder: "border-rose-100/90 dark:border-rose-900/45",
+    cardHover: "hover:border-rose-200 dark:hover:border-rose-700/60",
+    decor: "bg-rose-400",
+    iconBorder: "border-rose-400/20",
+    icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/></svg>`,
+    title: "text-rose-950 dark:text-rose-100",
+    tag: "bg-rose-100/90 text-rose-700 border-rose-200/70 dark:bg-rose-900/50 dark:text-rose-200 dark:border-rose-800/60",
+    quote: "border-l-rose-500 bg-rose-50/70 text-rose-900/75 dark:bg-rose-950/35 dark:text-rose-200/90 dark:border-l-rose-400",
+    strongColor: "#be123c",
+    sectionLabel: "text-rose-500/80 dark:text-rose-400/80",
+    refreshBtn: "text-rose-700 bg-white/70 border-rose-200/70 hover:bg-rose-50 dark:text-rose-300 dark:bg-rose-950/40 dark:border-rose-800/50 dark:hover:bg-rose-900/50",
+    questionBtn: "border-rose-200/80 bg-white/80 text-rose-800 hover:bg-rose-50 hover:border-rose-300 dark:border-rose-800/50 dark:bg-rose-950/25 dark:text-rose-200 dark:hover:bg-rose-900/40",
+    questionSkeleton: "bg-rose-50/40 border-rose-100/30 dark:bg-rose-950/15 dark:border-rose-900/20",
+    divider: "border-rose-100/80 dark:border-rose-900/35",
+  },
+  {
+    key: "cyan",
+    card: "bg-gradient-to-br from-cyan-50/95 via-white to-sky-50/35 dark:from-cyan-950/30 dark:via-gray-900/50 dark:to-sky-950/15",
+    cardBorder: "border-cyan-100/90 dark:border-cyan-900/45",
+    cardHover: "hover:border-cyan-200 dark:hover:border-cyan-700/60",
+    decor: "bg-cyan-400",
+    iconBorder: "border-cyan-400/20",
+    icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>`,
+    title: "text-cyan-950 dark:text-cyan-100",
+    tag: "bg-cyan-100/90 text-cyan-800 border-cyan-200/70 dark:bg-cyan-900/50 dark:text-cyan-200 dark:border-cyan-800/60",
+    quote: "border-l-cyan-500 bg-cyan-50/70 text-cyan-900/75 dark:bg-cyan-950/35 dark:text-cyan-200/90 dark:border-l-cyan-400",
+    strongColor: "#0e7490",
+    sectionLabel: "text-cyan-600/80 dark:text-cyan-400/80",
+    refreshBtn: "text-cyan-800 bg-white/70 border-cyan-200/70 hover:bg-cyan-50 dark:text-cyan-300 dark:bg-cyan-950/40 dark:border-cyan-800/50 dark:hover:bg-cyan-900/50",
+    questionBtn: "border-cyan-200/80 bg-white/80 text-cyan-900 hover:bg-cyan-50 hover:border-cyan-300 dark:border-cyan-800/50 dark:bg-cyan-950/25 dark:text-cyan-200 dark:hover:bg-cyan-900/40",
+    questionSkeleton: "bg-cyan-50/40 border-cyan-100/30 dark:bg-cyan-950/15 dark:border-cyan-900/20",
+    divider: "border-cyan-100/80 dark:border-cyan-900/35",
+  },
+];
+
+const resolveThemeKey = (index: number, title: string): string => {
+  const titleStr = title || "";
+  if (titleStr.includes("智能体") || titleStr.includes("Agent") || titleStr.includes("大模型") || titleStr.includes("AI")) return "violet";
+  if (titleStr.includes("权限") || titleStr.includes("审计") || titleStr.includes("安全") || titleStr.includes("合规")) return "amber";
+  if (titleStr.includes("运维") || titleStr.includes("告警") || titleStr.includes("机房") || titleStr.includes("监控")) return "emerald";
+  if (titleStr.includes("用户") || titleStr.includes("客户") || titleStr.includes("订单") || titleStr.includes("会员")) return "rose";
+  if (titleStr.includes("数据") || titleStr.includes("看板") || titleStr.includes("报表") || titleStr.includes("门户")) return "cyan";
+  if (titleStr.includes("分析") || titleStr.includes("日志") || titleStr.includes("诊断") || titleStr.includes("统计")) return "blue";
+  return CARD_THEMES[index % CARD_THEMES.length].key;
+};
+
+const getGroupVisuals = (index: number, title: string): GroupVisualTheme => {
+  const key = resolveThemeKey(index, title);
+  return CARD_THEMES.find((theme) => theme.key === key) || CARD_THEMES[index % CARD_THEMES.length];
+};
 
 // 计算属性：联合搜索与过滤
 const filteredGroups = computed(() => {
@@ -617,21 +994,33 @@ const filteredGroups = computed(() => {
   });
 });
 
-const formattedGeneratedAt = computed(() => {
-  if (!props.payload.generated_at) return "";
-  const date = new Date(props.payload.generated_at);
-  if (Number.isNaN(date.getTime())) return props.payload.generated_at;
-  return date.toLocaleString();
+const displayGroups = computed(() => {
+  const sorted = [...filteredGroups.value].sort(
+    (a, b) => groupPopularityScore(b) - groupPopularityScore(a),
+  );
+  return sorted.map((group, idx) => ({
+    group,
+    visuals: getGroupVisuals(idx, group.title),
+  }));
 });
 
 const handleRefreshClick = () => {
   isRefreshing.value = true;
   emit("refresh");
-  // 防御性安全重置
-  setTimeout(() => {
-    isRefreshing.value = false;
-  }, 30000);
+  if (refreshSafetyTimer) clearTimeout(refreshSafetyTimer);
+  refreshSafetyTimer = setTimeout(() => {
+    clearRefreshBusy();
+  }, 120000);
 };
+
+watch(
+  () => props.backgroundRefreshing,
+  (busy, wasBusy) => {
+    if (wasBusy && !busy) {
+      clearRefreshBusy();
+    }
+  },
+);
 
 const handleRefreshGroupQuestions = async (group: DatasetCapabilityGroup) => {
   const uniqueId = group.id || group.title;
@@ -670,16 +1059,22 @@ const handleRefreshGroupQuestions = async (group: DatasetCapabilityGroup) => {
 
 // 监听 payload 的变化重置刷新动画与过滤状态
 watch(
-  () => props.payload,
-  () => {
-    isRefreshing.value = false;
-    searchQuery.value = "";
-    selectedTag.value = "All";
+  () => [props.payload?.dataset_menu_hash, props.payload?.generated_at] as const,
+  (next, prev) => {
+    if (!prev) return;
+    const [nextHash, nextGeneratedAt] = next;
+    const [prevHash, prevGeneratedAt] = prev;
+    if (nextHash !== prevHash || nextGeneratedAt !== prevGeneratedAt) {
+      clearRefreshBusy();
+    }
+    if (prevHash && nextHash !== prevHash) {
+      searchQuery.value = "";
+      selectedTag.value = "All";
+    }
     activeTableDictionary.value = null;
     pinnedTableDictionary.value = null;
     refreshingGroupIds.value = {};
   },
-  { deep: true }
 );
 
 const toggleGroup = (groupId: string) => {
@@ -726,76 +1121,71 @@ const handleQuickQuestionClick = (type: 'structure' | 'query' | 'recommend', tab
   pinnedTableDictionary.value = null;
   activeTableDictionary.value = null;
 };
-
-// 图标与视觉渐变定义辅助函数
-const getGroupVisuals = (index: number, title: string) => {
-  const titleStr = title || "";
-  
-  if (titleStr.includes("分析") || titleStr.includes("监控") || titleStr.includes("日志") || titleStr.includes("诊断")) {
-    return {
-      bg: "bg-blue-50 dark:bg-blue-950/20",
-      border: "border-blue-100 dark:border-blue-900/30",
-      text: "text-blue-500 dark:text-blue-400",
-      icon: `<svg class="w-4.5 h-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 002 2h2a2 2 0 002-2z"/>
-      </svg>`
-    };
-  }
-  
-  if (titleStr.includes("智能体") || titleStr.includes("Agent") || titleStr.includes("大模型") || titleStr.includes("AI")) {
-    return {
-      bg: "bg-violet-50 dark:bg-violet-950/20",
-      border: "border-violet-100 dark:border-violet-900/30",
-      text: "text-violet-500 dark:text-violet-400",
-      icon: `<svg class="w-4.5 h-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
-      </svg>`
-    };
-  }
-  
-  if (titleStr.includes("数据") || titleStr.includes("看板") || titleStr.includes("报表") || titleStr.includes("门户")) {
-    return {
-      bg: "bg-emerald-50 dark:bg-emerald-950/20",
-      border: "border-emerald-100 dark:border-emerald-900/30",
-      text: "text-emerald-500 dark:text-emerald-400",
-      icon: `<svg class="w-4.5 h-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-      </svg>`
-    };
-  }
-
-  // 默认根据 index 索引轮换
-  const visuals = [
-    {
-      bg: "bg-blue-50 dark:bg-blue-950/20",
-      border: "border-blue-100 dark:border-blue-900/30",
-      text: "text-blue-500 dark:text-blue-400",
-      icon: `<svg class="w-4.5 h-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
-      </svg>`
-    },
-    {
-      bg: "bg-purple-50 dark:bg-purple-950/20",
-      border: "border-purple-100 dark:border-purple-900/30",
-      text: "text-purple-500 dark:text-purple-400",
-      icon: `<svg class="w-4.5 h-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"/>
-      </svg>`
-    },
-    {
-      bg: "bg-teal-50 dark:bg-teal-950/20",
-      border: "border-teal-100 dark:border-teal-900/30",
-      text: "text-teal-500 dark:text-teal-400",
-      icon: `<svg class="w-4.5 h-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
-      </svg>`
-    }
-  ];
-  return visuals[index % visuals.length];
-};
 </script>
 
 <style scoped>
+.portal-card-icon :deep(svg) {
+  width: 18px;
+  height: 18px;
+  display: block;
+  flex-shrink: 0;
+}
+
+.portal-card-icon[data-theme="blue"] {
+  background: linear-gradient(135deg, #3b82f6, #2563eb);
+  box-shadow: 0 4px 12px rgb(59 130 246 / 0.25);
+}
+
+.portal-card-icon[data-theme="violet"] {
+  background: linear-gradient(135deg, #8b5cf6, #7c3aed);
+  box-shadow: 0 4px 12px rgb(139 92 246 / 0.25);
+}
+
+.portal-card-icon[data-theme="emerald"] {
+  background: linear-gradient(135deg, #10b981, #0d9488);
+  box-shadow: 0 4px 12px rgb(16 185 129 / 0.25);
+}
+
+.portal-card-icon[data-theme="amber"] {
+  background: linear-gradient(135deg, #f59e0b, #ea580c);
+  box-shadow: 0 4px 12px rgb(245 158 11 / 0.25);
+}
+
+.portal-card-icon[data-theme="rose"] {
+  background: linear-gradient(135deg, #f43f5e, #db2777);
+  box-shadow: 0 4px 12px rgb(244 63 94 / 0.25);
+}
+
+.portal-card-icon[data-theme="cyan"] {
+  background: linear-gradient(135deg, #06b6d4, #0284c7);
+  box-shadow: 0 4px 12px rgb(6 182 212 / 0.25);
+}
+
+.portal-card-summary :deep(strong) {
+  font-weight: 600;
+  color: var(--summary-strong, rgb(55 65 81));
+}
+
+:global(.dark) .portal-card-summary :deep(strong) {
+  filter: brightness(1.35);
+}
+
+@keyframes portal-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.portal-skeleton-shimmer {
+  background: linear-gradient(90deg, rgb(243 244 246) 25%, rgb(229 231 235) 50%, rgb(243 244 246) 75%);
+  background-size: 200% 100%;
+  animation: portal-shimmer 1.4s ease-in-out infinite;
+}
+
+:global(.dark) .portal-skeleton-shimmer {
+  background: linear-gradient(90deg, rgb(31 41 55) 25%, rgb(55 65 81) 50%, rgb(31 41 55) 75%);
+  background-size: 200% 100%;
+}
+
 .animate-pulse-slow {
   animation: pulse 2.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }

--- a/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
+++ b/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
@@ -40,8 +40,12 @@
       </div>
       <button
         type="button"
-        class="w-8 h-8 flex-shrink-0 flex items-center justify-center rounded-lg border border-transparent bg-gray-100 hover:bg-gray-200/70 dark:bg-gray-800 dark:hover:bg-gray-750 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-all active:scale-90 cursor-pointer"
-        :title="refreshButtonTitle"
+        class="w-8 h-8 flex-shrink-0 flex items-center justify-center rounded-lg border border-transparent bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400 transition-all"
+        :class="refreshDisabled
+          ? 'opacity-50 cursor-not-allowed'
+          : 'hover:bg-gray-200/70 dark:hover:bg-gray-750 hover:text-gray-700 dark:hover:text-gray-200 active:scale-90 cursor-pointer'"
+        :disabled="refreshDisabled"
+        :title="refreshDisabled && props.initialLoading ? '数据门户首次加载中，请稍候' : refreshButtonTitle"
         @click="handleRefreshClick"
       >
         <svg 
@@ -337,12 +341,11 @@
                         v-for="table in related.tables || []"
                         :key="table"
                         class="relative inline-block overflow-visible"
-                        @mouseenter="handleMouseEnter($event, `${group.id || group.title}_${related.dataset || related.display_name || ''}_${table}`)"
-                        @mouseleave="handleMouseLeave"
                       >
                         <span
-                          class="inline-flex items-center gap-1 rounded bg-white dark:bg-gray-800 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:text-gray-300 ring-1 ring-gray-100 dark:ring-gray-700/60 shadow-sm hover:scale-102 hover:shadow-xs transition-all duration-200 cursor-pointer select-none active:scale-95"
-                          @click.stop="handleClick($event, `${group.id || group.title}_${related.dataset || related.display_name || ''}_${table}`)"
+                          class="inline-flex items-center gap-1 rounded bg-white dark:bg-gray-800 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:text-gray-300 ring-1 ring-gray-100 dark:ring-gray-700/60 shadow-sm hover:shadow-xs transition-all duration-200 cursor-pointer select-none active:scale-95"
+                          :class="pinnedTableDictionary === buildTableDictionaryKey(group, related, table) ? 'ring-2 ring-primary/35 text-primary dark:text-primary' : 'hover:scale-102'"
+                          @click.stop="handleTableDictionaryClick($event, group, related, table)"
                         >
                           <svg class="w-2.5 h-2.5 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/>
@@ -360,9 +363,9 @@
                           leave-to-class="opacity-0 translate-y-1 scale-95"
                         >
                           <div 
-                            v-if="(activeTableDictionary === `${group.id || group.title}_${related.dataset || related.display_name || ''}_${table}` || pinnedTableDictionary === `${group.id || group.title}_${related.dataset || related.display_name || ''}_${table}`) && related.table_columns?.[table]?.length" 
+                            v-if="pinnedTableDictionary === buildTableDictionaryKey(group, related, table) && related.table_columns?.[table]?.length" 
                             class="absolute z-45 bottom-full mb-2 w-72 bg-white dark:bg-gray-850 border border-gray-150 dark:border-gray-750 rounded-xl p-3 shadow-xl text-left select-none ring-1 ring-black/5"
-                            :style="popoverStyles[`${group.id || group.title}_${related.dataset || related.display_name || ''}_${table}`] || { left: '50%', transform: 'translateX(-50%)' }"
+                            :style="popoverStyles[buildTableDictionaryKey(group, related, table)] || { left: '50%', transform: 'translateX(-50%)' }"
                             @click.stop
                           >
                             <h5 class="text-[10px] font-bold text-gray-800 dark:text-gray-250 mb-2 border-b border-gray-100 dark:border-gray-750 pb-1 flex items-center justify-between">
@@ -375,7 +378,7 @@
                               <button 
                                 type="button" 
                                 class="text-gray-400 hover:text-gray-650 dark:hover:text-gray-200 w-4 h-4 flex items-center justify-center rounded-full hover:bg-gray-100 dark:hover:bg-gray-750 transition-colors flex-shrink-0 cursor-pointer"
-                                @click.stop="pinnedTableDictionary = null; activeTableDictionary = null"
+                                @click.stop="pinnedTableDictionary = null"
                               >
                                 &times;
                               </button>
@@ -418,12 +421,47 @@
                               </button>
                               <button
                                 type="button"
-                                class="flex-1 flex items-center justify-center gap-0.5 py-1 px-1.5 text-[9px] font-bold rounded bg-amber-50 hover:bg-amber-100 dark:bg-amber-950/30 dark:hover:bg-amber-900/40 text-amber-600 dark:text-amber-400 border border-amber-100/50 dark:border-amber-900/30 transition-all cursor-pointer active:scale-95 whitespace-nowrap"
-                                title="推荐业务分析问题"
-                                @click.stop="handleQuickQuestionClick('recommend', table, related)"
+                                class="flex-1 flex items-center justify-center gap-0.5 py-1 px-1.5 text-[9px] font-bold rounded bg-amber-50 hover:bg-amber-100 dark:bg-amber-950/30 dark:hover:bg-amber-900/40 text-amber-600 dark:text-amber-400 border border-amber-100/50 dark:border-amber-900/30 transition-all cursor-pointer active:scale-95 whitespace-nowrap disabled:opacity-60 disabled:cursor-not-allowed"
+                                title="基于字段定义推荐业务分析问题"
+                                :disabled="tableRecommendState[buildTableDictionaryKey(group, related, table)]?.loading"
+                                @click.stop="handleRecommendQuestions(group, related, table)"
                               >
-                                <span>💡 推荐提问</span>
+                                <span v-if="tableRecommendState[buildTableDictionaryKey(group, related, table)]?.loading">生成中…</span>
+                                <span v-else>💡 推荐提问</span>
                               </button>
+                            </div>
+                            <div
+                              v-if="tableRecommendState[buildTableDictionaryKey(group, related, table)]"
+                              class="mt-2 pt-2 border-t border-gray-100 dark:border-gray-750 space-y-1.5"
+                            >
+                              <div
+                                v-if="tableRecommendState[buildTableDictionaryKey(group, related, table)]?.loading"
+                                class="flex items-center gap-1.5 text-[9px] text-amber-700/80 dark:text-amber-300/80"
+                              >
+                                <svg class="w-3 h-3 animate-spin flex-shrink-0" fill="none" viewBox="0 0 24 24">
+                                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
+                                正在基于字段定义生成推荐提问…
+                              </div>
+                              <div
+                                v-else-if="tableRecommendState[buildTableDictionaryKey(group, related, table)]?.error"
+                                class="text-[9px] text-rose-600 dark:text-rose-400 leading-relaxed"
+                              >
+                                {{ tableRecommendState[buildTableDictionaryKey(group, related, table)]?.error }}
+                              </div>
+                              <template v-else>
+                                <div class="text-[9px] font-bold text-gray-500 dark:text-gray-400">推荐业务提问</div>
+                                <button
+                                  v-for="question in tableRecommendState[buildTableDictionaryKey(group, related, table)]?.questions || []"
+                                  :key="question.query"
+                                  type="button"
+                                  class="w-full text-left rounded-lg border border-amber-100/80 dark:border-amber-900/40 bg-amber-50/50 dark:bg-amber-950/20 px-2 py-1.5 text-[9px] font-semibold text-amber-900 dark:text-amber-100 hover:bg-amber-100/70 dark:hover:bg-amber-950/40 transition-all active:scale-[0.99]"
+                                  @click.stop="handleRecommendedQuestionClick(question)"
+                                >
+                                  🙋 {{ question.label }}
+                                </button>
+                              </template>
                             </div>
                           </div>
                         </transition>
@@ -563,6 +601,7 @@ const isRefreshing = ref(false);
 let refreshSafetyTimer: ReturnType<typeof setTimeout> | null = null;
 
 const showRefreshBusy = computed(() => isRefreshing.value || props.backgroundRefreshing);
+const refreshDisabled = computed(() => props.initialLoading || showRefreshBusy.value);
 
 const clearRefreshBusy = () => {
   isRefreshing.value = false;
@@ -573,17 +612,19 @@ const clearRefreshBusy = () => {
 };
 const expandedGroups = ref<Record<string, boolean>>({});
 const refreshingGroupIds = ref<Record<string, boolean>>({});
-const activeTableDictionary = ref<string | null>(null);
 const pinnedTableDictionary = ref<string | null>(null);
 const popoverStyles = ref<Record<string, Record<string, string>>>({});
+const tableRecommendState = ref<Record<string, {
+  loading: boolean;
+  questions: Array<{ label: string; query: string }>;
+  error?: string;
+}>>({});
 
-const toggleTablePin = (uniqueId: string) => {
-  if (pinnedTableDictionary.value === uniqueId) {
-    pinnedTableDictionary.value = null;
-  } else {
-    pinnedTableDictionary.value = uniqueId;
-  }
-};
+const buildTableDictionaryKey = (
+  group: DatasetCapabilityGroup,
+  related: DatasetCapabilityRelatedData,
+  table: string,
+) => `${group.id || group.title}_${related.dataset || related.display_name || ""}_${table}`;
 
 const handleGlobalClick = () => {
   pinnedTableDictionary.value = null;
@@ -637,20 +678,18 @@ const updatePopoverStyle = (badgeEl: HTMLElement, uniqueId: string) => {
   };
 };
 
-const handleMouseEnter = (event: MouseEvent, uniqueId: string) => {
-  activeTableDictionary.value = uniqueId;
-  const target = event.currentTarget as HTMLElement;
-  if (target) {
-    updatePopoverStyle(target, uniqueId);
+const handleTableDictionaryClick = (
+  event: MouseEvent,
+  group: DatasetCapabilityGroup,
+  related: DatasetCapabilityRelatedData,
+  table: string,
+) => {
+  const uniqueId = buildTableDictionaryKey(group, related, table);
+  if (pinnedTableDictionary.value === uniqueId) {
+    pinnedTableDictionary.value = null;
+    return;
   }
-};
-
-const handleMouseLeave = () => {
-  activeTableDictionary.value = null;
-};
-
-const handleClick = (event: MouseEvent, uniqueId: string) => {
-  toggleTablePin(uniqueId);
+  pinnedTableDictionary.value = uniqueId;
   const target = event.currentTarget as HTMLElement;
   if (target) {
     updatePopoverStyle(target, uniqueId);
@@ -1005,6 +1044,7 @@ const displayGroups = computed(() => {
 });
 
 const handleRefreshClick = () => {
+  if (refreshDisabled.value) return;
   isRefreshing.value = true;
   emit("refresh");
   if (refreshSafetyTimer) clearTimeout(refreshSafetyTimer);
@@ -1071,9 +1111,9 @@ watch(
       searchQuery.value = "";
       selectedTag.value = "All";
     }
-    activeTableDictionary.value = null;
     pinnedTableDictionary.value = null;
     refreshingGroupIds.value = {};
+    tableRecommendState.value = {};
   },
 );
 
@@ -1100,7 +1140,7 @@ const handleQuestionClick = (question: DatasetCapabilityQuestion, group: Dataset
 };
 
 // 数据表数据字典快捷提问处理器
-const handleQuickQuestionClick = (type: 'structure' | 'query' | 'recommend', table: string, related: DatasetCapabilityRelatedData) => {
+const handleQuickQuestionClick = (type: 'structure' | 'query', table: string, related: DatasetCapabilityRelatedData) => {
   const physicalName = related.table_physical_names?.[table] || "";
   const tableWithPhysical = physicalName ? `‘${table}’（物理表名：${physicalName}）` : `‘${table}’`;
 
@@ -1109,8 +1149,6 @@ const handleQuickQuestionClick = (type: 'structure' | 'query' | 'recommend', tab
     queryText = `说明数据表${tableWithPhysical}的字段结构和分析口径`;
   } else if (type === 'query') {
     queryText = `查询数据表${tableWithPhysical}最近10条明细数据`;
-  } else if (type === 'recommend') {
-    queryText = `根据数据表${tableWithPhysical}的字段定义，推荐 3 个最适合的业务分析提问。生成的问题以 \`- [🙋 推荐问题描述](quick:提问具体指令)\` 的格式输出这 3 个问题，以便我一键点击触发提问。`;
   }
   
   if (queryText) {
@@ -1119,7 +1157,55 @@ const handleQuickQuestionClick = (type: 'structure' | 'query' | 'recommend', tab
   
   // 收起浮窗
   pinnedTableDictionary.value = null;
-  activeTableDictionary.value = null;
+};
+
+const handleRecommendQuestions = async (
+  group: DatasetCapabilityGroup,
+  related: DatasetCapabilityRelatedData,
+  table: string,
+) => {
+  const uniqueId = buildTableDictionaryKey(group, related, table);
+  pinnedTableDictionary.value = uniqueId;
+  tableRecommendState.value[uniqueId] = { loading: true, questions: [] };
+
+  try {
+    const columns = related.table_columns?.[table] || [];
+    const res = await axios.post("/api/v1/chat/dataset-menu/recommend-table-questions", {
+      table,
+      physical_table_name: related.table_physical_names?.[table] || "",
+      dataset_name: related.display_name || related.dataset || "",
+      columns: columns.map((col) => ({
+        name: col.name,
+        term: col.term,
+        type: col.type,
+        description: col.description,
+      })),
+    });
+    const questions = res.data?.data?.questions || [];
+    if (!questions.length) {
+      tableRecommendState.value[uniqueId] = {
+        loading: false,
+        questions: [],
+        error: "暂未生成可用推荐提问，请稍后重试",
+      };
+      return;
+    }
+    tableRecommendState.value[uniqueId] = { loading: false, questions };
+  } catch (error) {
+    console.warn("Failed to recommend table questions", error);
+    tableRecommendState.value[uniqueId] = {
+      loading: false,
+      questions: [],
+      error: "生成推荐提问失败，请稍后重试",
+    };
+  }
+};
+
+const handleRecommendedQuestionClick = (question: { label: string; query: string }) => {
+  const query = String(question.query || "").trim();
+  if (!query) return;
+  emitQuickQuestion(query);
+  pinnedTableDictionary.value = null;
 };
 </script>
 

--- a/frontend/src/components/embed/ChatInput.vue
+++ b/frontend/src/components/embed/ChatInput.vue
@@ -246,6 +246,13 @@ const handleShortcutClick = (cmd: any) => {
     }
 };
 
+const openDataPortalFromPlusMenu = () => {
+    if (props.isProcessing) return;
+    showPlusMenu.value = false;
+    const cmd = filteredSystemCommands.value.find((c) => c.id === 'sys_dataset_menu');
+    handleShortcutClick(cmd);
+};
+
 import axios from "@/utils/axios";
 
 // 附件上传状态
@@ -691,6 +698,16 @@ defineExpose({
                       leave-to-class="transform opacity-0 scale-95"
                     >
                         <div v-if="showPlusMenu" class="absolute bottom-full left-0 mb-2 w-52 bg-white/95 dark:bg-gray-800/95 backdrop-blur-md rounded-xl shadow-xl border border-gray-200/50 dark:border-gray-700/50 py-1.5 z-50 animate-fade-in-up">
+                            <!-- Data Portal -->
+                            <button
+                              v-if="filteredSystemCommands.some(c => c.id === 'sys_dataset_menu')"
+                              @click="openDataPortalFromPlusMenu"
+                              class="w-full flex items-center space-x-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-primary/10 dark:hover:bg-primary/20 hover:text-primary transition-all duration-150"
+                            >
+                                <span class="text-lg">📊</span>
+                                <span class="font-medium text-left">打开数据门户</span>
+                            </button>
+
                             <!-- Upload File (Active) -->
                             <button @click="triggerFileInput" class="w-full flex items-center space-x-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-primary/10 dark:hover:bg-primary/20 hover:text-primary transition-all duration-150">
                                 <span class="text-lg">📁</span>

--- a/frontend/src/constants/permissions.ts
+++ b/frontend/src/constants/permissions.ts
@@ -35,7 +35,7 @@ export const MENU_TREE = [
     },
     {
         id: 'menu:agent_management',
-        label: '智能体管理',
+        label: '智能体中心',
         children: [
             { id: 'element:agent:create', label: '创建智能体' },
             { id: 'element:agent:edit', label: '编辑配置' },
@@ -44,12 +44,12 @@ export const MENU_TREE = [
     },
     {
         id: 'menu:skills_management',
-        label: '技能管理',
+        label: '技能工作台',
         children: []
     },
     {
         id: 'menu:memory_management',
-        label: '记忆管理中心',
+        label: '记忆工作台',
         children: [
             { id: 'element:memory:config_save', label: '保存服务配置' },
             { id: 'element:memory:config_index', label: '索引检查与重建' },
@@ -89,12 +89,12 @@ export const MENU_TREE = [
     },
     {
         id: 'menu:agent_debug',
-        label: '智能体调试',
+        label: '智能体测评',
         children: []
     },
     {
         id: 'menu:playground',
-        label: 'API 调试',
+        label: '接口调试台',
         children: []
     },
     {
@@ -123,21 +123,21 @@ export const MENU_TREE = [
     },
     {
         id: 'menu:prompts',
-        label: '提示词工作室',
+        label: '提示词工坊',
         children: [
             { id: 'element:prompts:optimize', label: 'AI 优化建议' }
         ]
     },
     {
         id: 'menu:task_center',
-        label: '任务中心',
+        label: '任务调度台',
         children: [
             { id: 'element:task:manage', label: '任务管理 (增删改执行)' }
         ]
     },
     {
         id: 'menu:widget_debug',
-        label: '组件调试',
+        label: '组件调试台',
         children: []
     }
 ];

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -163,13 +163,13 @@ const router = createRouter({
           path: 'skills',
           name: 'SkillsManagement',
           component: () => import('../views/SkillsManagement.vue'),
-          meta: { perm: 'menu:skills_management', title: '技能管理' }
+          meta: { perm: 'menu:skills_management', title: '技能工作台' }
         },
         {
           path: 'memory',
           name: 'MemoryManagement',
           component: () => import('../views/MemoryManagement.vue'),
-          meta: { perm: 'menu:memory_management', title: '记忆管理中心' }
+          meta: { perm: 'menu:memory_management', title: '记忆工作台' }
         },
 
         {

--- a/frontend/src/utils/chartRenderer.ts
+++ b/frontend/src/utils/chartRenderer.ts
@@ -16,6 +16,53 @@ const colors = [
 
 const cartesianSeriesTypes = new Set(["bar", "line", "scatter"]);
 
+const axisLabelReadableColor = "#6b7280";
+const axisNameReadableColor = "#374151";
+const titleReadableColor = "#111827";
+
+/** 过浅的颜色在白底图表上几乎不可见，强制替换为可读灰 */
+function normalizeReadableTextColor(color: unknown, fallback = axisLabelReadableColor): string {
+  if (typeof color !== "string" || !color.trim()) return fallback;
+  const value = color.trim().toLowerCase();
+  if (value === "transparent" || value === "inherit" || value === "currentcolor") return fallback;
+
+  const hexMatch = value.match(/^#([0-9a-f]{3,8})$/i);
+  if (hexMatch) {
+    let hex = hexMatch[1];
+    if (hex.length === 3) hex = hex.split("").map((c) => c + c).join("");
+    if (hex.length === 8) hex = hex.slice(0, 6);
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    return luminance > 0.72 ? fallback : color;
+  }
+
+  const rgbMatch = value.match(/^rgba?\(([^)]+)\)$/);
+  if (rgbMatch) {
+    const parts = rgbMatch[1].split(",").map((part) => Number(part.trim()));
+    const [r = 0, g = 0, b = 0, a = 1] = parts;
+    if (a <= 0.35) return fallback;
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    return luminance > 0.72 ? fallback : color;
+  }
+
+  return color;
+}
+
+function mergeAxisLabelDefaults(defaultLabel: Record<string, any>, label: any): Record<string, any> {
+  const merged = { ...defaultLabel, ...(label || {}) };
+  const nestedTextStyle = merged.textStyle;
+  if (nestedTextStyle && typeof nestedTextStyle === "object") {
+    merged.textStyle = {
+      ...nestedTextStyle,
+      color: normalizeReadableTextColor(nestedTextStyle.color, axisLabelReadableColor),
+    };
+  }
+  merged.color = normalizeReadableTextColor(merged.color, axisLabelReadableColor);
+  return merged;
+}
+
 export function parseChartOptions(raw: string): ChartParseResult {
   const jsonStr = raw.trim().replace(/^(json|chart)\s+/i, "");
 
@@ -73,15 +120,16 @@ export function mergeChartDefaults(options: Record<string, any>): Record<string,
   if (shouldUseCartesianDefaults) {
     defaults.grid = { left: "3%", right: "4%", bottom: "3%", top: "15%", containLabel: true, show: false };
     defaults.xAxis = {
-      axisLine: { lineStyle: { color: "#e5e7eb" } },
+      axisLine: { lineStyle: { color: "#d1d5db" } },
       axisTick: { show: false },
-      axisLabel: { fontSize: 11 },
+      axisLabel: { fontSize: 11, color: axisLabelReadableColor },
       splitLine: { show: false },
     };
     defaults.yAxis = {
       axisLine: { show: false },
       axisTick: { show: false },
-      axisLabel: { fontSize: 11 },
+      axisLabel: { fontSize: 11, color: axisLabelReadableColor },
+      nameTextStyle: { color: axisNameReadableColor, fontSize: 11 },
       splitLine: { lineStyle: { color: "#f3f4f6", type: "dashed" } },
     };
   }
@@ -90,8 +138,44 @@ export function mergeChartDefaults(options: Record<string, any>): Record<string,
     ...defaults,
     ...options,
     tooltip: { ...defaults.tooltip, ...(options.tooltip || {}) },
-    legend: { ...defaults.legend, ...(options.legend || {}) },
+    legend: {
+      ...defaults.legend,
+      ...(options.legend || {}),
+      textStyle: {
+        color: axisNameReadableColor,
+        fontSize: 11,
+        ...((options.legend || {}).textStyle || {}),
+        color: normalizeReadableTextColor(
+          (options.legend || {}).textStyle?.color,
+          axisNameReadableColor,
+        ),
+      },
+    },
   };
+
+  if (options.title) {
+    merged.title = Array.isArray(options.title)
+      ? options.title.map((item: any) => ({
+          ...item,
+          textStyle: {
+            color: titleReadableColor,
+            fontSize: 13,
+            fontWeight: 600,
+            ...(item?.textStyle || {}),
+            color: normalizeReadableTextColor(item?.textStyle?.color, titleReadableColor),
+          },
+        }))
+      : {
+          ...options.title,
+          textStyle: {
+            color: titleReadableColor,
+            fontSize: 13,
+            fontWeight: 600,
+            ...(options.title?.textStyle || {}),
+            color: normalizeReadableTextColor(options.title?.textStyle?.color, titleReadableColor),
+          },
+        };
+  }
 
   if (shouldUseCartesianDefaults) {
     merged.grid = { ...defaults.grid, ...(options.grid || {}) };
@@ -133,10 +217,26 @@ function isChartOption(value: any): value is Record<string, any> {
 }
 
 function mergeAxisDefaults(defaultAxis: Record<string, any>, axis: any): any {
+  const mergeOne = (item: any) => {
+    const merged = { ...defaultAxis, ...(item || {}) };
+    merged.axisLabel = mergeAxisLabelDefaults(defaultAxis.axisLabel || {}, item?.axisLabel);
+    if (item?.nameTextStyle || defaultAxis.nameTextStyle) {
+      merged.nameTextStyle = {
+        ...(defaultAxis.nameTextStyle || {}),
+        ...(item?.nameTextStyle || {}),
+        color: normalizeReadableTextColor(
+          item?.nameTextStyle?.color ?? defaultAxis.nameTextStyle?.color,
+          axisNameReadableColor,
+        ),
+      };
+    }
+    return merged;
+  };
+
   if (Array.isArray(axis)) {
-    return axis.map((item) => ({ ...defaultAxis, ...item }));
+    return axis.map((item) => mergeOne(item));
   }
-  return { ...defaultAxis, ...(axis || {}) };
+  return mergeOne(axis);
 }
 
 function mergeSeriesDefaults(series: any): any {

--- a/frontend/src/utils/chartRenderer.ts
+++ b/frontend/src/utils/chartRenderer.ts
@@ -142,7 +142,6 @@ export function mergeChartDefaults(options: Record<string, any>): Record<string,
       ...defaults.legend,
       ...(options.legend || {}),
       textStyle: {
-        color: axisNameReadableColor,
         fontSize: 11,
         ...((options.legend || {}).textStyle || {}),
         color: normalizeReadableTextColor(
@@ -158,7 +157,6 @@ export function mergeChartDefaults(options: Record<string, any>): Record<string,
       ? options.title.map((item: any) => ({
           ...item,
           textStyle: {
-            color: titleReadableColor,
             fontSize: 13,
             fontWeight: 600,
             ...(item?.textStyle || {}),
@@ -168,7 +166,6 @@ export function mergeChartDefaults(options: Record<string, any>): Record<string,
       : {
           ...options.title,
           textStyle: {
-            color: titleReadableColor,
             fontSize: 13,
             fontWeight: 600,
             ...(options.title?.textStyle || {}),

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -2793,7 +2793,7 @@ onUnmounted(() => {
             />
           </svg>
           <span class="font-medium text-gray-800"
-            >智能体调试 (Real-Time Agent)</span
+            >智能体测评</span
           >
         </div>
         <div class="flex items-center space-x-4">

--- a/frontend/src/views/AgentManagement.vue
+++ b/frontend/src/views/AgentManagement.vue
@@ -1086,7 +1086,7 @@ const formatDate = (dateStr: string) => {
     <div class="flex justify-between items-center">
       <div>
         <div class="flex items-center space-x-3">
-          <h1 class="text-xl sm:text-2xl font-bold text-gray-900">智能体管理</h1>
+          <h1 class="text-xl sm:text-2xl font-bold text-gray-900">智能体中心</h1>
           <!-- 「？」帮助按钮 -->
           <button 
             @click="showHelp = true"

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -263,15 +263,15 @@ const menuGroups: MenuGroup[] = [
   {
     title: '智能体开发平台',
     items: [
-      { name: '智能体管理', to: '/dashboard/agent-management', icon: 'agent_mgmt', perm: 'menu:agent_management', activeNames: ['AgentManagement'] },
-      { name: '技能管理中心', to: '/dashboard/skills', icon: 'skills', perm: 'menu:skills_management', activeNames: ['SkillsManagement'] },
-      { name: '记忆管理中心', to: '/dashboard/memory', icon: 'memory', perm: 'menu:memory_management', activeNames: ['MemoryManagement'] },
-      { name: '提示词工作室', to: '/dashboard/prompts', icon: 'prompts', perm: 'menu:prompts', desktopOnly: true, activeNames: ['PromptStudio'] },
+      { name: '智能体中心', to: '/dashboard/agent-management', icon: 'agent_mgmt', perm: 'menu:agent_management', activeNames: ['AgentManagement'] },
+      { name: '技能工作台', to: '/dashboard/skills', icon: 'skills', perm: 'menu:skills_management', activeNames: ['SkillsManagement'] },
+      { name: '记忆工作台', to: '/dashboard/memory', icon: 'memory', perm: 'menu:memory_management', activeNames: ['MemoryManagement'] },
+      { name: '提示词工坊', to: '/dashboard/prompts', icon: 'prompts', perm: 'menu:prompts', desktopOnly: true, activeNames: ['PromptStudio'] },
 
-      { name: '任务调度中心', to: '/dashboard/tasks', icon: 'tasks', perm: 'menu:task_center', activeNames: ['TaskCenter'] },
-      { name: '智能体测试', to: '/dashboard/agent-debug', icon: 'agent_debug', perm: 'menu:agent_debug', desktopOnly: true, activeNames: ['AgentDebug'] },
-      { name: 'API调试', to: '/dashboard/playground', icon: 'playground', perm: 'menu:playground', desktopOnly: true, activeNames: ['Playground'] },
-      { name: '组件测试', to: '/dashboard/widget-debug', icon: 'widget', perm: 'menu:widget_debug', desktopOnly: true, activeNames: ['WidgetDebugger'] }
+      { name: '任务调度台', to: '/dashboard/tasks', icon: 'tasks', perm: 'menu:task_center', activeNames: ['TaskCenter'] },
+      { name: '智能体测评', to: '/dashboard/agent-debug', icon: 'agent_debug', perm: 'menu:agent_debug', desktopOnly: true, activeNames: ['AgentDebug'] },
+      { name: '接口调试台', to: '/dashboard/playground', icon: 'playground', perm: 'menu:playground', desktopOnly: true, activeNames: ['Playground'] },
+      { name: '组件调试台', to: '/dashboard/widget-debug', icon: 'widget', perm: 'menu:widget_debug', desktopOnly: true, activeNames: ['WidgetDebugger'] }
     ]
   },
   {

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -978,6 +978,20 @@
                 </svg>
                 <span>导出</span>
               </button>
+              <!-- ChatBI 可视化分析 -->
+              <button
+                v-if="msg.hasDataOutput && checkRole(msg, 'agent') && !msg.isThinking"
+                type="button"
+                @click="handleVisualAnalysis()"
+                class="flex shrink-0 items-center space-x-1 text-[10px] font-medium text-primary border border-primary/25 bg-primary/5 hover:bg-primary/10 transition-colors rounded"
+                :class="windowWidth < 640 ? 'p-2.5' : 'px-1.5 py-0.5'"
+                title="基于本轮查询结果进行可视化深度分析"
+              >
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                </svg>
+                <span class="hidden sm:inline">可视化分析</span>
+              </button>
               <!-- Time -->
               <span v-if="msg.timestamp" class="text-[10px] text-gray-400 dark:text-gray-500 select-none mr-1">{{ formatBubbleTime(msg.timestamp) }}</span>
               <button
@@ -2208,7 +2222,7 @@
       </transition>
 
       <!-- 抽屉面板 (Drawer Panel) -->
-      <div class="absolute inset-y-0 right-0 pl-10 max-w-full flex">
+      <div class="absolute inset-y-0 right-0 pl-0 sm:pl-10 max-w-full flex">
         <transition
           enter-active-class="transform transition ease-in-out duration-300"
           enter-from-class="translate-x-full"
@@ -2219,52 +2233,51 @@
         >
           <div 
             v-show="showPortalDrawer"
-            class="w-screen max-w-md bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-800 shadow-2xl flex flex-col h-full relative z-10"
+            class="w-screen max-w-[min(100vw,28rem)] bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-800 shadow-2xl flex flex-col h-full relative z-10 pb-[env(safe-area-inset-bottom,0px)]"
           >
             <!-- 抽屉头部 -->
-            <div class="px-4 py-4 border-b border-gray-150 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/20 flex items-center justify-between">
-              <span class="text-sm font-bold text-gray-900 dark:text-gray-100 flex items-center gap-1.5 select-none">
-                <svg class="w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div class="px-4 py-3 sm:py-4 border-b border-gray-150 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/20 flex items-center justify-between gap-2 pt-[max(0.75rem,env(safe-area-inset-top,0px))]">
+              <span class="text-sm font-bold text-gray-900 dark:text-gray-100 flex items-center gap-1.5 select-none min-w-0">
+                <svg class="w-4 h-4 text-blue-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2v-4z" />
                 </svg>
-                数据门户导航
+                <span class="truncate">数据门户导航</span>
               </span>
-              <button 
-                type="button" 
-                class="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 p-1 rounded-md hover:bg-gray-150 dark:hover:bg-gray-800 transition-colors"
-                @click="showPortalDrawer = false"
-              >
-                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
+              <div class="flex items-center gap-2 flex-shrink-0">
+                <label
+                  class="hidden sm:flex items-center gap-1.5 text-[10px] text-gray-500 dark:text-gray-400 cursor-pointer select-none whitespace-nowrap"
+                  title="开启后点击问题不会关闭抽屉，可连续提问"
+                >
+                  <input
+                    v-model="portalKeepOpenOnQuestion"
+                    type="checkbox"
+                    class="rounded border-gray-300 text-primary focus:ring-primary/30"
+                  />
+                  提问后保持
+                </label>
+                <button 
+                  type="button" 
+                  class="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 p-1 rounded-md hover:bg-gray-150 dark:hover:bg-gray-800 transition-colors"
+                  title="关闭 (Esc)"
+                  @click="showPortalDrawer = false"
+                >
+                  <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
             </div>
             <!-- 抽屉内容 -->
-            <div class="flex-1 overflow-y-auto p-4 bg-white dark:bg-gray-900/60">
+            <div class="flex-1 overflow-y-auto p-3 sm:p-4 bg-white dark:bg-gray-900/60">
               <DatasetCapabilityMenu
-                v-slot="{ payload: navPayload }"
-                v-if="portalNavigationPayload"
-                :payload="portalNavigationPayload"
+                ref="portalMenuRef"
+                :payload="portalNavigationPayload || { groups: [] }"
+                :initial-loading="portalLoading && !portalNavigationPayload"
+                :background-refreshing="portalBackgroundRefreshing"
                 @quick-question="handlePortalQuickQuestion"
                 @record-question-click="(payload) => recordDatasetMenuQuestionClick(portalNavigationPayload, payload)"
                 @refresh="refreshPortalNavigation"
               />
-              <div v-else class="flex flex-col items-center justify-center h-full text-gray-400 dark:text-gray-500 text-xs p-6 text-center select-none">
-                <!-- 旋转菊花 -->
-                <div class="flex items-center space-x-2 mb-3">
-                  <svg class="w-4 h-4 animate-spin text-primary" fill="none" viewBox="0 0 24 24">
-                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                  </svg>
-                  <span class="font-medium text-gray-600 dark:text-gray-300">正在努力初始化数据门户...</span>
-                </div>
-                <!-- 轮换温馨提示词（带位移淡入淡出动画） -->
-                <transition name="slide-fade" mode="out-in">
-                  <span :key="currentPortalLoadingTip" class="text-[11px] text-gray-400 dark:text-gray-500 max-w-[240px] leading-normal h-8 block">
-                    {{ currentPortalLoadingTip }}
-                  </span>
-                </transition>
-              </div>
             </div>
           </div>
         </transition>
@@ -2388,6 +2401,7 @@ interface Message {
   agentName?: string;
   agentDisplayName?: string;
   turnType?: TurnType | string;
+  hasDataOutput?: boolean;
   prompt_tokens?: number;
   completion_tokens?: number;
   total_tokens?: number;
@@ -2958,6 +2972,7 @@ const fetchAllowedAgents = async (force = false) => {
             allowedAgents.value = res.data; // Already filtered by backend
             hasFetchedAgents.value = true;
             console.log(`[LifeCycle] Successfully fetched ${res.data.length} allowed agents.`);
+            void prefetchPortalNavigationIfEligible();
         }
     } catch (e) {
         console.warn("Mention feature disabled: Cannot fetch allowed agents", e);
@@ -4184,8 +4199,17 @@ const refreshDatasetMenuNavigation = async (msg: Message) => {
 const showPortalDrawer = ref(false);
 const portalNavigationPayload = ref<any>(null);
 const portalLoading = ref(false);
+const portalSilentRefreshing = ref(false);
+const portalPrefetchInFlight = ref(false);
+const portalMenuRef = ref<InstanceType<typeof DatasetCapabilityMenu> | null>(null);
 const hasSilentlyRefreshed = ref(false);
 let silentRefreshTimer: any = null;
+
+const PORTAL_KEEP_OPEN_KEY = "embed_portal_keep_open";
+const portalKeepOpenOnQuestion = ref(localStorage.getItem(PORTAL_KEEP_OPEN_KEY) === "1");
+watch(portalKeepOpenOnQuestion, (val) => {
+  localStorage.setItem(PORTAL_KEEP_OPEN_KEY, val ? "1" : "0");
+});
 
 // 数据门户初始化加载温馨提示词轮播
 const portalLoadingTips = [
@@ -4215,6 +4239,23 @@ const stopPortalLoadingTips = () => {
   }
 };
 
+const prefetchPortalNavigationIfEligible = async () => {
+  if (portalNavigationPayload.value || portalPrefetchInFlight.value || portalLoading.value) return;
+  if (!findDataQueryAgent()) return;
+  portalPrefetchInFlight.value = true;
+  try {
+    await fetchPortalNavigationData(false, true);
+  } catch {
+    // 静默预加载失败不影响主流程
+  } finally {
+    portalPrefetchInFlight.value = false;
+  }
+};
+
+const portalBackgroundRefreshing = computed(
+  () => portalSilentRefreshing.value || (portalLoading.value && !!portalNavigationPayload.value),
+);
+
 const openPortalDrawer = async () => {
   showPortalDrawer.value = true;
   hasSilentlyRefreshed.value = false;
@@ -4226,9 +4267,10 @@ const openPortalDrawer = async () => {
   if (!portalNavigationPayload.value) {
     await fetchPortalNavigationData();
   } else if (portalNavigationPayload.value.is_fallback) {
-    // 如果已有本地缓存但它是 fallback 兜底数据，也可以立即触发一次静默刷新
     await fetchPortalNavigationData(false, false);
   }
+  await nextTick();
+  portalMenuRef.value?.focusSearch();
 };
 
 const fetchPortalNavigationData = async (refresh = false, silent = false) => {
@@ -4236,6 +4278,8 @@ const fetchPortalNavigationData = async (refresh = false, silent = false) => {
     if (portalLoading.value) return;
     portalLoading.value = true;
     startPortalLoadingTips();
+  } else if (refresh) {
+    portalSilentRefreshing.value = true;
   }
   try {
     const payload = await fetchDatasetMenuNavigationPayload(refresh);
@@ -4246,7 +4290,7 @@ const fetchPortalNavigationData = async (refresh = false, silent = false) => {
       hasSilentlyRefreshed.value = true;
       if (silentRefreshTimer) clearTimeout(silentRefreshTimer);
       silentRefreshTimer = setTimeout(async () => {
-        if (showPortalDrawer.value) {
+        if (showPortalDrawer.value || portalNavigationPayload.value) {
           await fetchPortalNavigationData(true, true);
         }
       }, 3000);
@@ -4267,7 +4311,15 @@ const fetchPortalNavigationData = async (refresh = false, silent = false) => {
     if (!silent) {
       portalLoading.value = false;
       stopPortalLoadingTips();
+    } else if (refresh) {
+      portalSilentRefreshing.value = false;
     }
+  }
+};
+
+const handlePortalDrawerKeydown = (event: KeyboardEvent) => {
+  if (event.key === "Escape" && showPortalDrawer.value) {
+    showPortalDrawer.value = false;
   }
 };
 
@@ -4278,6 +4330,8 @@ watch(showPortalDrawer, (val) => {
       silentRefreshTimer = null;
     }
     stopPortalLoadingTips();
+  } else {
+    nextTick(() => portalMenuRef.value?.focusSearch());
   }
 });
 
@@ -4286,7 +4340,9 @@ const refreshPortalNavigation = async () => {
 };
 
 const handlePortalQuickQuestion = (query: string) => {
-  showPortalDrawer.value = false;
+  if (!portalKeepOpenOnQuestion.value) {
+    showPortalDrawer.value = false;
+  }
   handleQuickQuestion(query);
 };
 
@@ -4626,6 +4682,10 @@ const handleQuickQuestion = async (content: string) => {
   sendMessage();
 };
 
+const handleVisualAnalysis = async () => {
+  await handleQuickQuestion("可视化分析一下");
+};
+
 const addEmbedLogFromStream = (msg: Message, data: any) => {
   if (!msg.logs) msg.logs = [];
   const logId = data.id || Date.now() + Math.random();
@@ -4718,6 +4778,7 @@ const applyPermissionStreamEvent = (msg: Message, data: any) => {
     if (data.turn_type) msg.turnType = data.turn_type;
     if (data.prompt_tokens !== undefined) msg.prompt_tokens = data.prompt_tokens;
     if (data.completion_tokens !== undefined) msg.completion_tokens = data.completion_tokens;
+    if (data.has_data_output) msg.hasDataOutput = true;
   } else if (data.type === "error") {
     if (msg.pendingPermission) msg.pendingPermission.status = "error";
     msg.isThinking = false;
@@ -5104,6 +5165,9 @@ const sendMessage = async () => {
             if (data.completion_tokens !== undefined) {
               agentMsg.value.completion_tokens = data.completion_tokens;
             }
+            if (data.has_data_output) {
+              agentMsg.value.hasDataOutput = true;
+            }
           } else if (data.type === "retraction") {
             agentMsg.value.content = data.content;
             if (data.final !== false) {
@@ -5247,6 +5311,7 @@ const onUnmountHandlers = ref<{
   onOnline?: () => void;
   onOffline?: () => void;
   onWindowClick?: () => void;
+  onPortalDrawerKeydown?: (e: KeyboardEvent) => void;
 } | null>(null);
 // Lifecycle
 onMounted(() => {
@@ -5274,6 +5339,7 @@ onMounted(() => {
   window.addEventListener("fullscreenchange", updateFullScreenStatus);
   // Close agent selector on global click
   window.addEventListener("click", onWindowClick);
+  document.addEventListener("keydown", handlePortalDrawerKeydown);
   // Initialize or Retrieve Conversation ID
   const savedId = localStorage.getItem("yovole_embed_conv_id");
   if (savedId) {
@@ -5320,7 +5386,7 @@ onMounted(() => {
   }
 
   // Attach cleanup handlers to component instance scope
-  (onUnmountHandlers as any).value = { onMessage, onOnline, onOffline, onWindowClick };
+  (onUnmountHandlers as any).value = { onMessage, onOnline, onOffline, onWindowClick, onPortalDrawerKeydown: handlePortalDrawerKeydown };
 });
 onUnmounted(() => {
   window.removeEventListener("resize", updateWidth);
@@ -5330,6 +5396,7 @@ onUnmounted(() => {
   if (handlers?.onOnline) window.removeEventListener("online", handlers.onOnline);
   if (handlers?.onOffline) window.removeEventListener("offline", handlers.onOffline);
   if (handlers?.onWindowClick) window.removeEventListener("click", handlers.onWindowClick);
+  if (handlers?.onPortalDrawerKeydown) document.removeEventListener("keydown", handlers.onPortalDrawerKeydown);
   if (thoughtTimer) clearInterval(thoughtTimer);
 });
 // --- Typewriter Effect ---

--- a/frontend/src/views/MemoryManagement.vue
+++ b/frontend/src/views/MemoryManagement.vue
@@ -657,7 +657,7 @@ onMounted(async () => {
     <!-- Header（与技能管理顶格一致，由 Dashboard main 统一留白） -->
     <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
       <div class="min-w-0">
-        <h1 class="text-2xl font-bold tracking-normal text-gray-900 dark:text-white">记忆管理中心</h1>
+        <h1 class="text-2xl font-bold tracking-normal text-gray-900 dark:text-white">记忆工作台</h1>
         <p class="text-sm text-gray-500 mt-1">跨会话摘要、向量检索与 Redis 会话明细管理（配置独立于系统设置）</p>
       </div>
       <div class="flex gap-1 border-b border-gray-200 dark:border-gray-700 shrink-0">

--- a/frontend/src/views/Overview.vue
+++ b/frontend/src/views/Overview.vue
@@ -345,7 +345,7 @@
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
               </div>
-              <h3 class="font-bold text-gray-900 text-sm sm:text-base">API 调试</h3>
+              <h3 class="font-bold text-gray-900 text-sm sm:text-base">接口调试台</h3>
             </div>
             <p class="text-xs sm:text-sm text-gray-500 mb-3">
               在线测试 API 接口，快速验证功能

--- a/frontend/src/views/PromptStudio.vue
+++ b/frontend/src/views/PromptStudio.vue
@@ -702,7 +702,7 @@ watch(
     <div class="mb-6 flex justify-between items-center">
       <div>
         <h1 class="text-2xl font-bold text-gray-900">
-          提示词工作室 (Prompt Studio)
+          提示词工坊 (Prompt Studio)
         </h1>
         <p class="text-gray-500 text-sm mt-1">
           统一管理、编辑和测试系统及智能体的提示词。
@@ -723,7 +723,7 @@ watch(
     >
       <ArrowPathIcon class="w-12 h-12 text-primary animate-spin mb-4" />
       <h2 class="text-xl font-medium text-gray-700">加载中...</h2>
-      <p class="mt-2 text-sm text-gray-500">正在初始化提示词工作室</p>
+      <p class="mt-2 text-sm text-gray-500">正在初始化提示词工坊</p>
     </div>
 
     <!-- Initial Error State -->

--- a/frontend/src/views/SkillsManagement.vue
+++ b/frontend/src/views/SkillsManagement.vue
@@ -353,7 +353,7 @@ onMounted(() => {
     <!-- Header 头部栏 -->
     <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
       <div class="flex items-center space-x-3">
-        <h1 class="text-2xl font-bold tracking-normal text-gray-900">智能体技能管理中心</h1>
+        <h1 class="text-2xl font-bold tracking-normal text-gray-900">技能工作台</h1>
 
         <!-- 「？」呼吸帮助按钮 -->
         <button 

--- a/frontend/src/views/TaskCenter.vue
+++ b/frontend/src/views/TaskCenter.vue
@@ -388,7 +388,7 @@ onMounted(() => { fetchTasks(true); fetchAgents() })
     <!-- Header Section -->
     <div class="flex flex-col md:flex-row md:items-center justify-between gap-4">
       <div>
-        <h1 class="text-2xl font-bold text-gray-900">任务中心</h1>
+        <h1 class="text-2xl font-bold text-gray-900">任务调度台</h1>
         <p class="text-gray-500 mt-1 text-sm hidden sm:block">管理并监控智能体的定时自动化巡检与报表任务</p>
         <p class="text-gray-500 mt-1 text-xs sm:hidden">智能体定时任务与巡检管理</p>
       </div>

--- a/frontend/src/views/WidgetDebugger.vue
+++ b/frontend/src/views/WidgetDebugger.vue
@@ -2,7 +2,7 @@
   <div class="h-full flex flex-col space-y-4">
     <div class="flex justify-between items-center gap-4">
       <div class="flex items-center gap-3 min-w-0">
-        <h1 class="text-2xl font-bold text-gray-800 truncate">组件调试 (Widget Debugger)</h1>
+        <h1 class="text-2xl font-bold text-gray-800 truncate">组件调试台</h1>
         <button
           @click="showIntegrationGuide = true"
           class="h-8 w-8 inline-flex items-center justify-center rounded-full border border-blue-200 bg-blue-50 text-blue-600 hover:bg-blue-100 hover:border-blue-300 transition-colors flex-shrink-0"

--- a/tests/ai/runners/test_data_agent_runner.py
+++ b/tests/ai/runners/test_data_agent_runner.py
@@ -1783,6 +1783,21 @@ def test_resolve_initial_tool_choice_skips_without_fresh_data_or_schema(data_con
     ) is None
 
 
+def test_resolve_has_data_output_requires_saved_followup_and_visible_content(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-has-data-output", trace_buffer=[])
+
+    runner._last_run_state = _DataRunState(requires_fresh_data=True, followup_data_saved=True, full_content="| a | b |")
+    assert runner.resolve_has_data_output() is True
+
+    runner._last_run_state = _DataRunState(requires_fresh_data=True, followup_data_saved=False)
+    assert runner.resolve_has_data_output() is False
+
+    runner._last_run_state = _DataRunState(requires_fresh_data=False, followup_data_saved=True, full_content="chart")
+    assert runner.resolve_has_data_output() is False
+
+
 def test_resolve_repair_tool_choice_forces_schema_when_missing(data_config):
     from agentscope.tool import ToolChoice
 

--- a/tests/ai/test_data_query_prompts.py
+++ b/tests/ai/test_data_query_prompts.py
@@ -7,10 +7,14 @@ def test_build_clarification_fallback_for_followup_missing_context():
         "请求类别 LLM 未返回有效结果；检测到结果追问但没有可信的近期可复用结构化查询结果",
         "用户: 查询算力SU 1-6月回款率\n助手: | 月份 | 回款率 |",
     )
-    assert "继续分析或可视化" in content
+    assert "### ℹ️ 为什么需要补充信息" in content
+    assert "**触发原因：**" in content
+    assert "**您可以这样改：**" in content
+    assert "可复用的查询结果" in content
     assert "### 💬 您可以这样继续" in content
     assert "(quick:" in content
     assert "算力SU" in content
+    assert "PUE" not in content
 
 
 def test_build_clarification_fallback_for_general_chat():
@@ -19,14 +23,50 @@ def test_build_clarification_fallback_for_general_chat():
         "当前请求不是明确的 ChatBI 查数请求，需要用户补充想查询的业务数据、指标、维度或时间范围",
         "",
     )
-    assert "PUE" in content
+    assert "### ℹ️ 为什么需要补充信息" in content
+    assert "尚未识别为明确的数据查询" in content
+    assert "数据对象、指标和时间范围" in content
     assert DataQueryPrompts.has_quick_suggestions(content)
+    assert "PUE" not in content
+
+
+def test_build_clarification_fallback_anchors_to_user_question():
+    question = "最近一次对话中用户提问和 AI 响应的 Token 消耗是多少？"
+    content = DataQueryPrompts.build_clarification_fallback(
+        question,
+        "需要用户补充查数信息",
+        "",
+    )
+    assert "### ℹ️ 为什么需要补充信息" in content
+    assert "**触发原因：**" in content
+    assert "Token" in content
+    assert question in content
+    assert "PUE" not in content
+    assert "告警" not in content
+    assert "(quick:" in content
+
+
+def test_append_contextual_quick_suggestions_when_llm_body_only():
+    question = "统计各机房上周 PUE 排名"
+    body = "还需要您补充具体统计口径后才能继续。"
+    merged = DataQueryPrompts.append_contextual_quick_suggestions(
+        body,
+        question,
+        "需要用户补充查数信息",
+        "",
+    )
+    assert merged.startswith(body)
+    assert "### 💬 您可以这样继续" in merged
+    assert "PUE" in merged
+    assert "(quick:" in merged
 
 
 def test_build_missing_reusable_result_fallback_includes_quick_buttons():
     content = DataQueryPrompts.build_missing_reusable_result_fallback(
         "用户: 查询算力SU回款趋势",
+        user_question="可视化分析一下",
     )
+    assert "### ℹ️ 为什么需要补充信息" in content
     assert "结构化查询结果" in content
     assert "(quick:对刚刚的查询结果做可视化分析)" in content
     assert "(quick:查询算力SU回款趋势)" in content

--- a/tests/api/v1/test_chat_recommend_table_questions.py
+++ b/tests/api/v1/test_chat_recommend_table_questions.py
@@ -1,0 +1,49 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from app.main import app
+from unittest.mock import AsyncMock, patch
+from app.services.auth_service import AuthService
+
+
+@pytest.mark.asyncio
+async def test_recommend_table_questions_api_success(db_session):
+    user_key = await AuthService.generate_api_key("test_recommend_table_user_api", role="user", db=db_session)
+
+    mock_questions = [
+        {"label": "用户增长趋势", "query": "统计最近30天每日新增用户数", "type": "dynamic"},
+        {"label": "角色分布", "query": "按角色统计当前用户数量分布", "type": "dynamic"},
+    ]
+
+    with patch(
+        "app.services.dataset_navigation_service.DatasetNavigationService.recommend_table_questions",
+        AsyncMock(return_value=mock_questions),
+    ) as mock_recommend:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            payload = {
+                "table": "智能体用户表",
+                "physical_table_name": "ai_agent_users",
+                "dataset_name": "智能体数据集",
+                "columns": [
+                    {
+                        "name": "id",
+                        "term": "用户ID",
+                        "type": "bigint",
+                        "description": "主键",
+                    }
+                ],
+            }
+            resp = await client.post(
+                "/api/v1/chat/dataset-menu/recommend-table-questions",
+                json=payload,
+                headers={"X-API-Key": user_key},
+            )
+
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["code"] == 200
+            assert data["message"] == "success"
+            assert len(data["data"]["questions"]) == 2
+            assert data["data"]["questions"][0]["label"] == "用户增长趋势"
+            assert data["data"]["questions"][0]["query"] == "统计最近30天每日新增用户数"
+
+            mock_recommend.assert_awaited_once()

--- a/tests/services/test_dataset_navigation_service.py
+++ b/tests/services/test_dataset_navigation_service.py
@@ -66,6 +66,48 @@ def test_parse_dataset_blocks_captures_table_descriptions():
 
 
 @pytest.mark.no_infrastructure
+def test_build_dataset_navigation_groups_merges_same_scene_title():
+    menu = """Available Datasets:
+- Dataset: ops_alerts
+  Display Name: 机房告警
+  Includes Tables: 机房告警表
+  Table Details:
+    - 机房告警表: 告警记录
+
+- Dataset: ops_devices
+  Display Name: 设备监控
+  Includes Tables: 设备状态表
+  Table Details:
+    - 设备状态表: 设备运行状态
+"""
+    groups = DataQueryPrompts.build_dataset_navigation_groups(menu)
+    assert len(groups) == 1
+    assert groups[0]["title"] == "运维监控分析"
+    assert len(groups[0]["related_data"]) == 2
+    assert groups[0]["related_data"][0]["dataset"] == "ops_alerts"
+    assert groups[0]["related_data"][1]["dataset"] == "ops_devices"
+    assert "机房告警表" in groups[0]["related_data"][0]["tables"]
+    assert "设备状态表" in groups[0]["related_data"][1]["tables"]
+
+
+@pytest.mark.no_infrastructure
+def test_build_dataset_navigation_fallback_deduplicates_scene_cards():
+    menu = """Available Datasets:
+- Dataset: ops_alerts
+  Display Name: 机房告警
+  Includes Tables: 机房告警表
+
+- Dataset: ops_devices
+  Display Name: 设备监控
+  Includes Tables: 设备状态表
+"""
+    markdown = DataQueryPrompts.build_dataset_navigation_fallback(menu)
+    assert markdown.count("#### 运维监控分析") == 1
+    assert "机房告警 (ops_alerts)" in markdown
+    assert "设备监控 (ops_devices)" in markdown
+
+
+@pytest.mark.no_infrastructure
 def test_build_dataset_navigation_groups_from_dataset_menu():
     groups = DataQueryPrompts.build_dataset_navigation_groups(SAMPLE_MENU)
     assert len(groups) == 2

--- a/tests/services/test_dataset_navigation_service.py
+++ b/tests/services/test_dataset_navigation_service.py
@@ -472,3 +472,43 @@ async def test_refresh_group_questions_success():
     assert questions[2]["label"] == "失败原因分布"
     assert questions[2]["query"] == "统计最近24小时的失败原因分布"
 
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_recommend_table_questions_uses_frontend_columns_without_db_lookup():
+    llm_output = (
+        "- [🙋 用户增长趋势](quick:统计最近30天每日新增用户数)\n"
+        "- [🙋 角色分布](quick:按角色统计当前用户数量分布)\n"
+        "- [🙋 最近登录](quick:查询最近7天登录过的用户数量)"
+    )
+    mock_client = MagicMock()
+    mock_client.generate_text = AsyncMock(return_value=llm_output)
+    mock_db = AsyncMock()
+
+    with patch(
+        "app.services.dataset_navigation_service.AgentConfigProvider.get_configured_llm",
+        AsyncMock(return_value=object()),
+    ), patch(
+        "app.services.dataset_navigation_service.chat_client_from_handle",
+        return_value=mock_client,
+    ):
+        questions = await DatasetNavigationService.recommend_table_questions(
+            mock_db,
+            table="智能体用户表",
+            physical_table_name="ai_agent_users",
+            dataset_name="智能体数据集",
+            columns=[
+                {
+                    "name": "id",
+                    "term": "用户ID",
+                    "type": "bigint",
+                    "description": "主键",
+                }
+            ],
+        )
+
+    assert len(questions) == 3
+    assert questions[0]["label"] == "用户增长趋势"
+    assert questions[0]["query"] == "统计最近30天每日新增用户数"
+    mock_db.execute.assert_not_called()
+


### PR DESCRIPTION

## 概要 (Overview)

本 PR 在 `528d43c`（数据门户卡片按业务场景合并）之后，集中交付三类能力：

1. **数据门户与嵌入 Chat 体验升级**：加载/刷新状态、预加载、我常问、移动端适配，以及「可视化分析」闭环修复。
2. **表级推荐提问独立 API**：推荐提问不再误走 ChatBI 查数链路，门户交互与开发平台菜单命名同步优化。
3. **ChatBI 澄清回复泛化**：澄清文案锚定用户原问，并说明触发原因、缺失信息与修改指引。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)

- [x] **表级推荐提问 API**：新增 `POST /api/v1/chat/dataset-menu/recommend-table-questions`，由 `DatasetNavigationService.recommend_table_questions()` 独立生成推荐问题，门户浮层内展示 quick 按钮，不再将长 prompt 送入 Chat 查数链路。
- [x] **数据门户「我常问」与个性化排序**：基于本地使用记录对常用问题置顶排序。
- [x] **门户预加载与提问后保持**：`EmbedChat` 抽屉预加载数据集目录；支持「提问后保持」开关（`localStorage: embed_portal_keep_open`）。
- [x] **ChatBI 可视化分析闭环**：`has_data_output` 从 `DataQueryExecutor` → `agent_service` → `memory_service` 全链路透传；`EmbedChat` 在结构化查数结果下展示「可视化分析」入口。
- [x] **ChatBI 澄清回复泛化**：澄清兜底基于用户原问推断缺口（时间/指代/指标等）生成 contextual `quick:` 建议；新增 `### ℹ️ 为什么需要补充信息` 区块（触发原因 / 具体情况 / 您可以这样改）；LLM 半成功时自动补全 quick 与原因说明。

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)

- [x] **数据门户状态条与骨架屏**：加载、刷新、fallback 提示更清晰；首屏加载期间禁用刷新按钮，防止重复点击。
- [x] **字段字典交互**：数据表字段说明由悬停改为**点击**展示，避免误触。
- [x] **门户搜索/筛选/相关数据/抽屉交互**增强（`DatasetCapabilityMenu.vue` 大幅重构）。
- [x] **刷新状态父子同步**：修复刷新成功但遮罩/转圈未释放、toast 不同步问题。
- [x] **ECharts 横轴可读性**：`chartRenderer.ts` 修正横轴标签过浅；修复 legend/title 合并时 `Duplicate key "color"` 问题。
- [x] **开发平台侧栏菜单重命名**：统一为企业级五字命名（智能体中心、技能工作台等），同步 `Dashboard.vue`、`permissions.ts`、`permission_service.py` 及各页面标题。

### 3. 🐞 关键修复 (Bug Fixes)

- [x] **「可视化分析」按钮缺失**：修复结构化结果标记 `has_data_output` 未持久化/未下发导致前端无法展示按钮。
- [x] **表级「推荐提问」误走查数**：改为独立 API 方案，避免推荐 prompt 进入 ChatBI Agent 编排。
- [x] **`sql_error` 修复预算**：`DATA_REPAIR_BUDGETS["sql_error"]` 由 2 调整为 5，提高 SQL 错误自愈成功率。
- [x] **澄清固定模板答非所问**：移除与问题无关的 PUE/告警兜底，改为围绕原问的改写建议。

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `56cf6a0` | feat(chatbi): 数据门户体验升级与可视化分析闭环修复 |
| `4c48297` | feat(portal): 表级推荐提问 API 与门户交互优化，统一开发平台菜单命名 |
| `d848b13` | 优化 ChatBI 澄清回复：围绕用户原问生成建议并说明触发原因 |

**变更规模**：29 files，+1702 / -422 lines（`528d43c..HEAD`）

**主要涉及模块**：

| 区域 | 文件 |
|------|------|
| 推荐提问 API | `app/api/v1/endpoints/chat.py`, `dataset_navigation_service.py` |
| 澄清逻辑 | `executors/prompts.py`, `runners/data_agent_runner.py` |
| 可视化闭环 | `data_executor.py`, `agent_service.py`, `memory_service.py` |
| 数据门户 UI | `DatasetCapabilityMenu.vue`, `EmbedChat.vue`, `ChatInput.vue` |
| 图表渲染 | `chartRenderer.ts`, `chartRenderer.test.ts` |
| 菜单/权限 | `Dashboard.vue`, `permissions.ts`, `permission_service.py` |

---

## 测试覆盖 (Testing)

- [x] **单元测试**：`tests/ai/test_data_query_prompts.py`（澄清 fallback / 原因区块 / contextual quick）
- [x] **单元测试**：`tests/api/v1/test_chat_recommend_table_questions.py`（推荐提问 API）
- [x] **单元测试**：`tests/services/test_dataset_navigation_service.py`
- [x] **单元测试**：`tests/ai/runners/test_data_agent_runner.py`（澄清短路不测 Agent）
- [x] **前端测试**：`frontend/scripts/chartRenderer.test.ts`（图表 color 键与横轴样式）
- [ ] **UI 兼容性**：建议在 Chrome / Safari / 移动端验证门户抽屉与澄清回复展示
- [ ] **核心功能**：建议手动验证——数据门户刷新、表级推荐提问、可视化分析按钮、澄清原因区块
- [ ] **回归测试**：确认普通查数、Schema 歧义澄清、历史消息加载未回归

> [!IMPORTANT]
> 提交前请务必确认已更新 `tests/CHECKLIST.md` 中的自动化测试清单。

