### PR TITLE
Pull Request: ChatBI 数据门户全面升级、澄清体验优化与元数据导入修复

### DIFF
--- a/app/api/v1/endpoints/chat.py
+++ b/app/api/v1/endpoints/chat.py
@@ -203,6 +203,30 @@ async def record_dataset_menu_question_click(
 
 
 @router.post(
+    "/dataset-menu/click/clear",
+    response_model=StandardResponse[Dict[str, bool]],
+    summary="从我的常问中移除问题",
+    description="清除用户在数据门户中对某条 quick 问题的点击记录，用于「我常问」个性化列表的删除清理。",
+)
+async def clear_dataset_menu_question_click(
+    request: DatasetMenuClickRequest,
+    user_info: Dict[str, Any] = Depends(require_api_key),
+):
+    from app.services.dataset_navigation_service import DatasetNavigationService
+
+    raw_user_id = user_info.get("user_id") or user_info.get("id")
+    user_id = int(raw_user_id) if raw_user_id is not None else None
+    is_admin = user_info.get("role") == "admin"
+    cleared = await DatasetNavigationService.clear_question_click(
+        user_id=user_id,
+        is_admin=is_admin,
+        dataset_menu_hash=request.dataset_menu_hash,
+        query=request.query,
+    )
+    return StandardResponse(data={"success": cleared})
+
+
+@router.post(
     "/dataset-menu/refresh-group-questions",
     response_model=StandardResponse[DatasetGroupRefreshResponse],
     summary="局部刷新当前数据门户场景卡片下的推荐问题",

--- a/app/models/changelog.py
+++ b/app/models/changelog.py
@@ -8,7 +8,7 @@ class MetaChangelog(Base):
 
     id = Column(BigInteger, primary_key=True, index=True, autoincrement=True, comment='主键ID')
     resource_type = Column(String(20), nullable=False, index=True, comment='资源类型: dataset/table/column/metric/relationship')
-    resource_id = Column(String(50), nullable=False, index=True, comment='资源ID')
+    resource_id = Column(String(270), nullable=False, index=True, comment='资源ID')
     operation = Column(String(20), nullable=False, index=True, comment='操作类型: create/update/delete')
     old_data = Column(JSON, nullable=True, comment='变更前数据')
     new_data = Column(JSON, nullable=True, comment='变更后数据')

--- a/app/services/ai/executors/prompts.py
+++ b/app/services/ai/executors/prompts.py
@@ -76,10 +76,10 @@ class DataQueryPrompts:
     # 缺少可复用查询结果时的回复
     NO_REUSABLE_RESULT = "当前会话没有可复用的上一轮查询结果，请先完成一次数据查询后再进行可视化或分析。"
 
-    # ChatBI 入口没有足够查数意图时的回复（仅作 LLM/规则生成失败兜底）
-    CLARIFICATION_OR_NON_DATA = (
-        "请告诉我想查询的业务数据、指标、维度或时间范围。"
-        "例如：查询本月各机房 PUE 趋势、统计最近一周告警记录，或基于刚才的查询结果继续分析。"
+    # 纯寒暄/能力咨询时的兜底引导（仅当用户未提出具体业务问题时使用）
+    CLARIFICATION_CAPABILITY_ONBOARDING = (
+        "我可以帮您查询业务数据、统计分析，或基于查询结果做可视化。"
+        "请告诉我您想看的数据对象、指标和时间范围："
     )
 
     @staticmethod
@@ -125,15 +125,20 @@ class DataQueryPrompts:
         return f"""你是 ChatBI 数据查询助手的澄清引导模块。
 
 用户当前问题还不足以直接查数，或无法安全复用上一轮结果。请结合最近对话和系统判断原因：
-1. 用 1-2 句话说明**具体还缺什么信息**或**为什么需要用户补充**（不要泛泛而谈）。
-2. 给出 2-3 个结合上下文的追问建议，供用户一键点击发送。
+1. **必须先输出** `### ℹ️ 为什么需要补充信息` 区块，用 3 条列表说明：
+   - **触发原因：** 一句话说明系统为何没有直接查数（例如：非明确查数、缺少可复用结果、时间/指代模糊等）。
+   - **具体情况：** 结合【当前用户问题】和【系统判断原因】解释还缺什么。
+   - **您可以这样改：** 告诉用户应在原问题中补充哪些信息。
+2. 再用 1 句话引导用户选择下方建议或补充说明。
+3. 给出 2-3 个**围绕当前用户问题**的追问建议，供用户一键点击发送。
 
 输出要求：
 - 只输出 Markdown，不要 JSON，不要代码块包裹全文。
-- 正文后必须包含标题 `### 💬 您可以这样继续`。
+- 必须以 `### ℹ️ 为什么需要补充信息` 开头，然后再写引导语与 `### 💬 您可以这样继续`。
 - 每个建议必须是列表项，格式严格为：`- [🙋 简短标签](quick:完整可发送问题)`。
-- `quick:` 括号内必须是完整、可直接发送的中文问题，可包含具体业务对象/指标/时间范围。
-- 优先结合最近对话中的业务对象、指标、时间范围定制建议；没有上下文时再给通用查数示例。
+- `quick:` 括号内必须是完整、可直接发送的中文问题，应是对【当前用户问题】的改写、补全或口径澄清。
+- **禁止**输出与用户当前问题无关的其他业务域示例（例如用户问 Token 时不得推荐 PUE/告警等无关问题）。
+- 优先结合最近对话中的业务对象、指标、时间范围定制建议；仅当用户只是寒暄且未提出具体问题时，才可给通用查数能力示例。
 - 不要编造对话中未出现的具体数值。
 - quick 追问按钮区块必须放在整段回答最末尾，位于所有图表之后。
 
@@ -590,6 +595,315 @@ class DataQueryPrompts:
             f"{cls.quick_button('重新查看数据门户', '/dataset_menu')}\n"
         )
 
+    @staticmethod
+    def _sanitize_reasoning_for_user(reasoning: str) -> str:
+        text = re.sub(r"\s+", " ", str(reasoning or "")).strip()
+        for prefix in (
+            "请求类别 LLM 未返回有效结果；",
+            "ChatBI 请求类别由大模型兜底识别",
+        ):
+            if text.startswith(prefix):
+                text = text[len(prefix):].strip()
+        return text
+
+    @classmethod
+    def _explain_clarification_trigger(cls, user_question: str, reasoning: str) -> dict[str, str]:
+        q = str(user_question or "").strip()
+        reasoning_text = cls._sanitize_reasoning_for_user(reasoning)
+        gaps = cls._infer_clarification_gaps(q, reasoning_text)
+        gap_text = "、".join(gaps)
+        topic = cls._truncate_for_display(q, 40)
+
+        trigger_rules: list[tuple[tuple[str, ...], dict[str, str]]] = [
+            (
+                ("不是明确", "查数请求", "打招呼"),
+                {
+                    "title": "尚未识别为明确的数据查询",
+                    "detail": (
+                        "您的问题更接近闲聊或能力咨询，尚未包含可直接查数的"
+                        "业务对象、指标和时间范围。"
+                    ),
+                    "fix": "请在问题中写明要查什么数据、看什么指标、覆盖哪段时间。",
+                },
+            ),
+            (
+                ("可复用", "结构化查询结果", "结果追问"),
+                {
+                    "title": "想基于上一轮结果继续，但会话中没有可复用的查询结果",
+                    "detail": (
+                        "您像是在对上一轮数据做可视化、分析或总结，"
+                        "但当前会话尚未保存或展示可供复用的结构化查数结果。"
+                    ),
+                    "fix": "先完成一次数据查询，或明确说明要基于哪一次查询的结果继续。",
+                },
+            ),
+            (
+                ("最近对话", "上下文"),
+                {
+                    "title": "对话上下文不足以安全复用上一轮结果",
+                    "detail": (
+                        "最近几轮对话里没有足够清晰的数据查询结果，"
+                        "系统无法判断应基于哪份数据继续。"
+                    ),
+                    "fix": "请重新说明要分析的对象和时间范围，或先发一次完整的数据查询。",
+                },
+            ),
+        ]
+
+        for keywords, payload in trigger_rules:
+            if any(keyword in reasoning_text for keyword in keywords):
+                result = dict(payload)
+                if gap_text and gap_text not in result["detail"]:
+                    result["detail"] = f"{result['detail']}此外，当前表述还缺少：{gap_text}。"
+                return result
+
+        if cls._looks_like_greeting_or_capability_question(q, reasoning_text):
+            return {
+                "title": "尚未识别为明确的数据查询",
+                "detail": "您还没有说明要查询的业务数据、指标或时间范围。",
+                "fix": "请直接描述想查的对象、指标和时间段，例如「查询本月某指标趋势」。",
+            }
+
+        if reasoning_text and reasoning_text not in {"需要用户补充查数信息"}:
+            return {
+                "title": "系统判断当前问题尚不足以直接执行查数",
+                "detail": (
+                    f"{reasoning_text}"
+                    + (f" 当前还缺少：{gap_text}。" if gap_text else "")
+                ),
+                "fix": (
+                    f"请在原问题「{topic}」中补充上述缺失信息，"
+                    "或点选下方已根据您的问题生成的改写建议。"
+                    if topic
+                    else "请补充统计对象、指标口径和时间范围，或点选下方建议。"
+                ),
+            }
+
+        return {
+            "title": "问题信息尚不完整，无法安全执行查数",
+            "detail": f"当前表述还缺少：{gap_text}。" if gap_text else "当前问题缺少执行查数所需的关键信息。",
+            "fix": (
+                f"请在原问题「{topic}」中补充上述信息；下方按钮已根据您的问题生成可一键发送的改写版本。"
+                if topic
+                else "请补充统计对象、指标口径和时间范围，或点选下方建议。"
+            ),
+        }
+
+    @classmethod
+    def _format_clarification_reason_block(cls, user_question: str, reasoning: str) -> str:
+        expl = cls._explain_clarification_trigger(user_question, reasoning)
+        return (
+            "### ℹ️ 为什么需要补充信息\n"
+            f"- **触发原因：** {expl['title']}\n"
+            f"- **具体情况：** {expl['detail']}\n"
+            f"- **您可以这样改：** {expl['fix']}\n"
+        )
+
+    @classmethod
+    def ensure_clarification_reason_block(
+        cls,
+        content: str,
+        user_question: str,
+        reasoning: str,
+    ) -> str:
+        body = str(content or "").strip()
+        if "### ℹ️ 为什么需要补充信息" in body:
+            return body
+        reason_block = cls._format_clarification_reason_block(user_question, reasoning)
+        if not body:
+            return reason_block.strip()
+        return f"{reason_block}\n{body}"
+
+    @staticmethod
+    def _truncate_for_display(text: str, max_len: int = 48) -> str:
+        cleaned = re.sub(r"\s+", " ", str(text or "")).strip()
+        if not cleaned:
+            return ""
+        if len(cleaned) <= max_len:
+            return cleaned
+        return cleaned[: max_len - 1] + "…"
+
+    @classmethod
+    def _looks_like_greeting_or_capability_question(cls, user_question: str, reasoning: str) -> bool:
+        q = str(user_question or "").strip()
+        q_lower = q.lower()
+        if not q_lower:
+            return True
+        greeting_signals = ["你好", "您好", "你是谁", "你能做什么", "谢谢", "感谢", "辛苦了"]
+        if any(signal in q_lower for signal in greeting_signals) and len(q_lower) <= 16:
+            return True
+        reasoning_text = str(reasoning or "")
+        if any(keyword in reasoning_text for keyword in ("打招呼", "不是明确", "查数请求")):
+            return len(q_lower) <= 12
+        return False
+
+    @classmethod
+    def _infer_clarification_gaps(cls, user_question: str, reasoning: str) -> list[str]:
+        q = str(user_question or "").strip().lower()
+        reasoning_text = str(reasoning or "")
+        gaps: list[str] = []
+
+        if any(keyword in reasoning_text for keyword in ("结果追问", "可复用", "结构化查询结果")):
+            gaps.append("要基于哪一份查询结果继续分析")
+        if any(keyword in reasoning_text for keyword in ("最近对话", "上下文")):
+            gaps.append("要继续分析的业务对象")
+
+        vague_time_signals = ("最近", "上次", "上一次", "近期", "这段时间", "刚才", "刚刚")
+        concrete_time_signals = (
+            "今天", "昨天", "本周", "上周", "本月", "上月", "今年", "去年",
+            "天内", "月内", "季度", "年度", "20", "19",
+        )
+        if any(signal in q for signal in vague_time_signals) and not any(
+            signal in q for signal in concrete_time_signals
+        ):
+            gaps.append("时间范围")
+
+        vague_ref_signals = ("这个", "那个", "这些", "那些", "上面", "前述", "最近一次")
+        if any(signal in q for signal in vague_ref_signals):
+            gaps.append("具体对象或指代范围")
+
+        metric_signals = ("多少", "趋势", "占比", "排名", "对比", "统计", "汇总", "消耗", "用量")
+        object_signals = ("各", "每", "所有", "全部", "部门", "机房", "用户", "智能体", "对话")
+        if any(signal in q for signal in metric_signals) and not any(
+            signal in q for signal in object_signals
+        ):
+            gaps.append("统计对象或指标口径")
+
+        if not gaps:
+            gaps = ["统计对象", "指标口径", "时间范围"]
+        deduped: list[str] = []
+        for gap in gaps:
+            if gap not in deduped:
+                deduped.append(gap)
+        return deduped[:3]
+
+    @classmethod
+    def _build_contextual_clarification_lead(cls, user_question: str, reasoning: str) -> str:
+        q = str(user_question or "").strip()
+        topic = cls._truncate_for_display(q, 56)
+        reasoning_text = str(reasoning or "")
+
+        if any(keyword in reasoning_text for keyword in ("结果追问", "可复用", "结构化查询结果")):
+            if topic:
+                return (
+                    f"您提到「{topic}」，但当前会话里还没有可复用的查询结果。"
+                    "请说明要基于哪份数据继续，或先完成一次查询："
+                )
+            return "当前还不确定要基于哪一份查询结果继续分析，请补充说明或先完成一次数据查询："
+
+        if any(keyword in reasoning_text for keyword in ("最近对话", "上下文")):
+            if topic:
+                return (
+                    f"关于「{topic}」，最近对话里暂时没有足够明确的数据上下文。"
+                    "请补充要分析的对象或时间范围："
+                )
+            return "最近对话里暂时没有足够明确的数据上下文，请补充您想分析的对象或时间范围："
+
+        if cls._looks_like_greeting_or_capability_question(q, reasoning_text):
+            return cls.CLARIFICATION_CAPABILITY_ONBOARDING
+
+        gap_text = "、".join(cls._infer_clarification_gaps(q, reasoning_text))
+        if topic:
+            return (
+                f"关于「{topic}」，还需要确认{gap_text}后才能继续。"
+                "您可以补充说明，或直接点选下面的建议："
+            )
+        return f"还需要确认{gap_text}后才能继续。您可以补充说明，或直接点选下面的建议："
+
+    @classmethod
+    def _build_contextual_clarification_quick_variants(
+        cls,
+        user_question: str,
+        reasoning: str,
+        history_excerpt: str,
+    ) -> list[tuple[str, str]]:
+        q = str(user_question or "").strip()
+        reasoning_text = str(reasoning or "")
+        last_topic = cls._extract_last_user_topic(history_excerpt, q)
+        topic_label = cls._truncate_for_display(q, 24) or "当前问题"
+        variants: list[tuple[str, str]] = []
+
+        def add(label: str, target: str) -> None:
+            target = str(target or "").strip()
+            if not target:
+                return
+            label = cls._truncate_for_display(label, 32)
+            if any(existing == target for _, existing in variants):
+                return
+            variants.append((label, target))
+
+        if any(keyword in reasoning_text for keyword in ("结果追问", "可复用", "结构化查询结果")):
+            if last_topic:
+                add(
+                    f"基于「{cls._truncate_for_display(last_topic, 16)}」继续",
+                    f"基于刚才关于{last_topic}的查询结果，{q or '继续分析'}",
+                )
+            add("基于上一轮查询结果", f"基于刚才的查询结果，{q or '继续分析'}")
+            if q:
+                add(f"先查数再分析：{topic_label}", f"请先完成一次数据查询，再{q}")
+            return variants[:3]
+
+        if any(keyword in reasoning_text for keyword in ("最近对话", "上下文")):
+            if last_topic:
+                add(
+                    f"重新查询「{cls._truncate_for_display(last_topic, 16)}」",
+                    f"查询{last_topic}",
+                )
+            if q:
+                add(f"明确对象后重问：{topic_label}", f"请明确要分析的对象和时间范围：{q}")
+                add(f"按原问题继续：{topic_label}", q)
+            return variants[:3]
+
+        if cls._looks_like_greeting_or_capability_question(q, reasoning_text):
+            add("查询本月业务指标趋势", "查询本月核心业务指标趋势")
+            add("统计最近一周关键记录", "统计最近一周关键业务记录")
+            add("查看数据门户", "/dataset_menu")
+            return variants[:3]
+
+        if not q:
+            add("打开数据门户选表提问", "/dataset_menu")
+            return variants[:3]
+
+        gaps = cls._infer_clarification_gaps(q, reasoning_text)
+        if "时间范围" in gaps:
+            add(f"补充时间：{topic_label}", f"{q}（时间范围：本月）")
+        if "具体对象或指代范围" in gaps:
+            add(f"补充指代范围：{topic_label}", f"请明确「{q}」中的对象范围和时间范围")
+        if "要基于哪一份查询结果继续分析" in gaps and last_topic:
+            add(
+                f"基于「{cls._truncate_for_display(last_topic, 16)}」",
+                f"基于刚才关于{last_topic}的查询结果，{q}",
+            )
+        if "统计对象或指标口径" in gaps or "指标口径" in gaps:
+            add(f"补充指标口径：{topic_label}", f"请补充具体指标和统计口径后回答：{q}")
+        if "统计对象" in gaps:
+            add(f"补充统计对象：{topic_label}", f"请明确统计对象后回答：{q}")
+        add(f"按原问题重试：{topic_label}", q)
+        return variants[:3]
+
+    @classmethod
+    def append_contextual_quick_suggestions(
+        cls,
+        text: str,
+        user_question: str,
+        reasoning: str,
+        history_excerpt: str = "",
+    ) -> str:
+        body = str(text or "").strip()
+        if cls.has_quick_suggestions(body):
+            return body
+        variants = cls._build_contextual_clarification_quick_variants(
+            user_question,
+            reasoning,
+            history_excerpt,
+        )
+        if not variants:
+            return body
+        buttons = [cls.quick_button(label, target) for label, target in variants]
+        if "### 💬" in body:
+            return f"{body}\n" + "\n".join(buttons)
+        return f"{body}\n\n### 💬 您可以这样继续\n" + "\n".join(buttons)
+
     @classmethod
     def build_clarification_fallback(
         cls,
@@ -597,83 +911,34 @@ class DataQueryPrompts:
         reasoning: str,
         history_excerpt: str = "",
     ) -> str:
-        reasoning_text = str(reasoning or "")
-        history_text = str(history_excerpt or "")
-        last_user_topic = cls._extract_last_user_topic(history_text, user_question)
-        buttons: list[str] = []
+        lead = cls._build_contextual_clarification_lead(user_question, reasoning)
+        variants = cls._build_contextual_clarification_quick_variants(
+            user_question,
+            reasoning,
+            history_excerpt,
+        )
+        buttons = [cls.quick_button(label, target) for label, target in variants]
+        suggestions = "\n".join(buttons[:3])
+        reason_block = cls._format_clarification_reason_block(user_question, reasoning)
+        return f"{reason_block}\n{lead}\n\n### 💬 您可以这样继续\n{suggestions}"
 
-        if any(keyword in reasoning_text for keyword in ("结果追问", "可复用", "结构化查询结果")):
-            lead = (
-                "我还不太确定您想基于哪份数据继续分析或可视化。"
-                "您可以补充具体指标/图表类型，或直接选择下面的建议："
-            )
-            if last_user_topic:
-                buttons.append(
-                    cls.quick_button(
-                        f"基于刚才关于「{last_user_topic}」的结果可视化",
-                        f"对刚才关于{last_user_topic}的查询结果做可视化分析",
-                    )
-                )
-            buttons.extend([
-                cls.quick_button("基于刚才的查询结果继续分析", "基于刚才的查询结果继续分析"),
-                cls.quick_button("查询本月业务指标趋势", "查询本月核心业务指标趋势"),
-            ])
-        elif any(keyword in reasoning_text for keyword in ("最近对话", "上下文")):
-            lead = (
-                "最近对话里暂时没有足够明确的数据结果上下文，"
-                "请告诉我您想继续分析的对象，或重新发起一次查询："
-            )
-            if last_user_topic:
-                buttons.append(
-                    cls.quick_button(
-                        f"重新查询「{last_user_topic}」",
-                        f"查询{last_user_topic}",
-                    )
-                )
-            buttons.extend([
-                cls.quick_button("查询本月各机房 PUE 趋势", "查询本月各机房 PUE 趋势"),
-                cls.quick_button("统计最近一周告警记录", "统计最近一周告警记录"),
-            ])
-        elif any(keyword in reasoning_text for keyword in ("不是明确", "打招呼", "查数请求")):
-            lead = (
-                "我可以帮您查询业务数据、统计分析或基于结果做可视化。"
-                "请告诉我您想看的数据对象、指标和时间范围："
-            )
-            buttons.extend([
-                cls.quick_button("查询本月各机房 PUE 趋势", "查询本月各机房 PUE 趋势"),
-                cls.quick_button("统计最近一周告警记录", "统计最近一周告警记录"),
-                cls.quick_button("查看部门收入与回款对比", "查询各部门本季度收入与回款对比"),
-            ])
-        else:
-            lead = cls.CLARIFICATION_OR_NON_DATA
-            buttons.extend([
-                cls.quick_button("查询本月各机房 PUE 趋势", "查询本月各机房 PUE 趋势"),
-                cls.quick_button("统计最近一周告警记录", "统计最近一周告警记录"),
-                cls.quick_button("基于刚才的查询结果继续分析", "基于刚才的查询结果继续分析"),
-            ])
-
-        unique_buttons: list[str] = []
-        seen_targets: set[str] = set()
-        for button in buttons:
-            match = re.search(r"\(quick:([^)]+)\)", button)
-            target = match.group(1).strip() if match else button
-            if target in seen_targets:
-                continue
-            seen_targets.add(target)
-            unique_buttons.append(button)
-
-        suggestions = "\n".join(unique_buttons[:3])
-        return f"{lead}\n\n### 💬 您可以这样继续\n{suggestions}"
-
-    @staticmethod
-    def build_missing_reusable_result_fallback(history_excerpt: str = "") -> str:
-        last_topic = DataQueryPrompts._extract_last_user_topic(history_excerpt, "")
+    @classmethod
+    def build_missing_reusable_result_fallback(
+        cls,
+        history_excerpt: str = "",
+        user_question: str = "",
+    ) -> str:
+        last_topic = cls._extract_last_user_topic(history_excerpt, user_question)
+        reasoning = (
+            "检测到本轮是基于上一轮结果的分析/可视化请求，"
+            "但当前会话没有保存的结构化查询结果。"
+        )
         buttons = [
-            DataQueryPrompts.quick_button(
+            cls.quick_button(
                 "基于刚才的查询结果继续分析",
                 "基于刚才的查询结果继续分析",
             ),
-            DataQueryPrompts.quick_button(
+            cls.quick_button(
                 "对刚才的结果做可视化",
                 "对刚刚的查询结果做可视化分析",
             ),
@@ -681,7 +946,7 @@ class DataQueryPrompts:
         if last_topic:
             buttons.insert(
                 0,
-                DataQueryPrompts.quick_button(
+                cls.quick_button(
                     f"重新查询「{last_topic}」",
                     f"查询{last_topic}",
                 ),
@@ -690,7 +955,8 @@ class DataQueryPrompts:
             "当前会话还没有可复用的结构化查询结果，无法直接基于上一轮数据出图或分析。"
             "您可以先完成一次查询，或选择下面的建议："
         )
-        return f"{lead}\n\n### 💬 您可以这样继续\n" + "\n".join(buttons[:3])
+        reason_block = cls._format_clarification_reason_block(user_question, reasoning)
+        return f"{reason_block}\n{lead}\n\n### 💬 您可以这样继续\n" + "\n".join(buttons[:3])
 
     @staticmethod
     def _extract_last_user_topic(history_excerpt: str, current_question: str) -> str:

--- a/app/services/ai/executors/prompts.py
+++ b/app/services/ai/executors/prompts.py
@@ -161,7 +161,7 @@ class DataQueryPrompts:
 
 任务：
 1. 开头用**引用块**（`>` 开头）做整体概要：用 1-2 句话说明数据集数量、覆盖的主要业务域与整体能查询的能力范围。
-2. 把数据目录改写成用户看得懂的**业务场景卡片**，不要只罗列表名。每个卡片标题应是业务动作或分析场景，例如“智能体运行分析”“权限审计分析”“运维监控分析”。
+2. **每个授权数据集对应一张独立的业务场景卡片**，卡片标题必须使用该数据集的 **Display Name**（若无则使用 Dataset 名）；不要将多个数据集合并到同一张卡片。
 3. 每张业务场景卡片必须包含：
    - `#### 场景标题`
    - 一段引用块概要，说明适合解决什么业务问题。
@@ -338,43 +338,63 @@ class DataQueryPrompts:
         return slug[:48] or "dataset_scene"
 
     @classmethod
-    def _infer_dataset_scene(cls, block: dict[str, Any]) -> dict[str, Any]:
-        name = str(block.get("name") or "").strip()
+    def _dataset_scene_title(cls, block: dict[str, Any]) -> str:
         display_name = str(block.get("display_name") or "").strip()
+        name = str(block.get("name") or "").strip()
+        return display_name or name or "未命名数据集"
+
+    @classmethod
+    def _extract_dataset_tags(cls, block: dict[str, Any], *, max_tags: int = 4) -> list[str]:
+        tags: list[str] = []
+        seen: set[str] = set()
+
+        def add(tag: str) -> None:
+            cleaned = str(tag or "").strip()
+            if not cleaned or cleaned in seen:
+                return
+            seen.add(cleaned)
+            tags.append(cleaned)
+
+        for metric in block.get("metrics") or []:
+            add(str(metric))
+            if len(tags) >= max_tags:
+                return tags[:max_tags]
+
+        for table in block.get("tables") or []:
+            add(str(table.get("term") or ""))
+            if len(tags) >= max_tags:
+                break
+
+        if not tags:
+            return ["明细查询", "统计汇总"]
+        return tags[:max_tags]
+
+    @classmethod
+    def _infer_dataset_scene(cls, block: dict[str, Any]) -> dict[str, Any]:
+        title = cls._dataset_scene_title(block)
         description = str(block.get("description") or "").strip()
-        table_terms = [str(t.get("term") or "").strip() for t in block.get("tables") or []]
-        haystack = " ".join([name, display_name, description, *table_terms]).lower()
-
-        if any(k in haystack for k in ("智能体", "agent", "对话", "模型", "trace", "链路", "token")):
-            return {
-                "title": "智能体运行分析",
-                "summary": "适合查看智能体访问、对话、执行链路、模型配置等运行情况，帮助定位使用量、失败原因与链路表现。",
-                "tags": ["调用统计", "对话追踪", "模型配置"],
-            }
-        if any(k in haystack for k in ("权限", "角色", "用户", "审计", "登录", "账号")):
-            return {
-                "title": "权限审计分析",
-                "summary": "适合查询账号、角色、权限变更与访问审计，帮助确认谁能访问哪些资源以及是否存在异常操作。",
-                "tags": ["账号权限", "角色审计", "访问记录"],
-            }
-        if any(k in haystack for k in ("告警", "机房", "设备", "pue", "容量", "资源", "运维", "监控")):
-            return {
-                "title": "运维监控分析",
-                "summary": "适合查看资源容量、设备状态、告警记录与趋势变化，帮助发现异常、定位风险和跟踪运维指标。",
-                "tags": ["告警趋势", "容量分析", "设备监控"],
-            }
-        if any(k in haystack for k in ("收入", "订单", "客户", "合同", "回款", "销售", "费用", "成本")):
-            return {
-                "title": "经营指标分析",
-                "summary": "适合查询收入、订单、客户、合同、回款或成本费用等经营指标，帮助做趋势、排名与对比分析。",
-                "tags": ["经营趋势", "客户分析", "收入成本"],
-            }
-
-        base = display_name or name or "业务数据"
+        tables = [
+            str(t.get("term") or "").strip()
+            for t in block.get("tables") or []
+            if str(t.get("term") or "").strip()
+        ]
+        table_hint = "、".join(tables[:3]) if tables else "相关表"
+        generic_descriptions = {
+            "no description",
+            "imported via smart wizard",
+            "无",
+            "暂无描述",
+        }
+        if description and description.lower() not in generic_descriptions:
+            summary = f"适合围绕「{title}」查询与分析。{description}"
+        else:
+            summary = (
+                f"适合围绕「{title}」中的{table_hint}发起明细查询、统计汇总与趋势分析。"
+            )
         return {
-            "title": f"{base}数据分析",
-            "summary": f"适合围绕{base}中的表和指标发起明细查询、统计汇总、趋势变化与字段探索。",
-            "tags": ["明细查询", "统计汇总", "趋势分析"],
+            "title": title,
+            "summary": summary,
+            "tags": cls._extract_dataset_tags(block),
         }
 
     @classmethod
@@ -419,84 +439,56 @@ class DataQueryPrompts:
 
     @classmethod
     def build_dataset_navigation_groups(cls, dataset_menu: str) -> list[dict[str, Any]]:
-        """按业务场景标题合并数据集，避免多个数据集命中同一场景时出现重复卡片。"""
-        grouped_blocks: dict[str, list[dict[str, Any]]] = {}
-        group_order: list[str] = []
+        """每个授权数据集生成一张独立场景卡片，标题与标签来自数据集元数据。"""
+        groups: list[dict[str, Any]] = []
 
         for block in cls._parse_dataset_blocks(dataset_menu):
-            scene_title = cls._infer_dataset_scene(block)["title"]
-            if scene_title not in grouped_blocks:
-                grouped_blocks[scene_title] = []
-                group_order.append(scene_title)
-            grouped_blocks[scene_title].append(block)
+            scene = cls._infer_dataset_scene(block)
+            name = str(block.get("name") or "").strip()
+            display_name = str(block.get("display_name") or "").strip() or name or "未命名数据集"
+            scene_title = scene["title"]
+            tables = [t for t in (block.get("tables") or []) if str(t.get("term") or "").strip()]
+            metrics = [str(m).strip() for m in (block.get("metrics") or []) if str(m).strip()]
 
-        groups: list[dict[str, Any]] = []
-        for scene_title in group_order:
-            blocks = grouped_blocks[scene_title]
-            scene = cls._infer_dataset_scene(blocks[0])
-
-            merged_tables: list[dict[str, Any]] = []
-            seen_table_terms: set[str] = set()
-            merged_metrics: list[str] = []
-            seen_metrics: set[str] = set()
-            related_data: list[dict[str, Any]] = []
-
-            for block in blocks:
-                name = str(block.get("name") or "").strip()
-                display_name = str(block.get("display_name") or "").strip() or name or "未命名数据集"
-                tables = [t for t in (block.get("tables") or []) if str(t.get("term") or "").strip()]
-                metrics = [str(m).strip() for m in (block.get("metrics") or []) if str(m).strip()]
-
-                table_terms: list[str] = []
-                table_descriptions: list[dict[str, str]] = []
-                for table in tables:
-                    term = str(table.get("term") or "").strip()
-                    if not term or term in seen_table_terms:
-                        continue
-                    seen_table_terms.add(term)
-                    merged_tables.append(table)
-                    table_terms.append(term)
-                    table_descriptions.append(
-                        {
-                            "name": term,
-                            "description": str(table.get("desc") or "").strip(),
-                        }
-                    )
-
-                for metric in metrics:
-                    if metric not in seen_metrics:
-                        seen_metrics.add(metric)
-                        merged_metrics.append(metric)
-
-                related_data.append(
+            table_terms: list[str] = []
+            table_descriptions: list[dict[str, str]] = []
+            for table in tables:
+                term = str(table.get("term") or "").strip()
+                table_terms.append(term)
+                table_descriptions.append(
                     {
-                        "dataset": name,
-                        "display_name": display_name,
-                        "tables": table_terms,
-                        "table_descriptions": table_descriptions,
+                        "name": term,
+                        "description": str(table.get("desc") or "").strip(),
                     }
                 )
 
             groups.append(
                 {
-                    "id": cls._slugify_scene_id(scene_title),
+                    "id": cls._slugify_scene_id(name or display_name),
                     "title": scene_title,
                     "summary": scene["summary"],
                     "tags": scene["tags"],
                     "questions": cls._question_templates_for_group(
                         scene_title=scene_title,
-                        tables=merged_tables,
-                        metrics=merged_metrics,
+                        tables=tables,
+                        metrics=metrics,
                     ),
-                    "related_data": related_data,
+                    "related_data": [
+                        {
+                            "dataset": name,
+                            "display_name": display_name,
+                            "tables": table_terms,
+                            "table_descriptions": table_descriptions,
+                        }
+                    ],
                     "followups": [
                         {
                             "label": "更多问题",
-                            "query": f"围绕{scene_title}，推荐我还能问哪些数据问题",
+                            "query": f"围绕「{scene_title}」，推荐我还能问哪些数据问题",
                         },
                         {
                             "label": "字段说明",
-                            "query": f"说明{scene_title}相关数据里有哪些可查询字段和适合的分析口径",
+                            "query": f"说明「{scene_title}」里有哪些可查询字段和适合的分析口径",
                         },
                     ],
                 }

--- a/app/services/ai/runners/data_agent_runner.py
+++ b/app/services/ai/runners/data_agent_runner.py
@@ -897,7 +897,10 @@ class DataAgentRunner(BaseExecutor):
                 ):
                     yield chunk
             else:
-                async for chunk in self._yield_missing_reusable_result_clarification(history):
+                async for chunk in self._yield_missing_reusable_result_clarification(
+                    history,
+                    user_question=user_question,
+                ):
                     yield chunk
             return
 
@@ -1790,10 +1793,40 @@ class DataAgentRunner(BaseExecutor):
             )
             cleaned = str(content or "").strip()
             if cleaned and DataQueryPrompts.has_quick_suggestions(cleaned):
-                return finalize_visible_reply(cleaned, collapse_duplicates=False)
+                return finalize_visible_reply(
+                    DataQueryPrompts.ensure_clarification_reason_block(
+                        cleaned,
+                        user_question,
+                        reasoning,
+                    ),
+                    collapse_duplicates=False,
+                )
+            if cleaned:
+                merged = DataQueryPrompts.append_contextual_quick_suggestions(
+                    cleaned,
+                    user_question,
+                    reasoning,
+                    history_excerpt,
+                )
+                if DataQueryPrompts.has_quick_suggestions(merged):
+                    return finalize_visible_reply(
+                        DataQueryPrompts.ensure_clarification_reason_block(
+                            merged,
+                            user_question,
+                            reasoning,
+                        ),
+                        collapse_duplicates=False,
+                    )
         except Exception as e:
             logger.warning("[DataAgentRunner] Contextual clarification generation failed: %s", e)
-        return finalize_visible_reply(fallback, collapse_duplicates=False)
+        return finalize_visible_reply(
+            DataQueryPrompts.ensure_clarification_reason_block(
+                fallback,
+                user_question,
+                reasoning,
+            ),
+            collapse_duplicates=False,
+        )
 
     async def _yield_contextual_clarification(
         self,
@@ -1820,17 +1853,26 @@ class DataAgentRunner(BaseExecutor):
     async def _yield_missing_reusable_result_clarification(
         self,
         history: List[Dict[str, str]],
+        *,
+        user_question: str = "",
     ) -> AsyncGenerator[Dict[str, Any], None]:
         history_excerpt = DataQueryPrompts.format_clarification_history(history)
+        reasoning = (
+            "检测到本轮是基于上一轮结果的分析/可视化请求，"
+            "但当前会话没有保存的结构化查询结果。"
+        )
         yield {
             "type": "log",
             "id": f"reuse_miss_{uuid.uuid4().hex[:8]}",
             "title": "缺少可复用查询结果",
-            "details": "检测到本轮是基于上一轮结果的分析/可视化请求，但当前会话没有保存的结构化查询结果。",
+            "details": reasoning,
             "status": "error",
         }
         yield {
-            "content": DataQueryPrompts.build_missing_reusable_result_fallback(history_excerpt),
+            "content": DataQueryPrompts.build_missing_reusable_result_fallback(
+                history_excerpt,
+                user_question=user_question,
+            ),
             "status": "success",
         }
 

--- a/app/services/changelog_service.py
+++ b/app/services/changelog_service.py
@@ -42,14 +42,15 @@ class ChangelogService:
                 user_name=user_name,
                 reason=reason
             )
-            
-            db.add(changelog)
-            await db.flush()  # 确保日志记录成功，但不立即提交
+
+            async with db.begin_nested():
+                db.add(changelog)
+                await db.flush()
             logger.info(f"记录变更日志: {resource_type}:{resource_id} - {operation} by {user_name}")
-            
+
         except Exception as e:
             logger.error(f"记录变更日志失败: {e}")
-            # 不抛出异常，避免影响主业务
+            # 不抛出异常，避免影响主业务；使用 savepoint 防止 flush 失败污染外层事务
             
     @staticmethod
     def _calculate_changed_fields(old_data: Dict[str, Any], new_data: Dict[str, Any]) -> List[str]:

--- a/app/services/dataset_navigation_service.py
+++ b/app/services/dataset_navigation_service.py
@@ -20,7 +20,7 @@ from app.services.ai.runtime.agentscope.stream_reconcile import finalize_visible
 logger = logging.getLogger(__name__)
 
 _NAV_CACHE_TTL_SECONDS = 600
-_NAV_PROMPT_VERSION = "v3"
+_NAV_PROMPT_VERSION = "v4"
 _CLICK_STATS_TTL_SECONDS = 90 * 24 * 60 * 60
 
 
@@ -258,6 +258,39 @@ class DatasetNavigationService:
             await redis.expire(meta_key, _CLICK_STATS_TTL_SECONDS)
         except Exception as e:
             logger.warning("Dataset navigation click stats write failed: %s", e)
+
+    @staticmethod
+    async def clear_question_click(
+        *,
+        user_id: Optional[int],
+        is_admin: bool,
+        dataset_menu_hash: str,
+        query: str,
+    ) -> bool:
+        clean_hash = str(dataset_menu_hash or "").strip()
+        clean_query = str(query or "").strip()
+        if not clean_hash or not clean_query:
+            return False
+        try:
+            redis = await get_redis()
+            if not redis:
+                return False
+            user_key = _user_cache_key(user_id=user_id, is_admin=is_admin)
+            question_id = _question_hash(clean_query)
+            rank_key = DatasetNavigationService._click_rank_key(
+                user_key=user_key,
+                dataset_menu_hash=clean_hash,
+            )
+            meta_key = DatasetNavigationService._click_meta_key(
+                user_key=user_key,
+                dataset_menu_hash=clean_hash,
+            )
+            removed_rank = int(await redis.zrem(rank_key, question_id) or 0)
+            removed_meta = int(await redis.hdel(meta_key, question_id) or 0)
+            return removed_rank > 0 or removed_meta > 0
+        except Exception as e:
+            logger.warning("Dataset navigation click stats clear failed: %s", e)
+            return False
 
     @staticmethod
     def parse_groups_from_markdown(

--- a/db-prod/V79-expand_meta_changelog_resource_id.sql
+++ b/db-prod/V79-expand_meta_changelog_resource_id.sql
@@ -1,0 +1,5 @@
+-- V79: 扩展 meta_changelog.resource_id 长度
+-- 表级变更日志使用 "{dataset_id}:{physical_name}"，物理表名最长 255，需容纳前缀
+
+ALTER TABLE `meta_changelog`
+    MODIFY COLUMN `resource_id` VARCHAR(270) NOT NULL COMMENT '资源ID';

--- a/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
+++ b/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
@@ -816,7 +816,7 @@ const tagFilterClass = (tag: string) => {
     return "bg-gray-50 dark:bg-gray-800/40 border-gray-150 dark:border-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800";
   }
   const owner = (props.payload.groups || []).find((group) => (group.tags || []).includes(tag));
-  const theme = getGroupVisuals(0, owner?.title || tag);
+  const theme = owner ? getGroupVisuals(owner, 0) : getGroupVisuals({ id: tag, title: tag }, 0);
   return `${theme.tag} ring-1 ring-current/20 shadow-xs`;
 };
 
@@ -983,20 +983,22 @@ const CARD_THEMES: GroupVisualTheme[] = [
   },
 ];
 
-const resolveThemeKey = (index: number, title: string): string => {
-  const titleStr = title || "";
-  if (titleStr.includes("智能体") || titleStr.includes("Agent") || titleStr.includes("大模型") || titleStr.includes("AI")) return "violet";
-  if (titleStr.includes("权限") || titleStr.includes("审计") || titleStr.includes("安全") || titleStr.includes("合规")) return "amber";
-  if (titleStr.includes("运维") || titleStr.includes("告警") || titleStr.includes("机房") || titleStr.includes("监控")) return "emerald";
-  if (titleStr.includes("用户") || titleStr.includes("客户") || titleStr.includes("订单") || titleStr.includes("会员")) return "rose";
-  if (titleStr.includes("数据") || titleStr.includes("看板") || titleStr.includes("报表") || titleStr.includes("门户")) return "cyan";
-  if (titleStr.includes("分析") || titleStr.includes("日志") || titleStr.includes("诊断") || titleStr.includes("统计")) return "blue";
-  return CARD_THEMES[index % CARD_THEMES.length].key;
+const hashThemeIndex = (seed: string): number => {
+  const normalized = seed.trim();
+  if (!normalized) return 0;
+  let hash = 0;
+  for (let i = 0; i < normalized.length; i += 1) {
+    hash = (hash * 31 + normalized.charCodeAt(i)) >>> 0;
+  }
+  return hash % CARD_THEMES.length;
 };
 
-const getGroupVisuals = (index: number, title: string): GroupVisualTheme => {
-  const key = resolveThemeKey(index, title);
-  return CARD_THEMES.find((theme) => theme.key === key) || CARD_THEMES[index % CARD_THEMES.length];
+const getGroupVisuals = (
+  group: Pick<DatasetCapabilityGroup, "id" | "title">,
+  fallbackIndex = 0,
+): GroupVisualTheme => {
+  const seed = String(group.id || group.title || fallbackIndex);
+  return CARD_THEMES[hashThemeIndex(seed)];
 };
 
 // 计算属性：联合搜索与过滤
@@ -1053,7 +1055,7 @@ const displayGroups = computed(() => {
   );
   return sorted.map((group, idx) => ({
     group,
-    visuals: getGroupVisuals(idx, group.title),
+    visuals: getGroupVisuals(group, idx),
   }));
 });
 

--- a/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
+++ b/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
@@ -15,7 +15,7 @@
     </div>
 
     <!-- Header -->
-    <div class="bg-gray-50/40 dark:bg-gray-800/10 backdrop-blur-sm border border-gray-150 dark:border-gray-800/80 rounded-xl p-3 flex flex-col sm:flex-row justify-between sm:items-center gap-3">
+    <div class="bg-gray-50/40 dark:bg-gray-800/10 backdrop-blur-sm border border-gray-150 dark:border-gray-800/80 rounded-xl p-3 flex flex-row items-center justify-between gap-2">
       <div class="flex items-center gap-2.5 min-w-0">
         <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-blue-600 dark:bg-blue-500 text-white shadow-sm flex-shrink-0">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -67,7 +67,6 @@
           </svg>
         </span>
         <input
-          ref="searchInputRef"
           v-model="searchQuery"
           type="text"
           placeholder="搜索场景、表名或指标..."
@@ -122,16 +121,31 @@
         <span>🔥</span> 我常问
       </div>
       <div class="flex flex-wrap gap-2">
-        <button
+        <div
           v-for="item in frequentQuestions"
           :key="item.question.query"
-          type="button"
-          class="inline-flex items-center gap-1.5 rounded-lg border border-amber-200/70 dark:border-amber-800/50 bg-white/80 dark:bg-gray-900/40 px-2.5 py-1.5 text-left text-[11px] font-semibold text-amber-900 dark:text-amber-100 hover:bg-amber-50 dark:hover:bg-amber-950/40 transition-all active:scale-95"
-          @click="handleFrequentQuestionClick(item)"
+          class="inline-flex items-stretch rounded-lg border border-amber-200/70 dark:border-amber-800/50 bg-white/80 dark:bg-gray-900/40 overflow-hidden"
         >
-          <span class="truncate max-w-[220px]">{{ item.question.label }}</span>
-          <span class="text-[9px] font-bold text-amber-600 dark:text-amber-400">{{ item.question.click_count }}次</span>
-        </button>
+          <button
+            type="button"
+            class="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-left text-[11px] font-semibold text-amber-900 dark:text-amber-100 hover:bg-amber-50 dark:hover:bg-amber-950/40 transition-all active:scale-95"
+            @click="handleFrequentQuestionClick(item)"
+          >
+            <span class="truncate max-w-[200px] sm:max-w-[220px]">{{ item.question.label }}</span>
+            <span class="text-[9px] font-bold text-amber-600 dark:text-amber-400">{{ item.question.click_count }}次</span>
+          </button>
+          <button
+            type="button"
+            class="flex items-center justify-center px-1.5 text-amber-500/80 dark:text-amber-400/80 border-l border-amber-200/70 dark:border-amber-800/50 hover:bg-amber-100/80 dark:hover:bg-amber-950/60 hover:text-amber-700 dark:hover:text-amber-200 transition-colors"
+            title="从常问中移除"
+            aria-label="从常问中移除"
+            @click.stop="handleClearFrequentQuestion(item)"
+          >
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
 
@@ -592,11 +606,11 @@ const formatGroupSummary = (text: string): string => {
 const emit = defineEmits<{
   (event: "quick-question", query: string): void;
   (event: "record-question-click", payload: { query: string; label?: string; group_id?: string }): void;
+  (event: "clear-question-click", payload: { query: string }): void;
   (event: "refresh"): void;
 }>();
 
 const menuContainer = ref<HTMLElement | null>(null);
-const searchInputRef = ref<HTMLInputElement | null>(null);
 const isRefreshing = ref(false);
 let refreshSafetyTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -815,11 +829,11 @@ const handleFrequentQuestionClick = (item: { question: DatasetCapabilityQuestion
   handleQuestionClick(item.question, item.group);
 };
 
-const focusSearch = () => {
-  nextTick(() => searchInputRef.value?.focus());
+const handleClearFrequentQuestion = (item: { question: DatasetCapabilityQuestion; group: DatasetCapabilityGroup }) => {
+  const query = String(item.question.query || "").trim();
+  if (!query) return;
+  emit("clear-question-click", { query });
 };
-
-defineExpose({ focusSearch });
 
 // 动态去重提取出当前有权访问的所有卡片 tags
 const allTags = computed(() => {

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -1604,6 +1604,43 @@ const recordDatasetMenuQuestionClick = async (
   }
 };
 
+const clearNavigationQuestionClickStats = (
+  navigation: DatasetNavigationPayload | undefined,
+  query: string,
+) => {
+  const normalized = String(query || "").trim();
+  if (!navigation?.groups || !normalized) return;
+  for (const group of navigation.groups) {
+    for (const question of group.questions || []) {
+      if (String(question.query || "").trim() !== normalized) continue;
+      question.click_count = 0;
+      delete question.last_clicked_at;
+    }
+  }
+};
+
+const clearDatasetMenuQuestionClick = async (
+  navigation: DatasetNavigationPayload | undefined,
+  payload: { query: string },
+) => {
+  const datasetMenuHash = navigation?.dataset_menu_hash;
+  const query = String(payload?.query || "").trim();
+  if (!datasetMenuHash || !query) return;
+  try {
+    await axios.post(
+      "/api/v1/chat/dataset-menu/click/clear",
+      {
+        dataset_menu_hash: datasetMenuHash,
+        query,
+      },
+      { headers: debugAuthHeaders() }
+    );
+    clearNavigationQuestionClickStats(navigation, query);
+  } catch (error) {
+    console.warn("Failed to clear dataset menu question click", error);
+  }
+};
+
 const openImagePreview = (url: string) => {
   window.open(url, "_blank");
 };
@@ -3657,6 +3694,7 @@ onUnmounted(() => {
                   :payload="msg.datasetNavigation"
                   @quick-question="handleQuickQuestion"
                   @record-question-click="(payload) => recordDatasetMenuQuestionClick(msg.datasetNavigation, payload)"
+                  @clear-question-click="(payload) => clearDatasetMenuQuestionClick(msg.datasetNavigation, payload)"
                   @refresh="refreshDatasetMenuNavigation(msg)"
                 />
                 <!-- 导出 / 点赞踩（托管 RAGFlow、OpenClaw 不展示点赞踩） -->

--- a/frontend/src/views/DataSourceManagement.vue
+++ b/frontend/src/views/DataSourceManagement.vue
@@ -135,6 +135,37 @@ const editConfig = (item: DbConnectionConfig) => {
   connError.value = ''
 }
 
+const stripCopySuffix = (name: string) => name.replace(/_copy(?:_\d+)?$/i, '')
+
+const buildUniqueCopyName = (baseName: string) => {
+  const root = stripCopySuffix(baseName) || baseName
+  const existing = new Set(configs.value.map((config) => config.name))
+  let candidate = `${root}_copy`
+  if (!existing.has(candidate)) return candidate
+  let n = 2
+  while (existing.has(`${root}_copy_${n}`)) n += 1
+  return `${root}_copy_${n}`
+}
+
+const copyConfig = (item: DbConnectionConfig) => {
+  editingId.value = null
+  form.name = buildUniqueCopyName(item.name)
+  form.type = item.db_type
+  form.host = item.host
+  form.port = item.port
+  form.user = item.db_user
+  form.password = item.password
+  form.database = item.database_name
+  const copyNote = `（复制自 ${item.name}）`
+  const description = (item.description || '').trim()
+  form.description = description.includes(copyNote)
+    ? description
+    : `${description}${description ? ' ' : ''}${copyNote}`.trim()
+  testPassed.value = false
+  connError.value = ''
+  showToast('已复制到左侧表单，请确认名称后测试并保存', 'success')
+}
+
 const toConfigPayload = () => ({
   name: form.name.trim(),
   db_type: form.type,
@@ -442,8 +473,9 @@ onMounted(() => {
                   <span class="line-clamp-2">{{ item.description }}</span>
                 </div>
               </div>
-              <div class="flex items-center gap-2 flex-shrink-0">
+              <div class="flex flex-wrap items-center justify-end gap-2 flex-shrink-0">
                 <button @click="editConfig(item)" class="px-3 py-1.5 rounded-lg bg-white border border-gray-200 text-gray-600 hover:bg-gray-100 text-xs font-bold">编辑</button>
+                <button @click="copyConfig(item)" class="px-3 py-1.5 rounded-lg bg-violet-50 border border-violet-100 text-violet-600 hover:bg-violet-100 text-xs font-bold">复制</button>
                 <button @click="testSavedConnection(item)" class="px-3 py-1.5 rounded-lg bg-blue-50 border border-blue-100 text-blue-600 hover:bg-blue-100 text-xs font-bold">测试</button>
                 <button @click="openSqlDebug(item)" class="px-3 py-1.5 rounded-lg bg-emerald-50 border border-emerald-100 text-emerald-600 hover:bg-emerald-100 text-xs font-bold">调试</button>
                 <button

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -850,6 +850,7 @@
                                                                   :payload="msg.datasetNavigation"
                                                                   @quick-question="handleQuickQuestion"
                                                                   @record-question-click="(payload) => recordDatasetMenuQuestionClick(msg.datasetNavigation, payload)"
+                                                                  @clear-question-click="(payload) => clearDatasetMenuQuestionClick(msg.datasetNavigation, payload)"
                                                                   @refresh="refreshDatasetMenuNavigation(msg)"
                                                                 />
                                 <!-- Typewriter Cursor -->
@@ -2246,7 +2247,7 @@
               <div class="flex items-center gap-2 flex-shrink-0">
                 <label
                   class="hidden sm:flex items-center gap-1.5 text-[10px] text-gray-500 dark:text-gray-400 cursor-pointer select-none whitespace-nowrap"
-                  title="开启后点击问题不会关闭抽屉，可连续提问"
+                  title="开启后点击问题不会关闭抽屉，可连续提问（仅桌面端生效）"
                 >
                   <input
                     v-model="portalKeepOpenOnQuestion"
@@ -2270,12 +2271,12 @@
             <!-- 抽屉内容 -->
             <div class="flex-1 overflow-y-auto p-3 sm:p-4 bg-white dark:bg-gray-900/60">
               <DatasetCapabilityMenu
-                ref="portalMenuRef"
                 :payload="portalNavigationPayload || { groups: [] }"
                 :initial-loading="portalLoading && !portalNavigationPayload"
                 :background-refreshing="portalBackgroundRefreshing"
                 @quick-question="handlePortalQuickQuestion"
                 @record-question-click="(payload) => recordDatasetMenuQuestionClick(portalNavigationPayload, payload)"
+                @clear-question-click="(payload) => clearDatasetMenuQuestionClick(portalNavigationPayload, payload)"
                 @refresh="refreshPortalNavigation"
               />
             </div>
@@ -3043,6 +3044,46 @@ const recordDatasetMenuQuestionClick = async (
     );
   } catch (error) {
     console.warn("Failed to record dataset menu question click", error);
+  }
+};
+
+const clearNavigationQuestionClickStats = (
+  navigation: DatasetNavigationPayload | undefined,
+  query: string,
+) => {
+  const normalized = String(query || "").trim();
+  if (!navigation?.groups || !normalized) return;
+  for (const group of navigation.groups) {
+    for (const question of group.questions || []) {
+      if (String(question.query || "").trim() !== normalized) continue;
+      question.click_count = 0;
+      delete question.last_clicked_at;
+    }
+  }
+};
+
+const clearDatasetMenuQuestionClick = async (
+  navigation: DatasetNavigationPayload | undefined,
+  payload: { query: string },
+) => {
+  const datasetMenuHash = navigation?.dataset_menu_hash;
+  const query = String(payload?.query || "").trim();
+  if (!datasetMenuHash || !query) return;
+  try {
+    await axios.post(
+      "/api/v1/chat/dataset-menu/click/clear",
+      {
+        dataset_menu_hash: datasetMenuHash,
+        query,
+      },
+      { headers: embedAuthHeaders() }
+    );
+    clearNavigationQuestionClickStats(navigation, query);
+    if (navigation === portalNavigationPayload.value && portalNavigationPayload.value) {
+      portalNavigationPayload.value = { ...portalNavigationPayload.value };
+    }
+  } catch (error) {
+    console.warn("Failed to clear dataset menu question click", error);
   }
 };
 const handleReorderCommands = async (reorderData: any[]) => {
@@ -4201,7 +4242,6 @@ const portalNavigationPayload = ref<any>(null);
 const portalLoading = ref(false);
 const portalSilentRefreshing = ref(false);
 const portalPrefetchInFlight = ref(false);
-const portalMenuRef = ref<InstanceType<typeof DatasetCapabilityMenu> | null>(null);
 const hasSilentlyRefreshed = ref(false);
 let silentRefreshTimer: any = null;
 
@@ -4210,6 +4250,13 @@ const portalKeepOpenOnQuestion = ref(localStorage.getItem(PORTAL_KEEP_OPEN_KEY) 
 watch(portalKeepOpenOnQuestion, (val) => {
   localStorage.setItem(PORTAL_KEEP_OPEN_KEY, val ? "1" : "0");
 });
+
+const isMobileViewport = () =>
+  typeof window !== "undefined" && window.matchMedia("(max-width: 639px)").matches;
+
+/** 移动端点击问题后始终关闭抽屉；桌面端尊重「提问后保持」开关。 */
+const shouldClosePortalAfterQuestion = () =>
+  isMobileViewport() || !portalKeepOpenOnQuestion.value;
 
 // 数据门户初始化加载温馨提示词轮播
 const portalLoadingTips = [
@@ -4269,8 +4316,6 @@ const openPortalDrawer = async () => {
   } else if (portalNavigationPayload.value.is_fallback) {
     await fetchPortalNavigationData(false, false);
   }
-  await nextTick();
-  portalMenuRef.value?.focusSearch();
 };
 
 const fetchPortalNavigationData = async (refresh = false, silent = false) => {
@@ -4330,8 +4375,6 @@ watch(showPortalDrawer, (val) => {
       silentRefreshTimer = null;
     }
     stopPortalLoadingTips();
-  } else {
-    nextTick(() => portalMenuRef.value?.focusSearch());
   }
 });
 
@@ -4340,7 +4383,7 @@ const refreshPortalNavigation = async () => {
 };
 
 const handlePortalQuickQuestion = (query: string) => {
-  if (!portalKeepOpenOnQuestion.value) {
+  if (shouldClosePortalAfterQuestion()) {
     showPortalDrawer.value = false;
   }
   handleQuickQuestion(query);

--- a/tests/ai/test_data_query_prompts.py
+++ b/tests/ai/test_data_query_prompts.py
@@ -7,10 +7,14 @@ def test_build_clarification_fallback_for_followup_missing_context():
         "请求类别 LLM 未返回有效结果；检测到结果追问但没有可信的近期可复用结构化查询结果",
         "用户: 查询算力SU 1-6月回款率\n助手: | 月份 | 回款率 |",
     )
-    assert "继续分析或可视化" in content
+    assert "### ℹ️ 为什么需要补充信息" in content
+    assert "**触发原因：**" in content
+    assert "**您可以这样改：**" in content
+    assert "可复用的查询结果" in content
     assert "### 💬 您可以这样继续" in content
     assert "(quick:" in content
     assert "算力SU" in content
+    assert "PUE" not in content
 
 
 def test_build_clarification_fallback_for_general_chat():
@@ -19,14 +23,50 @@ def test_build_clarification_fallback_for_general_chat():
         "当前请求不是明确的 ChatBI 查数请求，需要用户补充想查询的业务数据、指标、维度或时间范围",
         "",
     )
-    assert "PUE" in content
+    assert "### ℹ️ 为什么需要补充信息" in content
+    assert "尚未识别为明确的数据查询" in content
+    assert "数据对象、指标和时间范围" in content
     assert DataQueryPrompts.has_quick_suggestions(content)
+    assert "PUE" not in content
+
+
+def test_build_clarification_fallback_anchors_to_user_question():
+    question = "最近一次对话中用户提问和 AI 响应的 Token 消耗是多少？"
+    content = DataQueryPrompts.build_clarification_fallback(
+        question,
+        "需要用户补充查数信息",
+        "",
+    )
+    assert "### ℹ️ 为什么需要补充信息" in content
+    assert "**触发原因：**" in content
+    assert "Token" in content
+    assert question in content
+    assert "PUE" not in content
+    assert "告警" not in content
+    assert "(quick:" in content
+
+
+def test_append_contextual_quick_suggestions_when_llm_body_only():
+    question = "统计各机房上周 PUE 排名"
+    body = "还需要您补充具体统计口径后才能继续。"
+    merged = DataQueryPrompts.append_contextual_quick_suggestions(
+        body,
+        question,
+        "需要用户补充查数信息",
+        "",
+    )
+    assert merged.startswith(body)
+    assert "### 💬 您可以这样继续" in merged
+    assert "PUE" in merged
+    assert "(quick:" in merged
 
 
 def test_build_missing_reusable_result_fallback_includes_quick_buttons():
     content = DataQueryPrompts.build_missing_reusable_result_fallback(
         "用户: 查询算力SU回款趋势",
+        user_question="可视化分析一下",
     )
+    assert "### ℹ️ 为什么需要补充信息" in content
     assert "结构化查询结果" in content
     assert "(quick:对刚刚的查询结果做可视化分析)" in content
     assert "(quick:查询算力SU回款趋势)" in content

--- a/tests/services/test_dataset_navigation_service.py
+++ b/tests/services/test_dataset_navigation_service.py
@@ -66,7 +66,7 @@ def test_parse_dataset_blocks_captures_table_descriptions():
 
 
 @pytest.mark.no_infrastructure
-def test_build_dataset_navigation_groups_merges_same_scene_title():
+def test_build_dataset_navigation_groups_one_card_per_dataset():
     menu = """Available Datasets:
 - Dataset: ops_alerts
   Display Name: 机房告警
@@ -81,17 +81,32 @@ def test_build_dataset_navigation_groups_merges_same_scene_title():
     - 设备状态表: 设备运行状态
 """
     groups = DataQueryPrompts.build_dataset_navigation_groups(menu)
-    assert len(groups) == 1
-    assert groups[0]["title"] == "运维监控分析"
-    assert len(groups[0]["related_data"]) == 2
+    assert len(groups) == 2
+    assert groups[0]["title"] == "机房告警"
+    assert groups[1]["title"] == "设备监控"
+    assert len(groups[0]["related_data"]) == 1
     assert groups[0]["related_data"][0]["dataset"] == "ops_alerts"
-    assert groups[0]["related_data"][1]["dataset"] == "ops_devices"
-    assert "机房告警表" in groups[0]["related_data"][0]["tables"]
-    assert "设备状态表" in groups[0]["related_data"][1]["tables"]
+    assert groups[1]["related_data"][0]["dataset"] == "ops_devices"
+    assert groups[0]["tags"] == ["机房告警表"]
+    assert groups[1]["tags"] == ["设备状态表"]
 
 
 @pytest.mark.no_infrastructure
-def test_build_dataset_navigation_fallback_deduplicates_scene_cards():
+def test_build_dataset_navigation_groups_prefers_metrics_as_tags():
+    menu = """Available Datasets:
+- Dataset: sales_kpi
+  Display Name: 销售指标
+  Metrics: 收入, 回款率
+  Includes Tables: 销售订单表
+"""
+    groups = DataQueryPrompts.build_dataset_navigation_groups(menu)
+    assert len(groups) == 1
+    assert groups[0]["title"] == "销售指标"
+    assert groups[0]["tags"] == ["收入", "回款率"]
+
+
+@pytest.mark.no_infrastructure
+def test_build_dataset_navigation_fallback_uses_one_card_per_dataset():
     menu = """Available Datasets:
 - Dataset: ops_alerts
   Display Name: 机房告警
@@ -102,7 +117,8 @@ def test_build_dataset_navigation_fallback_deduplicates_scene_cards():
   Includes Tables: 设备状态表
 """
     markdown = DataQueryPrompts.build_dataset_navigation_fallback(menu)
-    assert markdown.count("#### 运维监控分析") == 1
+    assert markdown.count("#### 机房告警") == 1
+    assert markdown.count("#### 设备监控") == 1
     assert "机房告警 (ops_alerts)" in markdown
     assert "设备监控 (ops_devices)" in markdown
 
@@ -113,9 +129,10 @@ def test_build_dataset_navigation_groups_from_dataset_menu():
     assert len(groups) == 2
     first_group = groups[0]
     assert first_group["id"]
-    assert "智能体" in first_group["title"]
+    assert first_group["title"] == "智能体元数据"
     assert first_group["summary"]
     assert first_group["tags"]
+    assert "智能体访问日志" in first_group["tags"]
     assert len(first_group["questions"]) >= 3
     assert first_group["questions"][0]["query"]
     assert first_group["followups"]
@@ -127,7 +144,7 @@ def test_build_dataset_navigation_groups_from_dataset_menu():
 def test_build_dataset_navigation_fallback_uses_business_scene_cards():
     markdown = DataQueryPrompts.build_dataset_navigation_fallback(SAMPLE_MENU)
     assert "### 📚 我的数据门户" in markdown
-    assert "#### 智能体运行分析" in markdown
+    assert "#### 智能体元数据" in markdown
     assert "> 您当前可访问 **2** 个数据集" in markdown
     assert "**你可以这样问：**" in markdown
     assert "**相关数据：** 智能体元数据 (ai_agent_meta)" in markdown
@@ -325,7 +342,7 @@ async def test_record_question_click_stores_redis_rank_and_metadata():
             dataset_menu_hash="abc123",
             query="查询智能体访问日志最近10条明细记录",
             label="查询明细",
-            group_id="ai_agent_meta_智能体运行分析",
+            group_id="ai_agent_meta",
         )
 
     redis.zincrby.assert_awaited_once()
@@ -333,12 +350,31 @@ async def test_record_question_click_stores_redis_rank_and_metadata():
     assert redis.expire.await_count == 2
 
 
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_clear_question_click_removes_redis_rank_and_metadata():
+    redis = AsyncMock()
+    redis.zrem = AsyncMock(return_value=1)
+    redis.hdel = AsyncMock(return_value=1)
+    with patch("app.services.dataset_navigation_service.get_redis", AsyncMock(return_value=redis)):
+        cleared = await DatasetNavigationService.clear_question_click(
+            user_id=7,
+            is_admin=False,
+            dataset_menu_hash="abc123",
+            query="查询智能体访问日志最近10条明细记录",
+        )
+
+    assert cleared is True
+    redis.zrem.assert_awaited_once()
+    redis.hdel.assert_awaited_once()
+
+
 @pytest.mark.no_infrastructure
 def test_parse_groups_from_markdown_success():
     static_groups = [
         {
-            "id": "ai_agent_meta_智能体运行分析",
-            "title": "智能体运行分析",
+            "id": "ai_agent_meta",
+            "title": "智能体元数据",
             "summary": "静态描述",
             "questions": [{"label": "静态问题", "query": "静态查询"}],
             "followups": [{"label": "静态追问", "query": "静态追问查询"}],
@@ -349,7 +385,7 @@ def test_parse_groups_from_markdown_success():
         "---\n"
         "> 整体描述\n"
         "\n"
-        "#### 智能体运行分析\n"
+        "#### 智能体元数据\n"
         "> 这是动态生成的智能体分析摘要，帮助分析性能。\n"
         "\n"
         "**你可以这样问：**\n"
@@ -367,7 +403,7 @@ def test_parse_groups_from_markdown_success():
     parsed = DatasetNavigationService.parse_groups_from_markdown(markdown, static_groups)
     assert len(parsed) == 1
     group = parsed[0]
-    assert group["title"] == "智能体运行分析"
+    assert group["title"] == "智能体元数据"
     assert group["summary"] == "这是动态生成的智能体分析摘要，帮助分析性能。"
     assert len(group["questions"]) == 2
     assert group["questions"][0]["label"] == "访问热度"
@@ -459,7 +495,7 @@ async def test_refresh_group_questions_success():
     ):
         questions = await DatasetNavigationService.refresh_group_questions(
             mock_db,
-            group_title="智能体运行分析",
+            group_title="智能体元数据",
             tables=["智能体访问日志"]
         )
 


### PR DESCRIPTION

## 概要 (Overview)

本 PR 在 `528d43c` 之后集中交付 **ChatBI 数据门户** 的体验重构与能力增强：从嵌入页抽屉门户、场景卡片生成策略、个性化「我常问」，到表级推荐提问独立 API、澄清回复上下文化等。同时修复结构化结果未透传导致「可视化分析」缺失、元数据保存时长表名触发 changelog 写入失败等问题，并补充数据源管理「复制」等运维侧小能力。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)

- [x] **数据门户一数据集一场景**：每个授权数据集独立一张卡片，标题用 Display Name，tags 从 Metrics/表术语提取；LLM prompt 与缓存版本升至 v4
- [x] **嵌入页门户抽屉**：`/dataset_menu` 打开右侧抽屉，支持静默预加载、fallback 自动二次刷新、状态条与骨架屏
- [x] **「我常问」个性化**：记录点击偏好排序；支持 × 删除常问（`POST /dataset-menu/click/clear`）
- [x] **表级推荐提问**：新增 `POST /dataset-menu/recommend-table-questions`，仅依据字段元数据生成 quick，不走 ChatBI 查数
- [x] **ChatBI 澄清回复增强**：澄清兜底围绕用户原问生成建议；新增「为什么需要补充信息」说明区块
- [x] **数据源管理复制**：列表一键复制到左侧添加表单，自动去重命名（`xxx_copy` / `xxx_copy_2`）

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)

- [x] **门户卡片视觉**：6 套主题色按数据集 `id` 稳定哈希分配，避免 Display Name 含「数据」等词导致同色
- [x] **门户交互**：搜索/标签筛选、常用问题置顶、场景「换一批」、表字典点击展示推荐提问
- [x] **移动端**：点击问题后强制关闭抽屉；刷新按钮与标题同行；取消打开时搜索框自动聚焦
- [x] **桌面端**：「提问后保持」开关仅桌面生效
- [x] **图表展示**：修复 ECharts 横轴标签过浅、配置重复 `color` 键；刷新遮罩与 toast 时序优化
- [x] **开发平台菜单**：侧栏统一为企业级五字命名（智能体开发平台等）

### 3. 🐞 关键修复 (Bug Fixes)

- [x] **可视化分析按钮缺失**：修复 ChatBI 结构化结果 `data_render` 标记未透传，恢复「可视化分析」闭环
- [x] **元数据导入 500**：`meta_changelog.resource_id` 从 VARCHAR(50) 扩至 270，解决长物理表名（如 `replication_asynchronous_connection_failover_managed`）写入失败
- [x] **changelog 污染主事务**：变更日志写入改用 savepoint，日志失败不再拖垮表结构保存
- [x] **sql_error 修复预算**：调至 5 次，提升 SQL 自修复成功率

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `56cf6a0` | feat(chatbi): 数据门户体验升级与可视化分析闭环修复 |
| `4c48297` | feat(portal): 表级推荐提问 API 与门户交互优化，统一开发平台菜单命名 |
| `9a46e40` | feat(chatbi): 优化澄清回复，围绕用户原问生成建议并说明触发原因 |
| `50ee320` | feat(portal): 一数据集一场景、我常问删除与门户移动端交互优化 |
| `071962f` | fix(metadata): 扩展变更日志 resource_id 长度并隔离写入失败 |

---

## 测试覆盖 (Testing)

- [ ] **UI 兼容性**: 嵌入页门户抽屉（桌面/移动）、AgentDebug 流内门户、数据源复制按钮
- [ ] **核心功能**:
  - 打开 `/dataset_menu` → 场景卡片加载 / 刷新 / fallback 二次拉取
  - 点击推荐问题 → 记录常问 → × 删除常问
  - 表字典「推荐提问」→ 独立 API 返回 quick 按钮
  - ChatBI 澄清场景 → 回复含原因说明与 contextual quick
  - 元数据导入保存长表名表结构（需先执行 V79 迁移）
- [ ] **回归测试**: ChatBI 正常查数、图表渲染、权限与数据集菜单生成

> [!IMPORTANT]
> 提交前请务必确认已更新 `tests/CHECKLIST.md` 中的自动化测试清单。

**已有自动化测试（本 PR 涉及）：**
- `tests/ai/test_data_query_prompts.py` — 澄清兜底
- `tests/services/test_dataset_navigation_service.py` — 一数据集一场景、常问清除
- `tests/api/v1/test_chat_recommend_table_questions.py` — 表级推荐提问 API
- `tests/ai/runners/test_data_agent_runner.py` — runner 相关
- `frontend/scripts/chartRenderer.test.ts` — 图表渲染

---

## 其他备注 (Notes)

### 数据库迁移（必须）

部署后请执行：

```sql
-- db-prod/V79-expand_meta_changelog_resource_id.sql
ALTER TABLE `meta_changelog`
    MODIFY COLUMN `resource_id` VARCHAR(270) NOT NULL COMMENT '资源ID';
```

未执行前，导入/保存**物理表名较长**的元数据仍可能 500。

### Redis 缓存

数据门户导航缓存 key 版本 **v3 → v4**，部署后首次打开会重新生成门户 Markdown（约 15–30s），属预期行为。

### 行为变化说明

| 项 | 528d43c 时 | 本 PR |
|----|-----------|--------|
| 场景卡片 | 多数据集合并为固定业务场景类型 | **一数据集一张卡** |
| 卡片配色 | 标题关键词匹配（易同色） | **按数据集 id 哈希** |
| 门户入口（EmbedChat） | 聊天流内插消息 | **右侧抽屉**（主路径） |

### 主要改动文件

- 后端：`dataset_navigation_service.py`、`prompts.py`、`data_agent_runner.py`、`chat.py`、`changelog_service.py`
- 前端：`DatasetCapabilityMenu.vue`、`EmbedChat.vue`、`DataSourceManagement.vue`、`chartRenderer.ts`
- 迁移：`db-prod/V79-expand_meta_changelog_resource_id.sql`
