### PR TITLE
Pull Request: ChatBI 查数稳定性、数据门户体验与 LLM 网关兼容

### DIFF
--- a/app/api/v1/endpoints/chat.py
+++ b/app/api/v1/endpoints/chat.py
@@ -98,6 +98,16 @@ class DatasetNavigationResponse(BaseModel):
     groups: List[Dict[str, Any]] = Field(default_factory=list, description="按标签分组的数据集导航")
     markdown: str = Field(..., description="含 quick 按钮的 Markdown 导航内容")
     is_fallback: bool = Field(..., description="标记当前是否是降级到兜底模板的数据")
+    has_datasets: bool = Field(default=True, description="当前用户是否有可用数据集")
+    from_cache: bool = Field(default=False, description="本次结果是否来自缓存")
+    llm_generation_failed: bool = Field(
+        default=False,
+        description="本次生成是否因 LLM 调用失败而降级到兜底模板",
+    )
+    llm_error_message: Optional[str] = Field(
+        default=None,
+        description="LLM 生成失败时的简要错误信息（供前端提示）",
+    )
 
 
 class DatasetMenuClickRequest(BaseModel):

--- a/app/api/v1/endpoints/chat.py
+++ b/app/api/v1/endpoints/chat.py
@@ -169,7 +169,7 @@ async def get_greeting():
     "/dataset-menu",
     response_model=StandardResponse[DatasetNavigationResponse],
     summary="获取我的数据门户",
-    description="基于当前用户授权的 {dataset_menu} 目录，由 LLM 生成我的数据门户与 quick 追问建议，供 /dataset_menu 系统指令使用。",
+    description="基于当前用户授权的 {dataset_menu} 目录，由 LLM 生成我的数据门户与 quick 追问建议，供 /dataset_portal 系统指令使用。",
 )
 async def get_dataset_menu_navigation(
     refresh: bool = False,
@@ -194,7 +194,7 @@ async def get_dataset_menu_navigation(
     "/dataset-menu/click",
     response_model=StandardResponse[Dict[str, bool]],
     summary="记录我的数据门户点击偏好",
-    description="记录用户在 /dataset_menu 中点击的 quick 问题，用于同一数据目录下的个性化排序。",
+    description="记录用户在 /dataset_portal 中点击的 quick 问题，用于同一数据目录下的个性化排序。",
 )
 async def record_dataset_menu_question_click(
     request: DatasetMenuClickRequest,

--- a/app/services/ai/agent_service.py
+++ b/app/services/ai/agent_service.py
@@ -860,6 +860,7 @@ class AgentService:
 
             model_name = getattr(agent_config, "model_name", None) if agent_config else None
             yield {
+                "type": "error",
                 "content": format_execution_error(str(e), model_name=model_name),
                 "status": "error",
             }

--- a/app/services/ai/chatbi_sql_user_messages.py
+++ b/app/services/ai/chatbi_sql_user_messages.py
@@ -1,0 +1,206 @@
+"""将 ChatBI SQL 工具层错误映射为用户可见文案。
+
+仅用于 SSE 正文与终态 Guard；repair 提示、Agent 对话历史仍使用工具原始返回，
+避免影响模型理解与自动修正。
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+GENERIC_SQL_ERROR_CONTENT = (
+    "数据查询遇到了一些技术问题，暂时无法获取结果。\n\n"
+    "💡 **建议您可以尝试**：\n"
+    "1. 稍微修改提问的表述，避免过于复杂的交叉分析或含糊的口径。\n"
+    "2. 若多次尝试依然失败，可能是底层服务正在维护，请稍后重试或联系管理员。"
+)
+
+
+@dataclass(frozen=True)
+class SqlUserErrorPresentation:
+    title: str
+    content: str
+    specific: bool = True
+
+
+def map_sql_tool_error_for_user(raw: str) -> SqlUserErrorPresentation:
+    text = str(raw or "").strip()
+    if not text:
+        return SqlUserErrorPresentation(
+            title="数据查询失败",
+            content=GENERIC_SQL_ERROR_CONTENT,
+            specific=False,
+        )
+
+    if text.startswith("[Permission Denied]"):
+        return _map_permission_denied(text)
+
+    if text.startswith("[Security Error]"):
+        return SqlUserErrorPresentation(
+            title="数据权限处理失败",
+            content=(
+                "⚠️ 系统在应用行级数据权限时遇到问题，本次查数已终止。\n"
+                "请稍后重试；若问题持续，请联系管理员检查数据权限配置。"
+            ),
+        )
+
+    dataset_match = re.match(r"Error: Dataset '([^']+)' not found", text)
+    if dataset_match:
+        dataset_name = dataset_match.group(1)
+        return SqlUserErrorPresentation(
+            title="数据集不存在",
+            content=(
+                f"⚠️ 未找到名为「{dataset_name}」的数据集，本次查数已终止。\n\n"
+                "建议：\n"
+                "1. 检查数据集名称是否正确；\n"
+                "2. 先检索您有权限访问的数据集，确认名称后再查数。"
+            ),
+        )
+
+    if "[Validation Failed]" in text:
+        return _map_validation_failed(text)
+
+    text_lower = text.lower()
+    if any(
+        marker in text_lower
+        for marker in (
+            "unknown column",
+            "unknown table",
+            "syntax error",
+            "sql syntax",
+            "invalid expression",
+            "unexpected token",
+        )
+    ):
+        return SqlUserErrorPresentation(
+            title="SQL 语法或字段问题",
+            content=(
+                "⚠️ 生成的 SQL 存在语法、字段或表引用问题，暂时无法执行。\n\n"
+                "建议：简化提问、补充更明确的表名/字段名，或换一种表述后重试。"
+            ),
+        )
+
+    if any(
+        marker in text_lower
+        for marker in ("access denied", "permission denied", "unauthorized")
+    ):
+        return SqlUserErrorPresentation(
+            title="数据访问被拒绝",
+            content=(
+                "⚠️ 数据权限校验未通过，本次查数已终止。\n"
+                "请确认数据集与表的访问权限，或联系管理员。"
+            ),
+        )
+
+    return SqlUserErrorPresentation(
+        title="数据查询失败",
+        content=GENERIC_SQL_ERROR_CONTENT,
+        specific=False,
+    )
+
+
+def _map_permission_denied(text: str) -> SqlUserErrorPresentation:
+    if "缺少用户身份" in text:
+        return SqlUserErrorPresentation(
+            title="无法校验数据权限",
+            content=(
+                "⚠️ 当前会话无法确认您的身份，数据权限校验未通过，本次查数已终止。\n"
+                "请重新登录或联系管理员。"
+            ),
+        )
+
+    table_match = re.search(r"无权访问表\s*'([^']+)'", text)
+    if table_match:
+        table_name = table_match.group(1)
+        return SqlUserErrorPresentation(
+            title="无权访问数据表",
+            content=(
+                f"⚠️ 您没有访问数据表「{table_name}」的权限，本次查数已终止。\n\n"
+                "建议：\n"
+                "1. 确认是否选对了数据集；\n"
+                "2. 联系管理员申请该表的访问权限后重试。"
+            ),
+        )
+
+    return SqlUserErrorPresentation(
+        title="数据访问被拒绝",
+        content=(
+            "⚠️ 数据权限校验未通过，本次查数已终止。\n"
+            "请确认数据集与表的访问权限，或联系管理员。"
+        ),
+    )
+
+
+def _map_validation_failed(text: str) -> SqlUserErrorPresentation:
+    if "未在元数据中注册" in text or ("物理表" in text and "不存在" in text):
+        table_match = re.search(r"物理表\s*'([^']+)'", text)
+        table_name = table_match.group(1) if table_match else "指定表"
+        return SqlUserErrorPresentation(
+            title="数据表不存在",
+            content=(
+                f"⚠️ 数据表「{table_name}」未在元数据中注册或不存在，无法继续查询。\n\n"
+                "建议：先检索数据集定义，使用返回的物理表名（table_name）再查数。"
+            ),
+        )
+
+    term_match = re.search(r"'([^']+)'\s*是业务术语", text)
+    if term_match:
+        term = term_match.group(1)
+        physical_match = re.search(r"物理表名\s*'([^']+)'", text)
+        physical_hint = (
+            f"请改用物理表名「{physical_match.group(1)}」。"
+            if physical_match
+            else "请改用数据集定义中的物理表名（table_name）。"
+        )
+        return SqlUserErrorPresentation(
+            title="请使用物理表名",
+            content=(
+                f"⚠️ 「{term}」是业务术语，不能直接写在 SQL 的 FROM/JOIN 中。{physical_hint}\n\n"
+                "建议：重新检索数据集定义后再查数。"
+            ),
+        )
+
+    dataset_name_match = re.search(r"'([^']+)'\s*是数据集名称", text)
+    if dataset_name_match:
+        name = dataset_name_match.group(1)
+        return SqlUserErrorPresentation(
+            title="请勿将数据集名当作表名",
+            content=(
+                f"⚠️ 「{name}」是数据集名称，不能用于 SQL 的 FROM/JOIN。\n\n"
+                "建议：检索数据集定义后，使用其中的物理表名查询。"
+            ),
+        )
+
+    cross_dataset_match = re.search(
+        r"表\s*'([^']+)'\s*不属于当前指定的数据集\s*'([^']+)'",
+        text,
+    )
+    if cross_dataset_match:
+        table_name, dataset_name = cross_dataset_match.groups()
+        return SqlUserErrorPresentation(
+            title="表与数据集不匹配",
+            content=(
+                f"⚠️ 表「{table_name}」不属于数据集「{dataset_name}」，"
+                "无法跨数据集或凭空猜表查询。\n\n"
+                "建议：重新检索该数据集下的可用表名后再查数。"
+            ),
+        )
+
+    if "SQL语法错误" in text:
+        return SqlUserErrorPresentation(
+            title="SQL 语法问题",
+            content=(
+                "⚠️ 生成的 SQL 存在语法或结构问题，暂时无法执行。\n\n"
+                "建议：简化提问或换一种表述；系统也会尝试自动修正。"
+            ),
+        )
+
+    return SqlUserErrorPresentation(
+        title="SQL 校验未通过",
+        content=(
+            "⚠️ 本次 SQL 未通过平台校验（表名、数据集范围或语法可能不正确）。\n\n"
+            "建议：补充更明确的表名/指标口径，或让系统重新检索数据集定义后再查数。"
+        ),
+    )

--- a/app/services/ai/data_query_turn_classifier.py
+++ b/app/services/ai/data_query_turn_classifier.py
@@ -22,7 +22,7 @@ from app.services.ai.intent_service import (
     looks_like_skill_execution,
 )
 from app.services.ai.runtime.agentscope.chat import chat_client_from_handle
-from app.services.ai.runtime.agentscope.messages import RuntimeContentBlock, RuntimeMessage
+from app.services.ai.runtime.agentscope.messages import system_user_prompt_messages
 from app.services.ai.turn_classifier import (
     load_last_data_result,
 )
@@ -358,12 +358,7 @@ JSON 格式：
         llm = await AgentConfigProvider.get_configured_llm(streaming=False)
         chat_client = chat_client_from_handle(llm)
         content = await chat_client.generate_text(
-            [
-                RuntimeMessage(
-                    role="system",
-                    content=[RuntimeContentBlock(type="text", text=prompt)],
-                )
-            ]
+            system_user_prompt_messages(prompt, user_prompt=user_query)
         )
         data = _parse_llm_json(content)
         raw_turn_type = str(data.get("turn_type") or "").strip()

--- a/app/services/ai/executors/prompts.py
+++ b/app/services/ai/executors/prompts.py
@@ -48,6 +48,19 @@ class SharedPrompts:
     )
 
 
+DATASET_PORTAL_SLASH_COMMAND = "/dataset_portal"
+DATASET_PORTAL_LEGACY_SLASH_COMMAND = "/dataset_menu"
+
+
+def is_dataset_portal_slash_query(query: str) -> bool:
+    q = str(query or "").strip()
+    return (
+        q in (DATASET_PORTAL_SLASH_COMMAND, DATASET_PORTAL_LEGACY_SLASH_COMMAND)
+        or DATASET_PORTAL_SLASH_COMMAND in q
+        or DATASET_PORTAL_LEGACY_SLASH_COMMAND in q
+    )
+
+
 class DataQueryPrompts:
     """DataQueryExecutor 使用的系统级提示词。"""
 
@@ -179,7 +192,7 @@ class DataQueryPrompts:
     def dataset_navigation_generation_prompt(dataset_menu: str) -> str:
         return f"""你是 ChatBI 我的数据门户生成模块。
 
-用户执行了 `/dataset_menu` 指令，希望了解当前账号**有权访问**哪些数据、能问什么问题。
+用户执行了 `{DATASET_PORTAL_SLASH_COMMAND}` 指令，希望了解当前账号**有权访问**哪些数据、能问什么问题。
 下方【可用数据集目录】与 ChatBI 智能体 system prompt 中的 `{{dataset_menu}}` **完全一致**，请仅基于其中信息生成导航，不要编造未列出的数据集、表或指标。
 
 任务：
@@ -204,7 +217,7 @@ class DataQueryPrompts:
 - 以 `### 📚 我的数据门户` 开头，用 `---` 分隔区块。
 - 整体概要与每个场景介绍必须使用引用块（`>` 开头）。
 - quick 示例问题必须使用列表项格式：`- [🙋 简短标签](quick:完整可发送问题)`。
-- 文末必须包含 `### 💬 您可能还想了解`，其中至少包含一行列表项：`- [🙋 重新查看数据门户](quick:/dataset_menu)`。
+- 文末必须包含 `### 💬 您可能还想了解`，其中至少包含一行列表项：`- [🙋 重新查看数据门户](quick:{DATASET_PORTAL_SLASH_COMMAND})`。
 - “继续追问”属于每张业务场景卡片内部；全局“您可能还想了解”区块必须放在整段回答最末尾。
 - 不要编造目录中未出现的具体数值、表名或指标名。
 
@@ -601,10 +614,10 @@ class DataQueryPrompts:
             return (
                 "### 📚 我的数据门户\n"
                 "---\n"
-                "> 当前账号暂无可查询的数据集。请联系管理员开通数据权限后，再使用 `/dataset_menu` 查看导航。\n\n"
+                "> 当前账号暂无可查询的数据集。请联系管理员开通数据权限后，再使用 `{DATASET_PORTAL_SLASH_COMMAND}` 查看导航。\n\n"
                 "### 💬 您可能还想了解\n"
                 "---\n"
-                f"{cls.quick_button('重新查看数据门户', '/dataset_menu')}\n"
+                f"{cls.quick_button('重新查看数据门户', DATASET_PORTAL_SLASH_COMMAND)}\n"
             )
 
         blocks = cls._parse_dataset_blocks(menu)
@@ -626,7 +639,7 @@ class DataQueryPrompts:
                 [
                     "### 💬 您可能还想了解",
                     "---",
-                    cls.quick_button("重新查看数据门户", "/dataset_menu"),
+                    cls.quick_button("重新查看数据门户", DATASET_PORTAL_SLASH_COMMAND),
                     "",
                 ]
             )
@@ -646,7 +659,7 @@ class DataQueryPrompts:
             "您可以直接用自然语言提问，或点击下方按钮重试。\n\n"
             "### 💬 您可能还想了解\n"
             "---\n"
-            f"{cls.quick_button('重新查看数据门户', '/dataset_menu')}\n"
+            f"{cls.quick_button('重新查看数据门户', DATASET_PORTAL_SLASH_COMMAND)}\n"
         )
 
     @staticmethod
@@ -911,11 +924,11 @@ class DataQueryPrompts:
         if cls._looks_like_greeting_or_capability_question(q, reasoning_text):
             add("查询本月业务指标趋势", "查询本月核心业务指标趋势")
             add("统计最近一周关键记录", "统计最近一周关键业务记录")
-            add("查看数据门户", "/dataset_menu")
+            add("查看数据门户", DATASET_PORTAL_SLASH_COMMAND)
             return variants[:3]
 
         if not q:
-            add("打开数据门户选表提问", "/dataset_menu")
+            add("打开数据门户选表提问", DATASET_PORTAL_SLASH_COMMAND)
             return variants[:3]
 
         gaps = cls._infer_clarification_gaps(q, reasoning_text)

--- a/app/services/ai/runners/data_agent_runner.py
+++ b/app/services/ai/runners/data_agent_runner.py
@@ -2680,6 +2680,13 @@ class DataAgentRunner(BaseExecutor):
                 "1. 稍微修改提问的表述，避免过于复杂的交叉分析或含糊的口径。\n"
                 "2. 若多次尝试依然失败，可能是底层服务正在维护，请稍后重试或联系管理员。"
             )
+        elif state.diagnostic_sql_pending_final:
+            content = (
+                "诊断查询已返回样本数据，但尚未完成最终业务 SQL 复核，暂时无法生成结论。\n\n"
+                "💡 **建议您可以尝试**：\n"
+                "1. 稍微调整筛选条件或时间范围后重新提问。\n"
+                "2. 若问题较复杂，可拆成更具体的单指标/单表问题。"
+            )
         elif state.empty_sql_result:
             content = (
                 "抱歉，系统在当前数据集中未查询到符合条件的数据。\n\n"
@@ -2709,8 +2716,6 @@ class DataAgentRunner(BaseExecutor):
                 "1. 重新检查提问中涉及的时间字段方向、时区或单位定义。\n"
                 "2. 重新核对提问内容并以简化的表述重新提问。"
             )
-        elif state.diagnostic_sql_pending_final:
-            content = "诊断查询已完成，但未能成功获取到最终的结论数据，请尝试重新提问。"
         elif state.tool_loop_fuse_triggered:
             content = f"检测到工具调用出现循环，已被系统安全中止。{state.tool_loop_fuse_reason}"
         else:
@@ -3368,8 +3373,15 @@ class DataAgentRunner(BaseExecutor):
         state.empty_sql_reason = ""
         state.empty_sql_result = False
         if is_diag and state.expecting_final_sql_after_diagnostic:
-            state.diagnostic_sql_pending_final = True
-            return parsed_output, False
+            if (
+                state.diagnostic_sql_pending_final
+                and self._result_has_data_rows(parsed_output)
+            ):
+                state.expecting_final_sql_after_diagnostic = False
+                state.diagnostic_sql_pending_final = False
+            else:
+                state.diagnostic_sql_pending_final = True
+                return parsed_output, False
 
         state.expecting_final_sql_after_diagnostic = False
         state.diagnostic_sql_pending_final = False
@@ -3433,16 +3445,6 @@ class DataAgentRunner(BaseExecutor):
         # 3. 包含 COUNT 查询且没有 GROUP BY (即只查表行数)
         if "COUNT(" in sql_upper and "GROUP BY" not in sql_upper:
             return True
-        # 4. 包含小 LIMIT 限制 (小于等于 10) 的自由采样数据
-        import re
-        match = re.search(r"LIMIT\s+(\d+)", sql_upper)
-        if match:
-            try:
-                limit_val = int(match.group(1))
-                if limit_val <= 10:
-                    return True
-            except Exception:
-                pass
         return False
 
     @staticmethod
@@ -3512,13 +3514,21 @@ class DataAgentRunner(BaseExecutor):
                 row_lists.extend(self._extract_result_row_lists(value, depth + 1))
         return row_lists
 
+    def _result_has_data_rows(self, parsed: Any) -> bool:
+        row_lists = self._extract_result_row_lists(parsed)
+        return bool(row_lists and any(len(rows) > 0 for rows in row_lists))
+
     def _detect_empty_result(self, parsed: Any) -> str | None:
         row_lists = self._extract_result_row_lists(parsed)
         if row_lists and not any(len(rows) > 0 for rows in row_lists):
             return "SQL 返回的行容器为空，未命中任何数据行"
         if isinstance(parsed, dict):
             total_like_keys = ("total", "count", "total_count")
-            if any(parsed.get(k) == 0 for k in total_like_keys) and row_lists:
+            if (
+                any(parsed.get(k) == 0 for k in total_like_keys)
+                and row_lists
+                and not self._result_has_data_rows(parsed)
+            ):
                 return "SQL 返回 total/count=0，且未命中任何数据行"
         return None
 

--- a/app/services/ai/runners/data_agent_runner.py
+++ b/app/services/ai/runners/data_agent_runner.py
@@ -28,6 +28,7 @@ from app.services.ai.executors.common import (
     extract_tokens_from_message,
     normalize_messages_for_llm,
 )
+from app.services.ai.chatbi_sql_user_messages import map_sql_tool_error_for_user
 from app.services.ai.executors.prompts import DataQueryPrompts
 from app.services.ai.time_anchor import build_data_query_time_anchor_block
 from app.services.ai.multimodal_support import (
@@ -176,6 +177,7 @@ class _DataRunState:
     sql_error_message: str = ""
     sql_fatal_error: bool = False
     sql_fatal_message: str = ""
+    sql_fatal_emitted: bool = False
     sql_static_risk: bool = False
     sql_static_risk_reason: str = ""
     sql_repeat_gate_block: bool = False
@@ -1357,6 +1359,8 @@ class DataAgentRunner(BaseExecutor):
                     yield chunk
                 return
             if state.sql_fatal_error:
+                async for chunk in self._yield_sql_fatal_abort(state):
+                    yield chunk
                 return
             if state.full_content and self._current_repair_kind(state):
                 async for chunk in self._retract_provisional_content_before_repair(
@@ -1403,6 +1407,21 @@ class DataAgentRunner(BaseExecutor):
                         state=agent.state,
                     )
                 return
+
+        if state.sql_fatal_error:
+            async for chunk in self._yield_sql_fatal_abort(state):
+                yield chunk
+            if self.conversation_id and not interrupted:
+                await agent_state_store.save(
+                    user_id=self._runtime_user_id(),
+                    conversation_id=self.conversation_id,
+                    agent_name=agent_name,
+                    agent_version=self.config.agent_version,
+                    tools_fingerprint=tools_fingerprint,
+                    model_name=str(model_name) if model_name else None,
+                    state=agent.state,
+                )
+            return
 
         async for chunk in self._emit_final_guard(state):
             yield chunk
@@ -2545,17 +2564,8 @@ class DataAgentRunner(BaseExecutor):
                     return
             if state.sql_fatal_error:
                 logger.info("[DataAgentRunner] Fatal SQL error detected during ReAct. Terminating execution immediately.")
-                yield {
-                    "type": "log",
-                    "id": f"fatal_sql_{uuid.uuid4().hex[:8]}",
-                    "title": "SQL 执行致命错误",
-                    "details": state.sql_fatal_message,
-                    "status": "error",
-                }
-                yield {
-                    "content": f"数据查询发生致命错误，已终止：\n\n{state.sql_fatal_message}",
-                    "status": "error",
-                }
+                async for chunk in self._yield_sql_fatal_abort(state):
+                    yield chunk
                 return
             if state.halt_current_react:
                 logger.info("[DataAgentRunner] SQL result requires repair. Stopping current ReAct stream.")
@@ -2620,6 +2630,27 @@ class DataAgentRunner(BaseExecutor):
             DataQueryPrompts.SCHEMA_SERVICE_UNAVAILABLE_CONTENT,
         )
 
+    async def _yield_sql_fatal_abort(
+        self,
+        state: _DataRunState,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        if state.sql_fatal_emitted:
+            return
+        presentation = map_sql_tool_error_for_user(state.sql_fatal_message)
+        state.sql_fatal_emitted = True
+        yield {
+            "type": "log",
+            "id": f"fatal_sql_{uuid.uuid4().hex[:8]}",
+            "title": presentation.title,
+            "details": truncate_for_context(str(state.sql_fatal_message or ""), max_len=1000)
+            or presentation.title,
+            "status": "error",
+        }
+        yield {
+            "content": presentation.content,
+            "status": "error",
+        }
+
     async def _yield_schema_fatal_abort(
         self,
         state: _DataRunState,
@@ -2674,12 +2705,9 @@ class DataAgentRunner(BaseExecutor):
         elif state.sql_before_schema:
             content = "为保证数据准确性，请先检索数据集定义后再执行数据查询。"
         elif state.sql_error:
-            content = (
-                "数据查询遇到了一些技术问题，暂时无法获取结果。\n\n"
-                "💡 **建议您可以尝试**：\n"
-                "1. 稍微修改提问的表述，避免过于复杂的交叉分析或含糊的口径。\n"
-                "2. 若多次尝试依然失败，可能是底层服务正在维护，请稍后重试或联系管理员。"
-            )
+            error_text = (state.last_sql_error_summary or state.sql_error_message or "").strip()
+            presentation = map_sql_tool_error_for_user(error_text)
+            content = presentation.content
         elif state.diagnostic_sql_pending_final:
             content = (
                 "诊断查询已返回样本数据，但尚未完成最终业务 SQL 复核，暂时无法生成结论。\n\n"

--- a/app/services/ai/runners/data_agent_runner.py
+++ b/app/services/ai/runners/data_agent_runner.py
@@ -39,7 +39,7 @@ from app.services.ai.runtime.agentscope.chat import (
     compat_to_runtime_messages,
     to_agentscope_messages,
 )
-from app.services.ai.runtime.agentscope.messages import RuntimeContentBlock, RuntimeMessage
+from app.services.ai.runtime.agentscope.messages import RuntimeContentBlock, RuntimeMessage, system_user_prompt_messages
 from app.services.ai.runtime.agentscope.agent_runtime import (
     build_model_config,
     build_tools_fingerprint,
@@ -1852,21 +1852,14 @@ class DataAgentRunner(BaseExecutor):
             )
             chat_client = chat_client_from_handle(llm)
             content = await chat_client.generate_text(
-                [
-                    RuntimeMessage(
-                        role="system",
-                        content=[
-                            RuntimeContentBlock(
-                                type="text",
-                                text=DataQueryPrompts.clarification_generation_prompt(
-                                    user_question,
-                                    reasoning,
-                                    history_excerpt,
-                                ),
-                            )
-                        ],
-                    )
-                ]
+                system_user_prompt_messages(
+                    DataQueryPrompts.clarification_generation_prompt(
+                        user_question,
+                        reasoning,
+                        history_excerpt,
+                    ),
+                    user_prompt=user_question,
+                )
             )
             cleaned = str(content or "").strip()
             if cleaned and DataQueryPrompts.has_quick_suggestions(cleaned):

--- a/app/services/ai/runtime/agentscope/messages.py
+++ b/app/services/ai/runtime/agentscope/messages.py
@@ -41,6 +41,26 @@ def _attachment_blocks(message: dict[str, Any]) -> list[RuntimeContentBlock]:
     return blocks
 
 
+DEFAULT_LLM_USER_PROMPT = "请严格按上述要求生成内容。"
+
+
+def system_user_prompt_messages(
+    system_prompt: str,
+    user_prompt: str = DEFAULT_LLM_USER_PROMPT,
+) -> list[RuntimeMessage]:
+    """Build system+user messages for gateways that require a user turn (e.g. Qwen on ds-api)."""
+    return [
+        RuntimeMessage(
+            role="system",
+            content=[RuntimeContentBlock(type="text", text=system_prompt)],
+        ),
+        RuntimeMessage(
+            role="user",
+            content=[RuntimeContentBlock(type="text", text=user_prompt)],
+        ),
+    ]
+
+
 def convert_history_to_runtime_messages(history: list[dict[str, Any]]) -> list[RuntimeMessage]:
     messages: list[RuntimeMessage] = []
     for item in history:

--- a/app/services/dataset_navigation_service.py
+++ b/app/services/dataset_navigation_service.py
@@ -113,11 +113,18 @@ class DatasetNavigationService:
             logger.warning("Dataset navigation cache write failed: %s", e)
 
     @staticmethod
-    async def _generate_navigation_markdown(dataset_menu: str) -> str:
+    async def _generate_navigation_markdown(dataset_menu: str) -> tuple[str, str | None]:
         if not menu_has_authorized_datasets(dataset_menu):
-            return DataQueryPrompts.build_dataset_navigation_fallback(dataset_menu)
+            return (
+                finalize_visible_reply(
+                    DataQueryPrompts.build_dataset_navigation_fallback(dataset_menu),
+                    collapse_duplicates=False,
+                ),
+                None,
+            )
 
         fallback = DataQueryPrompts.build_dataset_navigation_fallback(dataset_menu)
+        fallback_md = finalize_visible_reply(fallback, collapse_duplicates=False)
         try:
             llm = await AgentConfigProvider.get_configured_llm(streaming=False)
             chat_client = chat_client_from_handle(llm)
@@ -129,10 +136,12 @@ class DatasetNavigationService:
             )
             cleaned = str(content or "").strip()
             if cleaned and DataQueryPrompts.has_quick_suggestions(cleaned):
-                return finalize_visible_reply(cleaned, collapse_duplicates=False)
+                return finalize_visible_reply(cleaned, collapse_duplicates=False), None
+            return fallback_md, "模型返回内容无效或未包含推荐问题"
         except Exception as e:
             logger.warning("Dataset navigation LLM generation failed: %s", e)
-        return finalize_visible_reply(fallback, collapse_duplicates=False)
+            err = str(e).strip() or "模型调用失败"
+            return fallback_md, err[:240]
 
     @staticmethod
     def _click_rank_key(*, user_key: str, dataset_menu_hash: str) -> str:
@@ -493,14 +502,21 @@ class DatasetNavigationService:
                 "is_fallback": False,
                 "has_datasets": False,
                 "from_cache": False,
+                "llm_generation_failed": False,
+                "llm_error_message": None,
             }
 
         from_cache = False
+        llm_generation_failed = False
+        llm_error_message: str | None = None
         markdown = None if force_refresh else await DatasetNavigationService._load_cached_navigation(cache_key)
         if markdown:
             from_cache = True
         if not markdown:
-            markdown = await DatasetNavigationService._generate_navigation_markdown(dataset_menu)
+            markdown, llm_err = await DatasetNavigationService._generate_navigation_markdown(dataset_menu)
+            if llm_err:
+                llm_generation_failed = True
+                llm_error_message = llm_err
             
             # 检测是否因大模型报错或生成失败而降级到了兜底模板
             fallback_raw = DataQueryPrompts.build_dataset_navigation_fallback(dataset_menu)
@@ -571,6 +587,8 @@ class DatasetNavigationService:
             "is_fallback": is_fallback,
             "has_datasets": has_datasets,
             "from_cache": from_cache,
+            "llm_generation_failed": llm_generation_failed,
+            "llm_error_message": llm_error_message,
         }
 
     @staticmethod

--- a/app/services/dataset_navigation_service.py
+++ b/app/services/dataset_navigation_service.py
@@ -486,6 +486,22 @@ class DatasetNavigationService:
         )
         has_datasets = menu_has_authorized_datasets(dataset_menu)
 
+        if not has_datasets:
+            markdown = finalize_visible_reply(
+                DataQueryPrompts.build_dataset_navigation_fallback(dataset_menu),
+                collapse_duplicates=False,
+            )
+            return {
+                "dataset_count": 0,
+                "dataset_menu_hash": menu_hash,
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "groups": [],
+                "markdown": markdown,
+                "is_fallback": False,
+                "has_datasets": False,
+                "from_cache": False,
+            }
+
         from_cache = False
         markdown = None if force_refresh else await DatasetNavigationService._load_cached_navigation(cache_key)
         if markdown:

--- a/app/services/dataset_navigation_service.py
+++ b/app/services/dataset_navigation_service.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.redis import get_redis
 from app.services.ai.config import AgentConfigProvider
-from app.services.ai.executors.prompts import DataQueryPrompts
+from app.services.ai.executors.prompts import DataQueryPrompts, is_dataset_portal_slash_query
 from app.services.ai.runtime.agentscope.chat import chat_client_from_handle
 from app.services.ai.runtime.agentscope.messages import system_user_prompt_messages
 from app.services.ai.runtime.agentscope.stream_reconcile import finalize_visible_reply
@@ -20,7 +20,7 @@ from app.services.ai.runtime.agentscope.stream_reconcile import finalize_visible
 logger = logging.getLogger(__name__)
 
 _NAV_CACHE_TTL_SECONDS = 600
-_NAV_PROMPT_VERSION = "v4"
+_NAV_PROMPT_VERSION = "v5"
 _NAV_CACHE_GEN_KEY = "agent:dataset_navigation:cache_generation"
 _CLICK_STATS_TTL_SECONDS = 90 * 24 * 60 * 60
 
@@ -379,7 +379,7 @@ class DatasetNavigationService:
             for match in re.finditer(pattern, questions_part):
                 label = match.group(1).strip()
                 query = match.group(2).strip()
-                if "/dataset_menu" in query or "重新查看" in label:
+                if is_dataset_portal_slash_query(query) or "重新查看" in label:
                     continue
                 dynamic_questions.append({
                     "label": label,
@@ -391,7 +391,7 @@ class DatasetNavigationService:
             for match in re.finditer(pattern, followups_part):
                 label = match.group(1).strip()
                 query = match.group(2).strip()
-                if "/dataset_menu" in query or "重新查看" in label:
+                if is_dataset_portal_slash_query(query) or "重新查看" in label:
                     continue
                 dynamic_followups.append({
                     "label": label,
@@ -635,7 +635,7 @@ class DatasetNavigationService:
         for match in re.finditer(pattern, cleaned):
             label = match.group(1).strip()
             query = match.group(2).strip()
-            if "/dataset_menu" in query or "重新查看" in label:
+            if is_dataset_portal_slash_query(query) or "重新查看" in label:
                 continue
             questions.append({
                 "label": label,

--- a/app/services/dataset_navigation_service.py
+++ b/app/services/dataset_navigation_service.py
@@ -14,7 +14,7 @@ from app.core.redis import get_redis
 from app.services.ai.config import AgentConfigProvider
 from app.services.ai.executors.prompts import DataQueryPrompts
 from app.services.ai.runtime.agentscope.chat import chat_client_from_handle
-from app.services.ai.runtime.agentscope.messages import RuntimeContentBlock, RuntimeMessage
+from app.services.ai.runtime.agentscope.messages import system_user_prompt_messages
 from app.services.ai.runtime.agentscope.stream_reconcile import finalize_visible_reply
 
 logger = logging.getLogger(__name__)
@@ -122,17 +122,10 @@ class DatasetNavigationService:
             llm = await AgentConfigProvider.get_configured_llm(streaming=False)
             chat_client = chat_client_from_handle(llm)
             content = await chat_client.generate_text(
-                [
-                    RuntimeMessage(
-                        role="system",
-                        content=[
-                            RuntimeContentBlock(
-                                type="text",
-                                text=DataQueryPrompts.dataset_navigation_generation_prompt(dataset_menu),
-                            )
-                        ],
-                    )
-                ]
+                system_user_prompt_messages(
+                    DataQueryPrompts.dataset_navigation_generation_prompt(dataset_menu),
+                    user_prompt="请生成完整的数据门户 Markdown。",
+                )
             )
             cleaned = str(content or "").strip()
             if cleaned and DataQueryPrompts.has_quick_suggestions(cleaned):
@@ -639,12 +632,10 @@ class DatasetNavigationService:
             llm = await AgentConfigProvider.get_configured_llm(streaming=False)
             chat_client = chat_client_from_handle(llm)
             content = await chat_client.generate_text(
-                [
-                    RuntimeMessage(
-                        role="system",
-                        content=[RuntimeContentBlock(type="text", text=prompt)],
-                    )
-                ]
+                system_user_prompt_messages(
+                    prompt,
+                    user_prompt="请生成推荐问题。",
+                )
             )
             return DatasetNavigationService._parse_quick_questions_from_llm(content)
         except Exception as e:

--- a/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
+++ b/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
@@ -2,7 +2,7 @@
   <section ref="menuContainer" class="space-y-4">
     <!-- 状态条 -->
     <div
-      v-if="portalStatus !== 'ready' || showReadyBanner"
+      v-if="showStatusBanner"
       class="rounded-xl border px-3 py-2 text-[11px] leading-relaxed flex items-start gap-2"
       :class="statusBannerClass"
     >
@@ -59,7 +59,7 @@
     </div>
 
     <!-- Search and Filter Bar -->
-    <div class="space-y-2.5">
+    <div v-if="!isNoPermissionEmpty" class="space-y-2.5">
       <div class="relative">
         <span class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-400 dark:text-gray-500">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -742,7 +742,12 @@ const isRefreshing = ref(false);
 let refreshSafetyTimer: ReturnType<typeof setTimeout> | null = null;
 
 const showRefreshBusy = computed(() => isRefreshing.value || props.backgroundRefreshing);
-const refreshDisabled = computed(() => props.initialLoading || showRefreshBusy.value);
+const refreshDisabled = computed(
+  () =>
+    props.initialLoading
+    || showRefreshBusy.value
+    || props.payload?.has_datasets === false,
+);
 
 const clearRefreshBusy = () => {
   isRefreshing.value = false;
@@ -881,9 +886,16 @@ const countRelatedTables = (group: DatasetCapabilityGroup): number => {
 const portalStatus = computed(() => {
   if (props.initialLoading) return "loading";
   if (props.backgroundRefreshing) return "refreshing";
+  if (props.payload?.has_datasets === false) return "no_permission";
   if (props.payload?.is_fallback) return "fallback";
   return "ready";
 });
+
+const showStatusBanner = computed(
+  () =>
+    props.payload?.has_datasets !== false
+    && (portalStatus.value !== "ready" || showReadyBanner.value),
+);
 
 const formattedGeneratedAt = computed(() => {
   if (!props.payload.generated_at) return "";

--- a/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
+++ b/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
@@ -704,6 +704,8 @@ interface DatasetNavigationPayload {
   is_fallback?: boolean;
   from_cache?: boolean;
   has_datasets?: boolean;
+  llm_generation_failed?: boolean;
+  llm_error_message?: string | null;
 }
 
 const props = withDefaults(defineProps<{
@@ -887,6 +889,7 @@ const portalStatus = computed(() => {
   if (props.initialLoading) return "loading";
   if (props.backgroundRefreshing) return "refreshing";
   if (props.payload?.has_datasets === false) return "no_permission";
+  if (props.payload?.llm_generation_failed && props.payload?.is_fallback) return "llm_failed";
   if (props.payload?.is_fallback) return "fallback";
   return "ready";
 });
@@ -956,6 +959,8 @@ const statusBannerClass = computed(() => {
       return "border-blue-100 bg-blue-50/70 text-blue-700 dark:border-blue-900/40 dark:bg-blue-950/30 dark:text-blue-200";
     case "refreshing":
       return "border-blue-100 bg-blue-50/50 text-blue-600 dark:border-blue-900/40 dark:bg-blue-950/20 dark:text-blue-300";
+    case "llm_failed":
+      return "border-red-100 bg-red-50/70 text-red-800 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-200";
     case "fallback":
       return "border-amber-100 bg-amber-50/70 text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200";
     default:
@@ -965,6 +970,7 @@ const statusBannerClass = computed(() => {
 
 const statusBannerIcon = computed(() => {
   if (portalStatus.value === "fallback") return "⚠️";
+  if (portalStatus.value === "llm_failed") return "⚠️";
   if (portalStatus.value === "ready") return "✓";
   return "…";
 });
@@ -978,8 +984,13 @@ const statusBannerText = computed(() => {
       return "正在生成数据门户，首次加载约需 15–30 秒，请稍候…";
     case "refreshing":
       return "正在后台刷新完整门户内容…";
+    case "llm_failed": {
+      const detail = String(props.payload.llm_error_message || "").trim();
+      const suffix = detail ? `（${detail}）` : "";
+      return `AI 模型暂不可用，已展示基础场景目录${suffix}。请检查模型配置与网络，或点击右上角刷新重试。`;
+    }
     case "fallback":
-      return "当前为基础场景目录，完整 AI 场景卡片正在后台生成，可先点击问题开始查数。";
+      return "正在生成完整 AI 场景卡片，可先点击问题开始查数。";
     default: {
       const parts = ["门户已就绪"];
       if (cacheAgeLabel.value) parts.push(cacheAgeLabel.value);

--- a/frontend/src/components/chatbi/DatasetPortalDrawer.vue
+++ b/frontend/src/components/chatbi/DatasetPortalDrawer.vue
@@ -1,132 +1,148 @@
 <template>
-  <div
-    v-show="modelValue"
-    :class="[
-      'z-50',
-      pinned && isMobile
-        ? 'fixed inset-x-0 bottom-0 max-w-full flex pointer-events-none'
-        : pinned
-          ? 'fixed inset-y-0 right-0 max-w-full flex pointer-events-none'
-          : 'fixed inset-0 overflow-hidden',
-    ]"
-  >
-    <transition
-      v-if="!pinned"
-      enter-active-class="ease-out duration-300"
-      enter-from-class="opacity-0"
-      enter-to-class="opacity-100"
-      leave-active-class="ease-in duration-200"
-      leave-from-class="opacity-100"
-      leave-to-class="opacity-0"
-    >
-      <div
-        v-show="modelValue"
-        class="absolute inset-0 bg-gray-500/30 backdrop-blur-xs transition-opacity"
-        @click="closeDrawer"
-      />
-    </transition>
-
+  <teleport to="body">
     <div
+      v-show="modelValue"
       :class="[
-        pinned
-          ? isMobile
-            ? 'w-full flex pointer-events-auto min-h-0'
-            : 'h-full flex pointer-events-auto'
-          : isMobile
-            ? 'absolute inset-x-0 bottom-0 flex justify-center min-h-0'
-            : 'absolute inset-y-0 right-0 pl-0 sm:pl-10 max-w-full flex',
+        'z-[120]',
+        pinned && isMobile
+          ? 'fixed inset-x-0 bottom-0 max-w-full flex flex-col justify-end pointer-events-none'
+          : pinned
+            ? 'fixed inset-y-0 right-0 max-w-full flex pointer-events-none'
+            : isMobile
+              ? 'fixed inset-0 flex flex-col overflow-hidden'
+              : 'fixed inset-0 overflow-hidden',
       ]"
     >
       <transition
-        enter-active-class="transform transition ease-in-out duration-300"
-        :enter-from-class="sheetEnterFrom"
-        enter-to-class="translate-x-0 translate-y-0"
-        leave-active-class="transform transition ease-in-out duration-300"
-        leave-from-class="translate-x-0 translate-y-0"
-        :leave-to-class="sheetLeaveTo"
+        v-if="!pinned"
+        enter-active-class="ease-out duration-300"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="ease-in duration-200"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
       >
         <div
           v-show="modelValue"
           :class="[
-            'bg-white dark:bg-gray-900 shadow-2xl flex flex-col relative z-10 min-h-0 pb-[env(safe-area-inset-bottom,0px)]',
-            isMobile
-              ? 'w-full max-w-none rounded-t-2xl border-t border-gray-200 dark:border-gray-800'
-              : 'w-screen max-w-[min(100vw,28rem)] h-full border-l border-gray-200 dark:border-gray-800',
-            mobileSheetHeightClass,
+            'bg-gray-500/30 backdrop-blur-xs transition-opacity',
+            isMobile ? 'flex-1 min-h-0 w-full' : 'absolute inset-0',
           ]"
+          @click="closeDrawer"
+        />
+      </transition>
+
+      <div
+        :class="[
+          pinned
+            ? isMobile
+              ? 'w-full flex pointer-events-auto min-h-0 max-h-[58%]'
+              : 'h-full flex pointer-events-auto'
+            : isMobile
+              ? 'w-full flex justify-center min-h-0 max-h-[92%] shrink-0'
+              : 'absolute inset-y-0 right-0 pl-0 sm:pl-10 max-w-full flex',
+        ]"
+      >
+        <transition
+          enter-active-class="transform transition ease-in-out duration-300"
+          :enter-from-class="sheetEnterFrom"
+          enter-to-class="translate-x-0 translate-y-0"
+          leave-active-class="transform transition ease-in-out duration-300"
+          leave-from-class="translate-x-0 translate-y-0"
+          :leave-to-class="sheetLeaveTo"
         >
-          <div class="px-4 py-3 sm:py-4 border-b border-gray-150 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/20 flex items-center justify-between gap-2 pt-[max(0.75rem,env(safe-area-inset-top,0px))]">
-            <span class="text-sm font-bold text-gray-900 dark:text-gray-100 flex items-center gap-1.5 select-none min-w-0">
-              <svg class="w-4 h-4 text-blue-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2v-4z" />
-              </svg>
-              <span class="truncate">数据门户导航</span>
-              <span
-                v-if="pinned"
-                class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wide text-blue-600 bg-blue-50 border border-blue-100 dark:text-blue-300 dark:bg-blue-500/10 dark:border-blue-500/20"
-              >
-                已钉住
+          <div
+            v-show="modelValue"
+            :class="[
+              'bg-white dark:bg-gray-900 shadow-2xl flex flex-col relative z-10 min-h-0 pb-[env(safe-area-inset-bottom,0px)]',
+              isMobile
+                ? 'w-full max-w-none rounded-t-2xl border-t border-gray-200 dark:border-gray-800 h-full max-h-full'
+                : 'w-screen max-w-[min(100vw,28rem)] h-full border-l border-gray-200 dark:border-gray-800',
+            ]"
+          >
+            <div
+              v-if="isMobile"
+              class="shrink-0 flex justify-center pt-2 pb-1"
+              aria-hidden="true"
+            >
+              <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600" />
+            </div>
+            <div
+              class="shrink-0 px-4 py-3 sm:py-4 border-b border-gray-150 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/20 flex items-center justify-between gap-2"
+            >
+              <span class="text-sm font-bold text-gray-900 dark:text-gray-100 flex items-center gap-1.5 select-none min-w-0">
+                <svg class="w-4 h-4 text-blue-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2v-4z" />
+                </svg>
+                <span class="truncate">数据门户导航</span>
+                <span
+                  v-if="pinned"
+                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wide text-blue-600 bg-blue-50 border border-blue-100 dark:text-blue-300 dark:bg-blue-500/10 dark:border-blue-500/20"
+                >
+                  已钉住
+                </span>
               </span>
-            </span>
-            <div class="flex items-center gap-2 flex-shrink-0">
-              <label
-                class="hidden sm:flex items-center gap-1.5 text-[10px] text-gray-500 dark:text-gray-400 cursor-pointer select-none whitespace-nowrap"
-                title="开启后点击问题不会关闭抽屉，可连续提问（仅桌面端生效）"
-              >
-                <input
-                  v-model="keepOpenOnQuestion"
-                  type="checkbox"
-                  class="rounded border-gray-300 text-primary focus:ring-primary/30"
-                />
-                提问后保持
-              </label>
-              <button
-                type="button"
-                class="inline-flex text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 p-1 rounded-md hover:bg-gray-150 dark:hover:bg-gray-800 transition-colors"
-                :class="{ 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10': pinned }"
-                :title="pinButtonTitle"
-                @click="pinned = !pinned"
-              >
-                <svg v-if="pinned" class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M16 12V4h1a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-1v-2h1V6h-1v6h-2zM9.707 14.707a1 1 0 0 1-1.414 0l-2.829-2.829a1 1 0 0 1 1.414-1.414L9 12.586V4h2v8.586l1.707-1.707a1 1 0 0 1 1.414 1.414l-2.829 2.829z" />
-                </svg>
-                <svg v-else class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 12V4h1a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-1v-2h1V6h-1v6h-2M9.707 14.707a1 1 0 0 1-1.414 0l-2.829-2.829a1 1 0 0 1 1.414-1.414L9 12.586V4h2v8.586l1.707-1.707a1 1 0 0 1 1.414 1.414l-2.829 2.829z" />
-                </svg>
-              </button>
-              <button
-                type="button"
-                class="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 p-1 rounded-md hover:bg-gray-150 dark:hover:bg-gray-800 transition-colors"
-                title="关闭 (Esc)"
-                @click="closeDrawer"
-              >
-                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
+              <div class="flex items-center gap-2 flex-shrink-0">
+                <label
+                  class="hidden sm:flex items-center gap-1.5 text-[10px] text-gray-500 dark:text-gray-400 cursor-pointer select-none whitespace-nowrap"
+                  title="开启后点击问题不会关闭抽屉，可连续提问（仅桌面端生效）"
+                >
+                  <input
+                    v-model="keepOpenOnQuestion"
+                    type="checkbox"
+                    class="rounded border-gray-300 text-primary focus:ring-primary/30"
+                  />
+                  提问后保持
+                </label>
+                <button
+                  type="button"
+                  class="hidden sm:inline-flex text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 p-1 rounded-md hover:bg-gray-150 dark:hover:bg-gray-800 transition-colors"
+                  :class="{ 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10': pinned }"
+                  :title="pinButtonTitle"
+                  @click="pinned = !pinned"
+                >
+                  <svg v-if="pinned" class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M16 12V4h1a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-1v-2h1V6h-1v6h-2zM9.707 14.707a1 1 0 0 1-1.414 0l-2.829-2.829a1 1 0 0 1 1.414-1.414L9 12.586V4h2v8.586l1.707-1.707a1 1 0 0 1 1.414 1.414l-2.829 2.829z" />
+                  </svg>
+                  <svg v-else class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 12V4h1a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-1v-2h1V6h-1v6h-2M9.707 14.707a1 1 0 0 1-1.414 0l-2.829-2.829a1 1 0 0 1 1.414-1.414L9 12.586V4h2v8.586l1.707-1.707a1 1 0 0 1 1.414 1.414l-2.829 2.829z" />
+                  </svg>
+                </button>
+                <button
+                  type="button"
+                  class="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 p-1.5 rounded-md hover:bg-gray-150 dark:hover:bg-gray-800 transition-colors"
+                  title="关闭 (Esc)"
+                  aria-label="关闭数据门户"
+                  @click="closeDrawer"
+                >
+                  <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="portal-drawer-scroll flex-1 overflow-y-auto overscroll-y-contain p-3 sm:p-4 bg-white dark:bg-gray-900/60 min-h-0 touch-pan-y"
+            >
+              <DatasetCapabilityMenu
+                :payload="payload || { groups: [] }"
+                :initial-loading="initialLoading"
+                :background-refreshing="backgroundRefreshing"
+                @quick-question="(query) => emit('quick-question', query)"
+                @record-question-click="(p) => emit('record-question-click', p)"
+                @clear-question-click="(p) => emit('clear-question-click', p)"
+                @refresh="emit('refresh')"
+              />
             </div>
           </div>
-          <div
-            class="portal-drawer-scroll flex-1 overflow-y-auto overscroll-y-contain p-3 sm:p-4 bg-white dark:bg-gray-900/60 min-h-0 touch-pan-y"
-          >
-            <DatasetCapabilityMenu
-              :payload="payload || { groups: [] }"
-              :initial-loading="initialLoading"
-              :background-refreshing="backgroundRefreshing"
-              @quick-question="(query) => emit('quick-question', query)"
-              @record-question-click="(p) => emit('record-question-click', p)"
-              @clear-question-click="(p) => emit('clear-question-click', p)"
-              @refresh="emit('refresh')"
-            />
-          </div>
-        </div>
-      </transition>
+        </transition>
+      </div>
     </div>
-  </div>
+  </teleport>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from "vue";
+import { ref, computed, onMounted, onUnmounted, watch } from "vue";
 import DatasetCapabilityMenu from "@/components/chatbi/DatasetCapabilityMenu.vue";
 
 const modelValue = defineModel<boolean>({ default: false });
@@ -146,17 +162,33 @@ const emit = defineEmits<{
   (event: "refresh"): void;
 }>();
 
-const isMobile = ref(false);
+const isMobile = ref(
+  typeof window !== "undefined" && window.matchMedia("(max-width: 639px)").matches,
+);
 let mobileMq: MediaQueryList | null = null;
 
 const syncMobile = () => {
   const wasMobile = isMobile.value;
   isMobile.value = !!mobileMq?.matches;
-  // 桌面钉住状态不应带到移动端；切到移动端时强制恢复遮罩抽屉模式
   if (!wasMobile && isMobile.value && pinned.value) {
     pinned.value = false;
   }
 };
+
+const setMobileBodyScrollLock = (locked: boolean) => {
+  if (!isMobile.value) return;
+  const value = locked ? "hidden" : "";
+  document.documentElement.style.overflow = value;
+  document.body.style.overflow = value;
+};
+
+watch(
+  modelValue,
+  (open) => {
+    setMobileBodyScrollLock(!!open);
+  },
+  { immediate: true },
+);
 
 onMounted(() => {
   mobileMq = window.matchMedia("(max-width: 639px)");
@@ -169,17 +201,11 @@ onMounted(() => {
 
 onUnmounted(() => {
   mobileMq?.removeEventListener("change", syncMobile);
+  setMobileBodyScrollLock(false);
 });
 
 const sheetEnterFrom = computed(() => (isMobile.value ? "translate-y-full" : "translate-x-full"));
 const sheetLeaveTo = computed(() => (isMobile.value ? "translate-y-full" : "translate-x-full"));
-
-const mobileSheetHeightClass = computed(() => {
-  if (!isMobile.value) return "";
-  return pinned.value
-    ? "h-[min(58dvh,100%)] max-h-[min(58dvh,100%)]"
-    : "h-[min(85dvh,100%)] max-h-[min(85dvh,100%)]";
-});
 
 const pinButtonTitle = computed(() => {
   if (pinned.value) {
@@ -198,5 +224,6 @@ const closeDrawer = () => {
 <style scoped>
 .portal-drawer-scroll {
   -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
 }
 </style>

--- a/frontend/src/components/chatbi/DatasetPortalDrawer.vue
+++ b/frontend/src/components/chatbi/DatasetPortalDrawer.vue
@@ -30,10 +30,10 @@
       :class="[
         pinned
           ? isMobile
-            ? 'w-full flex pointer-events-auto'
+            ? 'w-full flex pointer-events-auto min-h-0'
             : 'h-full flex pointer-events-auto'
           : isMobile
-            ? 'absolute inset-x-0 bottom-0 flex justify-center'
+            ? 'absolute inset-x-0 bottom-0 flex justify-center min-h-0'
             : 'absolute inset-y-0 right-0 pl-0 sm:pl-10 max-w-full flex',
       ]"
     >
@@ -48,12 +48,11 @@
         <div
           v-show="modelValue"
           :class="[
-            'bg-white dark:bg-gray-900 shadow-2xl flex flex-col relative z-10 pb-[env(safe-area-inset-bottom,0px)]',
+            'bg-white dark:bg-gray-900 shadow-2xl flex flex-col relative z-10 min-h-0 pb-[env(safe-area-inset-bottom,0px)]',
             isMobile
               ? 'w-full max-w-none rounded-t-2xl border-t border-gray-200 dark:border-gray-800'
               : 'w-screen max-w-[min(100vw,28rem)] h-full border-l border-gray-200 dark:border-gray-800',
-            isMobile && pinned ? 'max-h-[min(58vh,100%)]' : '',
-            isMobile && !pinned ? 'max-h-[min(85vh,100%)]' : '',
+            mobileSheetHeightClass,
           ]"
         >
           <div class="px-4 py-3 sm:py-4 border-b border-gray-150 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/20 flex items-center justify-between gap-2 pt-[max(0.75rem,env(safe-area-inset-top,0px))]">
@@ -107,7 +106,9 @@
               </button>
             </div>
           </div>
-          <div class="flex-1 overflow-y-auto p-3 sm:p-4 bg-white dark:bg-gray-900/60 min-h-0">
+          <div
+            class="portal-drawer-scroll flex-1 overflow-y-auto overscroll-y-contain p-3 sm:p-4 bg-white dark:bg-gray-900/60 min-h-0 touch-pan-y"
+          >
             <DatasetCapabilityMenu
               :payload="payload || { groups: [] }"
               :initial-loading="initialLoading"
@@ -149,12 +150,20 @@ const isMobile = ref(false);
 let mobileMq: MediaQueryList | null = null;
 
 const syncMobile = () => {
+  const wasMobile = isMobile.value;
   isMobile.value = !!mobileMq?.matches;
+  // 桌面钉住状态不应带到移动端；切到移动端时强制恢复遮罩抽屉模式
+  if (!wasMobile && isMobile.value && pinned.value) {
+    pinned.value = false;
+  }
 };
 
 onMounted(() => {
   mobileMq = window.matchMedia("(max-width: 639px)");
   syncMobile();
+  if (isMobile.value && pinned.value) {
+    pinned.value = false;
+  }
   mobileMq.addEventListener("change", syncMobile);
 });
 
@@ -164,6 +173,13 @@ onUnmounted(() => {
 
 const sheetEnterFrom = computed(() => (isMobile.value ? "translate-y-full" : "translate-x-full"));
 const sheetLeaveTo = computed(() => (isMobile.value ? "translate-y-full" : "translate-x-full"));
+
+const mobileSheetHeightClass = computed(() => {
+  if (!isMobile.value) return "";
+  return pinned.value
+    ? "h-[min(58dvh,100%)] max-h-[min(58dvh,100%)]"
+    : "h-[min(85dvh,100%)] max-h-[min(85dvh,100%)]";
+});
 
 const pinButtonTitle = computed(() => {
   if (pinned.value) {
@@ -178,3 +194,9 @@ const closeDrawer = () => {
   modelValue.value = false;
 };
 </script>
+
+<style scoped>
+.portal-drawer-scroll {
+  -webkit-overflow-scrolling: touch;
+}
+</style>

--- a/frontend/src/components/embed/ChatInput.vue
+++ b/frontend/src/components/embed/ChatInput.vue
@@ -3,6 +3,7 @@ import { ref, reactive, nextTick, computed, watch, onMounted, onUnmounted } from
 import MentionList from "@/components/agent/MentionList.vue";
 import AttachmentImageThumb from "@/components/embed/AttachmentImageThumb.vue";
 import { isImageAttachment } from "@/utils/attachmentImages";
+import { DATASET_PORTAL_SYSTEM_COMMAND_ID } from "@/constants/datasetPortalCommand";
 
 type ApprovalMode = "ask" | "allow" | "deny";
 
@@ -249,7 +250,7 @@ const handleShortcutClick = (cmd: any) => {
 const openDataPortalFromPlusMenu = () => {
     if (props.isProcessing) return;
     showPlusMenu.value = false;
-    const cmd = filteredSystemCommands.value.find((c) => c.id === 'sys_dataset_menu');
+    const cmd = filteredSystemCommands.value.find((c) => c.id === DATASET_PORTAL_SYSTEM_COMMAND_ID);
     handleShortcutClick(cmd);
 };
 
@@ -498,7 +499,7 @@ defineExpose({
                         <div v-if="!isDrawerExpanded" class="flex items-center space-x-2">
                             <div class="flex flex-1 items-center space-x-2 overflow-x-auto no-scrollbar scroll-smooth pr-12">
                                 <template v-if="windowWidth < 640">
-                                    <button v-if="filteredSystemCommands.some(c => c.id === 'sys_dataset_menu')" @click="handleShortcutClick(filteredSystemCommands.find(c => c.id === 'sys_dataset_menu'))" class="px-3 py-1 text-[10px] font-bold bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-300 border border-blue-100/50 dark:border-blue-800 rounded-full whitespace-nowrap">📚 数据门户</button>
+                                    <button v-if="filteredSystemCommands.some(c => c.id === DATASET_PORTAL_SYSTEM_COMMAND_ID)" @click="handleShortcutClick(filteredSystemCommands.find(c => c.id === DATASET_PORTAL_SYSTEM_COMMAND_ID))" class="px-3 py-1 text-[10px] font-bold bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-300 border border-blue-100/50 dark:border-blue-800 rounded-full whitespace-nowrap">📚 数据门户</button>
                                     <button v-if="filteredSystemCommands.some(c => c.id === 'sys_clear')" @click="handleShortcutClick(filteredSystemCommands.find(c => c.id === 'sys_clear'))" class="px-3 py-1 text-[10px] font-bold bg-gray-100 dark:bg-gray-800 text-gray-600 rounded-full whitespace-nowrap">💬 新会话</button>
                                 </template>
                                 <template v-else>
@@ -700,7 +701,7 @@ defineExpose({
                         <div v-if="showPlusMenu" class="absolute bottom-full left-0 mb-2 w-52 bg-white/95 dark:bg-gray-800/95 backdrop-blur-md rounded-xl shadow-xl border border-gray-200/50 dark:border-gray-700/50 py-1.5 z-50 animate-fade-in-up">
                             <!-- Data Portal -->
                             <button
-                              v-if="filteredSystemCommands.some(c => c.id === 'sys_dataset_menu')"
+                              v-if="filteredSystemCommands.some(c => c.id === DATASET_PORTAL_SYSTEM_COMMAND_ID)"
                               @click="openDataPortalFromPlusMenu"
                               class="w-full flex items-center space-x-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-primary/10 dark:hover:bg-primary/20 hover:text-primary transition-all duration-150"
                             >

--- a/frontend/src/composables/useDatasetPortal.ts
+++ b/frontend/src/composables/useDatasetPortal.ts
@@ -157,7 +157,13 @@ export function useDatasetPortal(options: UseDatasetPortalOptions) {
       const payload = await fetchDatasetMenuNavigationPayload(refresh);
       portalNavigationPayload.value = payload;
 
-      if (payload?.is_fallback && !refresh && !silent && !hasSilentlyRefreshed.value) {
+      if (
+        payload?.is_fallback
+        && payload?.has_datasets !== false
+        && !refresh
+        && !silent
+        && !hasSilentlyRefreshed.value
+      ) {
         hasSilentlyRefreshed.value = true;
         if (silentRefreshTimer) clearTimeout(silentRefreshTimer);
         silentRefreshTimer = setTimeout(async () => {
@@ -220,7 +226,10 @@ export function useDatasetPortal(options: UseDatasetPortalOptions) {
     await options.lockToDataQueryAgentForDatasetMenu();
     if (!portalNavigationPayload.value) {
       await fetchPortalNavigationData();
-    } else if (portalNavigationPayload.value.is_fallback) {
+    } else if (
+      portalNavigationPayload.value.is_fallback
+      && portalNavigationPayload.value.has_datasets !== false
+    ) {
       await fetchPortalNavigationData(false, false);
     }
   };

--- a/frontend/src/composables/useDatasetPortal.ts
+++ b/frontend/src/composables/useDatasetPortal.ts
@@ -10,6 +10,8 @@ export interface DatasetPortalPayload {
   is_fallback?: boolean;
   from_cache?: boolean;
   has_datasets?: boolean;
+  llm_generation_failed?: boolean;
+  llm_error_message?: string | null;
   _failed_at?: string;
 }
 
@@ -163,6 +165,7 @@ export function useDatasetPortal(options: UseDatasetPortalOptions) {
         && !refresh
         && !silent
         && !hasSilentlyRefreshed.value
+        && !payload?.llm_generation_failed
       ) {
         hasSilentlyRefreshed.value = true;
         if (silentRefreshTimer) clearTimeout(silentRefreshTimer);
@@ -177,7 +180,16 @@ export function useDatasetPortal(options: UseDatasetPortalOptions) {
         options.showToast("数据门户已更新为完整 AI 推荐", "success");
       }
 
-      if (refresh && !silent) {
+      if (payload?.llm_generation_failed) {
+        const detail = String(payload.llm_error_message || "").trim();
+        const hint = detail ? `：${detail}` : "";
+        options.showToast(
+          silent
+            ? `AI 模型暂不可用，仍为基础场景目录${hint}`
+            : `AI 模型暂不可用，已展示基础场景目录${hint}`,
+          "error",
+        );
+      } else if (refresh && !silent) {
         options.showToast("数据门户刷新成功", "success");
       }
     } catch (error) {

--- a/frontend/src/composables/useDatasetPortal.ts
+++ b/frontend/src/composables/useDatasetPortal.ts
@@ -59,8 +59,27 @@ export function useDatasetPortal(options: UseDatasetPortalOptions) {
   });
 
   const pinStorageKey = options.pinStorageKey || "dataset_portal_pinned";
-  const portalPinned = ref(localStorage.getItem(pinStorageKey) === "1");
+
+  const readDesktopPortalPinned = () =>
+    localStorage.getItem(pinStorageKey) === "1";
+
+  const portalPinned = ref(
+    !isMobileViewport() && readDesktopPortalPinned(),
+  );
+
+  let portalViewportMq: MediaQueryList | null = null;
+
+  const applyPortalViewportLayout = () => {
+    const mobile = portalViewportMq?.matches ?? isMobileViewport();
+    if (mobile) {
+      portalPinned.value = false;
+      return;
+    }
+    portalPinned.value = readDesktopPortalPinned();
+  };
+
   watch(portalPinned, (val) => {
+    if (isMobileViewport()) return;
     localStorage.setItem(pinStorageKey, val ? "1" : "0");
   });
 
@@ -229,6 +248,9 @@ export function useDatasetPortal(options: UseDatasetPortalOptions) {
   };
 
   const openPortalDrawer = async () => {
+    if (isMobileViewport()) {
+      portalPinned.value = false;
+    }
     showPortalDrawer.value = true;
     hasSilentlyRefreshed.value = false;
     if (silentRefreshTimer) {
@@ -288,10 +310,14 @@ export function useDatasetPortal(options: UseDatasetPortalOptions) {
   };
 
   onMounted(() => {
+    portalViewportMq = window.matchMedia("(max-width: 639px)");
+    applyPortalViewportLayout();
+    portalViewportMq.addEventListener("change", applyPortalViewportLayout);
     document.addEventListener("keydown", handlePortalDrawerKeydown);
   });
 
   onUnmounted(() => {
+    portalViewportMq?.removeEventListener("change", applyPortalViewportLayout);
     document.removeEventListener("keydown", handlePortalDrawerKeydown);
     disposePortalTimers();
   });

--- a/frontend/src/constants/datasetPortalCommand.ts
+++ b/frontend/src/constants/datasetPortalCommand.ts
@@ -1,0 +1,15 @@
+/** 数据门户系统 slash 指令（用户输入与 quick 按钮） */
+export const DATASET_PORTAL_SLASH_COMMAND = "/dataset_portal";
+
+/** 旧指令，兼容历史会话与已缓存门户 markdown */
+export const DATASET_PORTAL_LEGACY_SLASH_COMMAND = "/dataset_menu";
+
+export const DATASET_PORTAL_SYSTEM_COMMAND_ID = "sys_dataset_portal";
+
+export function isDatasetPortalSlashCommand(cmd: string): boolean {
+  const normalized = String(cmd || "").trim();
+  return (
+    normalized === DATASET_PORTAL_SLASH_COMMAND
+    || normalized === DATASET_PORTAL_LEGACY_SLASH_COMMAND
+  );
+}

--- a/frontend/src/utils/agentscopeSseHandlers.ts
+++ b/frontend/src/utils/agentscopeSseHandlers.ts
@@ -272,6 +272,32 @@ export function finalizeAllPendingStreamLogs(
   }
 }
 
+const STALE_PENDING_CATEGORIES = new Set(["model", "agent", "tool", "sql", "knowledge", "default"]);
+
+/** 长时间无响应的挂起步骤标为失败，避免一直显示「进行中」 */
+export function markStalePendingStreamLogs(
+  msg: AgentStreamMessage,
+  now = Date.now(),
+  staleMs = 120_000,
+): boolean {
+  let changed = false;
+  for (const log of msg.logs || []) {
+    if (log.status !== "pending") continue;
+    if (log.category && NON_LIVE_TIMER_CATEGORIES.has(log.category)) continue;
+    if (log.category && !STALE_PENDING_CATEGORIES.has(log.category)) continue;
+    if (!log.started_at || now - log.started_at < staleMs) continue;
+    log.status = "error";
+    const durationMs = resolveStreamLogDurationMs(log, undefined, now);
+    if (durationMs !== undefined) {
+      log.execution_time_ms = durationMs;
+    }
+    const suffix = "（超过 120 秒无响应，可能模型或工具调用超时）";
+    log.details = log.details ? `${log.details}\n${suffix}` : suffix;
+    changed = true;
+  }
+  return changed;
+}
+
 export function handleModelCallEvent<T extends AgentStreamMessage>(
   msg: T,
   data: Record<string, unknown>,

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -19,6 +19,7 @@ import {
   formatExternalExecutionStatus,
   formatPermissionStatus,
   handlePermissionRequired as applyPermissionRequiredEvent,
+  markStalePendingStreamLogs,
   resumeExternalExecutionStream,
   type PendingExternalExecution,
   type PendingToolPermission,
@@ -754,6 +755,11 @@ interface DatasetNavigationPayload {
   }>;
   markdown?: string;
   is_fallback?: boolean;
+  has_datasets?: boolean;
+  from_cache?: boolean;
+  llm_generation_failed?: boolean;
+  llm_error_message?: string | null;
+  _failed_at?: string;
 }
 
 interface Message {
@@ -1754,16 +1760,22 @@ const showDatasetMenuNavigation = async () => {
     navMsg.value.content = markdown || "当前暂无可展示的数据集导航，请联系管理员开通数据权限。";
 
     // 静默自愈刷新：若获取到的是兜底数据，且该消息未曾静默刷新过，则 3 秒后静默触发一次大模型刷新
-    if (payload?.is_fallback && payload?.has_datasets !== false && !navMsg.value._hasSilentlyRefreshed) {
+    if (payload?.is_fallback && payload?.has_datasets !== false && !payload?.llm_generation_failed && !navMsg.value._hasSilentlyRefreshed) {
       navMsg.value._hasSilentlyRefreshed = true;
       setTimeout(async () => {
         if (
           navMsg.value.datasetNavigation?.is_fallback
           && navMsg.value.datasetNavigation?.has_datasets !== false
+          && !navMsg.value.datasetNavigation?.llm_generation_failed
         ) {
           await silentlyRefreshDatasetMenuNavigation(navMsg.value);
         }
       }, 3000);
+    }
+    if (payload?.llm_generation_failed) {
+      const detail = String(payload.llm_error_message || "").trim();
+      const hint = detail ? `：${detail}` : "";
+      showToast(`AI 模型暂不可用，已展示基础场景目录${hint}`, "error");
     }
   } catch (error) {
     console.warn("Failed to load dataset menu navigation", error);
@@ -1790,6 +1802,11 @@ const silentlyRefreshDatasetMenuNavigation = async (msg: Message) => {
     const payload = await fetchDatasetMenuNavigationPayload(true);
     msg.datasetNavigation = payload;
     msg.content = payload?.markdown || "当前暂无可展示的数据集导航，请联系管理员开通数据权限。";
+    if (payload?.llm_generation_failed) {
+      const detail = String(payload.llm_error_message || "").trim();
+      const hint = detail ? `：${detail}` : "";
+      showToast(`AI 模型暂不可用，仍为基础场景目录${hint}`, "error");
+    }
     await nextTick();
     scrollToBottom(true);
   } catch (error) {
@@ -1808,7 +1825,13 @@ const refreshDatasetMenuNavigation = async (msg: Message) => {
     msg.datasetNavigation = payload;
     msg.content = payload?.markdown || "当前暂无可展示的数据集导航，请联系管理员开通数据权限。";
     isProcessing.value = false;
-    showToast("数据门户刷新成功", "success");
+    if (payload?.llm_generation_failed) {
+      const detail = String(payload.llm_error_message || "").trim();
+      const hint = detail ? `：${detail}` : "";
+      showToast(`AI 模型暂不可用，仍为基础场景目录${hint}`, "error");
+    } else {
+      showToast("数据门户刷新成功", "success");
+    }
     await nextTick();
     scrollToBottom(true);
   } catch (error) {
@@ -2100,6 +2123,11 @@ const sendMessage = async () => {
       const msgIndex = (ticks / 30) % THINKING_MESSAGES.length;
       agentMsg.value.thinkingText = THINKING_MESSAGES[msgIndex];
     }
+    if (ticks % 100 === 0) {
+      if (markStalePendingStreamLogs(agentMsg.value)) {
+        agentMsg.value.isThinking = false;
+      }
+    }
   }, 100);
 
   // 3. Call Real API with SSE
@@ -2343,6 +2371,8 @@ const sendMessage = async () => {
                 clearInterval(thoughtTimer);
                 thoughtTimer = null;
               }
+              const errText = String(data.content || data.message || "未知错误").trim();
+              agentMsg.value.content += `\n\n> ❌ **服务异常**: ${errText}`;
             }
             if (data.intent) {
               agentMsg.value.intent = data.intent;
@@ -2514,7 +2544,11 @@ const applyPermissionStreamEvent = (msg: Message, data: any) => {
       }
     }
     if (data.status === "generating" && msg.content) msg.isThinking = false;
-    else if (data.status === "error") msg.isThinking = false;
+    else if (data.status === "error") {
+      msg.isThinking = false;
+      const errText = String(data.content || data.message || "未知错误").trim();
+      msg.content += `\n\n> ❌ **服务异常**: ${errText}`;
+    }
     if (data.intent) msg.intent = data.intent;
     return;
   }
@@ -2595,6 +2629,8 @@ const applyPermissionStreamEvent = (msg: Message, data: any) => {
     msg.isThinking = false;
   } else if (data.status === "error") {
     msg.isThinking = false;
+    const errText = String(data.content || data.message || "未知错误").trim();
+    msg.content += `\n\n> ❌ **服务异常**: ${errText}`;
   }
   if (data.intent) msg.intent = data.intent;
 };

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -1754,10 +1754,13 @@ const showDatasetMenuNavigation = async () => {
     navMsg.value.content = markdown || "当前暂无可展示的数据集导航，请联系管理员开通数据权限。";
 
     // 静默自愈刷新：若获取到的是兜底数据，且该消息未曾静默刷新过，则 3 秒后静默触发一次大模型刷新
-    if (payload?.is_fallback && !navMsg.value._hasSilentlyRefreshed) {
+    if (payload?.is_fallback && payload?.has_datasets !== false && !navMsg.value._hasSilentlyRefreshed) {
       navMsg.value._hasSilentlyRefreshed = true;
       setTimeout(async () => {
-        if (navMsg.value.datasetNavigation?.is_fallback) {
+        if (
+          navMsg.value.datasetNavigation?.is_fallback
+          && navMsg.value.datasetNavigation?.has_datasets !== false
+        ) {
           await silentlyRefreshDatasetMenuNavigation(navMsg.value);
         }
       }, 3000);

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -9,6 +9,11 @@ import MessageRenderer from "@/components/MessageRenderer.vue";
 import DatasetCapabilityMenu from "@/components/chatbi/DatasetCapabilityMenu.vue";
 import DatasetPortalDrawer from "@/components/chatbi/DatasetPortalDrawer.vue";
 import { useDatasetPortal } from "@/composables/useDatasetPortal";
+import {
+  DATASET_PORTAL_SLASH_COMMAND,
+  DATASET_PORTAL_SYSTEM_COMMAND_ID,
+  isDatasetPortalSlashCommand,
+} from "@/constants/datasetPortalCommand";
 import CitationPopover from "@/components/CitationPopover.vue";
 import MentionList from "@/components/agent/MentionList.vue"; // New Import
 import axios from "@/utils/axios";
@@ -382,7 +387,7 @@ watch(
 const agents = ref<any[]>([]);
 const debugMode = ref<"auto" | "specific">("auto");
 const SYSTEM_SLASH_COMMANDS = [
-  { id: "sys_dataset_menu", command: "/dataset_menu", label: "📚 数据门户", sort_order: -35 },
+  { id: DATASET_PORTAL_SYSTEM_COMMAND_ID, command: DATASET_PORTAL_SLASH_COMMAND, label: "📚 数据门户", sort_order: -35 },
   { id: "sys_clear", command: "/new", label: "💬 新会话", sort_order: -30 },
   { id: "sys_history", command: "/history", label: "🕒 历史", sort_order: -20 },
   { id: "sys_settings", command: "/settings", label: "⚙️ 设置", sort_order: -15 },
@@ -791,7 +796,6 @@ interface Message {
   datasetNavigation?: DatasetNavigationPayload;
   prompt_tokens?: number;
   completion_tokens?: number;
-  _hasSilentlyRefreshed?: boolean;
 }
 
 // --- Debug Config State ---
@@ -1582,74 +1586,6 @@ const lockToDataQueryAgentForDatasetMenu = async () => {
   handleSwitchMode(dataQueryAgent);
 };
 
-const fetchDatasetMenuNavigationPayload = async (refresh = false) => {
-  const res = await axios.get("/api/v1/chat/dataset-menu", {
-    headers: debugAuthHeaders(),
-    params: refresh ? { refresh: true } : undefined,
-  });
-  return res.data?.data || {};
-};
-
-const recordDatasetMenuQuestionClick = async (
-  navigation: DatasetNavigationPayload | undefined,
-  payload: { query: string; label?: string; group_id?: string }
-) => {
-  const datasetMenuHash = navigation?.dataset_menu_hash;
-  const query = String(payload?.query || "").trim();
-  if (!datasetMenuHash || !query) return;
-  try {
-    await axios.post(
-      "/api/v1/chat/dataset-menu/click",
-      {
-        dataset_menu_hash: datasetMenuHash,
-        query,
-        label: payload.label,
-        group_id: payload.group_id,
-      },
-      { headers: debugAuthHeaders() }
-    );
-  } catch (error) {
-    console.warn("Failed to record dataset menu question click", error);
-  }
-};
-
-const clearNavigationQuestionClickStats = (
-  navigation: DatasetNavigationPayload | undefined,
-  query: string,
-) => {
-  const normalized = String(query || "").trim();
-  if (!navigation?.groups || !normalized) return;
-  for (const group of navigation.groups) {
-    for (const question of group.questions || []) {
-      if (String(question.query || "").trim() !== normalized) continue;
-      question.click_count = 0;
-      delete question.last_clicked_at;
-    }
-  }
-};
-
-const clearDatasetMenuQuestionClick = async (
-  navigation: DatasetNavigationPayload | undefined,
-  payload: { query: string },
-) => {
-  const datasetMenuHash = navigation?.dataset_menu_hash;
-  const query = String(payload?.query || "").trim();
-  if (!datasetMenuHash || !query) return;
-  try {
-    await axios.post(
-      "/api/v1/chat/dataset-menu/click/clear",
-      {
-        dataset_menu_hash: datasetMenuHash,
-        query,
-      },
-      { headers: debugAuthHeaders() }
-    );
-    clearNavigationQuestionClickStats(navigation, query);
-  } catch (error) {
-    console.warn("Failed to clear dataset menu question click", error);
-  }
-};
-
 const openImagePreview = (url: string) => {
   window.open(url, "_blank");
 };
@@ -1672,13 +1608,11 @@ const toggleFullScreen = () => {
 
 const userInput = ref("");
 const isProcessing = ref(false);
-const datasetMenuLoading = ref(false);
 const inputTextarea = ref<HTMLTextAreaElement | null>(null);
 const messagesContainer = ref<HTMLDivElement | null>(null);
 
 let abortController: AbortController | null = null;
 let thoughtTimer: any = null;
-let datasetMenuThoughtTimer: ReturnType<typeof setInterval> | null = null;
 
 // Auto-scroll
 const isUserAtBottom = ref(true);
@@ -1707,151 +1641,13 @@ watch(
   }
 );
 
-const showDatasetMenuNavigation = async () => {
-  if (datasetMenuLoading.value || isProcessing.value) {
-    return;
-  }
-  datasetMenuLoading.value = true;
-  isProcessing.value = true;
-
-  if (!conversationId.value) {
-    generateNewConversation();
-  }
-  await lockToDataQueryAgentForDatasetMenu();
-
-  messages.value.push({
-    id: Date.now(),
-    role: "user",
-    content: "/dataset_menu",
-    timestamp: new Date().toISOString(),
-  });
-
-  const navMsg = ref<Message>({
-    id: Date.now() + 1,
-    role: "agent",
-    content: "",
-    agentName: "sys_dataset_menu",
-    agentDisplayName: "系统 · 数据门户",
-    isThinking: true,
-    thinkingText: "正在生成我的数据门户，请稍后...",
-    logs: [],
-    thoughtStartTime: Date.now(),
-    thoughtDuration: "0.0",
-    isThoughtExpanded: false,
-    isCitationsExpanded: false,
-    timestamp: new Date().toISOString(),
-  });
-  messages.value.push(navMsg.value);
-  datasetMenuThoughtTimer = setInterval(() => {
-    if (navMsg.value.thoughtStartTime) {
-      navMsg.value.thoughtDuration = (
-        (Date.now() - navMsg.value.thoughtStartTime) /
-        1000
-      ).toFixed(1);
-    }
-  }, 100);
-  await nextTick();
-  scrollToBottom(true);
-
-  try {
-    const payload = await fetchDatasetMenuNavigationPayload();
-    navMsg.value.datasetNavigation = payload;
-    const markdown = payload?.markdown || "";
-    navMsg.value.content = markdown || "当前暂无可展示的数据集导航，请联系管理员开通数据权限。";
-
-    // 静默自愈刷新：若获取到的是兜底数据，且该消息未曾静默刷新过，则 3 秒后静默触发一次大模型刷新
-    if (payload?.is_fallback && payload?.has_datasets !== false && !payload?.llm_generation_failed && !navMsg.value._hasSilentlyRefreshed) {
-      navMsg.value._hasSilentlyRefreshed = true;
-      setTimeout(async () => {
-        if (
-          navMsg.value.datasetNavigation?.is_fallback
-          && navMsg.value.datasetNavigation?.has_datasets !== false
-          && !navMsg.value.datasetNavigation?.llm_generation_failed
-        ) {
-          await silentlyRefreshDatasetMenuNavigation(navMsg.value);
-        }
-      }, 3000);
-    }
-    if (payload?.llm_generation_failed) {
-      const detail = String(payload.llm_error_message || "").trim();
-      const hint = detail ? `：${detail}` : "";
-      showToast(`AI 模型暂不可用，已展示基础场景目录${hint}`, "error");
-    }
-  } catch (error) {
-    console.warn("Failed to load dataset menu navigation", error);
-    navMsg.value.content = (
-      "暂时无法加载我的数据门户，请稍后重试。\n\n"
-      + "- [🙋 重新加载数据门户](quick:/dataset_menu)"
-    );
-  } finally {
-    navMsg.value.isThinking = false;
-    navMsg.value.thinkingText = "";
-    if (datasetMenuThoughtTimer) {
-      clearInterval(datasetMenuThoughtTimer);
-      datasetMenuThoughtTimer = null;
-    }
-    datasetMenuLoading.value = false;
-    isProcessing.value = false;
-    await nextTick();
-    scrollToBottom(true);
-  }
-};
-
-const silentlyRefreshDatasetMenuNavigation = async (msg: Message) => {
-  try {
-    const payload = await fetchDatasetMenuNavigationPayload(true);
-    msg.datasetNavigation = payload;
-    msg.content = payload?.markdown || "当前暂无可展示的数据集导航，请联系管理员开通数据权限。";
-    if (payload?.llm_generation_failed) {
-      const detail = String(payload.llm_error_message || "").trim();
-      const hint = detail ? `：${detail}` : "";
-      showToast(`AI 模型暂不可用，仍为基础场景目录${hint}`, "error");
-    }
-    await nextTick();
-    scrollToBottom(true);
-  } catch (error) {
-    console.warn("Failed to silently refresh dataset menu navigation", error);
-  }
-};
-
-const refreshDatasetMenuNavigation = async (msg: Message) => {
-  if (datasetMenuLoading.value || isProcessing.value) {
-    return;
-  }
-  datasetMenuLoading.value = true;
-  isProcessing.value = true;
-  try {
-    const payload = await fetchDatasetMenuNavigationPayload(true);
-    msg.datasetNavigation = payload;
-    msg.content = payload?.markdown || "当前暂无可展示的数据集导航，请联系管理员开通数据权限。";
-    isProcessing.value = false;
-    if (payload?.llm_generation_failed) {
-      const detail = String(payload.llm_error_message || "").trim();
-      const hint = detail ? `：${detail}` : "";
-      showToast(`AI 模型暂不可用，仍为基础场景目录${hint}`, "error");
-    } else {
-      showToast("数据门户刷新成功", "success");
-    }
-    await nextTick();
-    scrollToBottom(true);
-  } catch (error) {
-    console.warn("Failed to refresh dataset menu navigation", error);
-    showToast("刷新数据门户失败，请稍后重试", "error");
-    if (msg.datasetNavigation) {
-      msg.datasetNavigation = { ...msg.datasetNavigation, _failed_at: new Date().toISOString() };
-    }
-  } finally {
-    datasetMenuLoading.value = false;
-    isProcessing.value = false;
-  }
-};
-
 const handleSystemCommand = async (cmd: string): Promise<boolean> => {
+  if (isDatasetPortalSlashCommand(cmd)) {
+    userInput.value = "";
+    await openPortalDrawer();
+    return true;
+  }
   switch (cmd) {
-    case "/dataset_menu":
-      userInput.value = "";
-      await openPortalDrawer();
-      return true;
     case "/history":
       userInput.value = "";
       showHistorySidebar.value = !showHistorySidebar.value;
@@ -1888,6 +1684,7 @@ const {
   handlePortalQuickQuestion,
   recordDatasetMenuQuestionClick: recordPortalQuestionClick,
   clearDatasetMenuQuestionClick: clearPortalQuestionClick,
+  fetchDatasetMenuNavigationPayload,
   disposePortalTimers,
 } = useDatasetPortal({
   getAuthHeaders: () => debugAuthHeaders() || {},
@@ -1898,6 +1695,34 @@ const {
   keepOpenStorageKey: "debug_portal_keep_open",
   pinStorageKey: "debug_portal_pinned",
 });
+
+const INLINE_DATASET_MENU_EMPTY =
+  "当前暂无可展示的数据集导航，请联系管理员开通数据权限。";
+
+/** 历史消息内嵌 DatasetCapabilityMenu 的刷新（抽屉门户走 refreshPortalNavigation） */
+const refreshDatasetMenuNavigation = async (msg: Message) => {
+  if (isProcessing.value) return;
+  try {
+    const payload = await fetchDatasetMenuNavigationPayload(true);
+    msg.datasetNavigation = payload;
+    msg.content = payload?.markdown || INLINE_DATASET_MENU_EMPTY;
+    if (payload?.llm_generation_failed) {
+      const detail = String(payload.llm_error_message || "").trim();
+      const hint = detail ? `：${detail}` : "";
+      showToast(`AI 模型暂不可用，仍为基础场景目录${hint}`, "error");
+    } else {
+      showToast("数据门户刷新成功", "success");
+    }
+    await nextTick();
+    scrollToBottom(true);
+  } catch (error) {
+    console.warn("Failed to refresh dataset menu navigation", error);
+    showToast("刷新数据门户失败，请稍后重试", "error");
+    if (msg.datasetNavigation) {
+      msg.datasetNavigation = { ...msg.datasetNavigation, _failed_at: new Date().toISOString() };
+    }
+  }
+};
 
 const handleEscKey = (e: KeyboardEvent) => {
   if (e.key === "Escape" && showPortalDrawer.value) {
@@ -3779,8 +3604,8 @@ onUnmounted(() => {
                   v-else
                   :payload="msg.datasetNavigation"
                   @quick-question="handleQuickQuestion"
-                  @record-question-click="(payload) => recordDatasetMenuQuestionClick(msg.datasetNavigation, payload)"
-                  @clear-question-click="(payload) => clearDatasetMenuQuestionClick(msg.datasetNavigation, payload)"
+                  @record-question-click="(payload) => recordPortalQuestionClick(msg.datasetNavigation, payload)"
+                  @clear-question-click="(payload) => clearPortalQuestionClick(msg.datasetNavigation, payload)"
                   @refresh="refreshDatasetMenuNavigation(msg)"
                 />
                 <!-- 导出 / 点赞踩（托管 RAGFlow、OpenClaw 不展示点赞踩） -->

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -1213,6 +1213,7 @@ const memorySearchQuery = ref("");
 const selectedMemoryIds = ref<Set<string>>(new Set());
 
 const windowWidth = ref(window.innerWidth);
+const isMobile = computed(() => windowWidth.value < 640);
 const handleResize = () => {
   windowWidth.value = window.innerWidth;
 };
@@ -2672,7 +2673,7 @@ onUnmounted(() => {
     <!-- Center: Main Chat Area -->
     <div
       class="flex-1 flex flex-col bg-white shadow-sm overflow-hidden mr-px transition-[margin] duration-300"
-      :class="{ 'sm:mr-[min(28rem,100vw)]': showPortalDrawer && portalPinned }"
+      :class="{ 'sm:mr-[min(28rem,100vw)]': showPortalDrawer && portalPinned && !isMobile }"
     >
       <!-- Header -->
       <div

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -35,7 +35,7 @@
 
     <div
       class="flex-1 flex flex-col h-full relative z-10 min-w-0 transition-[margin] duration-300"
-      :class="{ 'sm:mr-[min(28rem,100vw)]': showPortalDrawer && portalPinned }"
+      :class="{ 'sm:mr-[min(28rem,100vw)]': showPortalDrawer && portalPinned && !isMobile }"
     >
       <!-- Dynamic Header Status (New) -->
       <div 

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -2277,6 +2277,7 @@ import {
   isLiveThoughtStepTimer,
   resolveStreamLogDurationMs,
   finalizeAllPendingStreamLogs,
+  markStalePendingStreamLogs,
   handlePermissionRequired as applyPermissionRequiredEvent,
   resumeExternalExecutionStream,
   type PendingExternalExecution,
@@ -2986,7 +2987,26 @@ const connectionStatus = ref<"connected" | "disconnected" | "reconnecting">(
 let abortController: AbortController | null = null;
 let thoughtTimer: any = null;
 let stallTimer: any = null;
+let stalePendingTimer: ReturnType<typeof setInterval> | null = null;
 const showStalledPrompt = ref(false);
+const clearStalePendingTimer = () => {
+  if (stalePendingTimer) {
+    clearInterval(stalePendingTimer);
+    stalePendingTimer = null;
+  }
+};
+const startStalePendingTimer = (msg: Message) => {
+  clearStalePendingTimer();
+  stalePendingTimer = setInterval(() => {
+    if (!isProcessing.value) {
+      clearStalePendingTimer();
+      return;
+    }
+    if (markStalePendingStreamLogs(msg)) {
+      msg.isThinking = false;
+    }
+  }, 10_000);
+};
 const clearStallTimer = () => {
   if (stallTimer) {
     clearTimeout(stallTimer);
@@ -4428,7 +4448,13 @@ const refreshDatasetMenuNavigation = async (msg: Message) => {
     msg.datasetNavigation = payload;
     msg.content = payload?.markdown || "当前暂无可展示的数据集导航，请联系管理员开通数据权限。";
     isProcessing.value = false;
-    showToast("数据门户刷新成功", "success");
+    if (payload?.llm_generation_failed) {
+      const detail = String(payload.llm_error_message || "").trim();
+      const hint = detail ? `：${detail}` : "";
+      showToast(`AI 模型暂不可用，仍为基础场景目录${hint}`, "error");
+    } else {
+      showToast("数据门户刷新成功", "success");
+    }
     await nextTick();
     scrollToBottom(true);
   } catch (error) {
@@ -4729,6 +4755,7 @@ const sendMessage = async () => {
     timestamp: new Date().toISOString(),
   });
   messages.value.push(agentMsg.value);
+  startStalePendingTimer(agentMsg.value);
   // 新一轮发送：恢复自动跟随（避免上一轮「向上滚动」导致本轮仍不跟底）
   autoScrollEnabled.value = true;
   showNewMessageHint.value = false;
@@ -4922,8 +4949,8 @@ const sendMessage = async () => {
             }
           } else if (data.status === "error") {
             agentMsg.value.isThinking = false;
-            agentMsg.value.content +=
-              "\n[Error: " + (data.message || "Unknown error") + "]";
+            const errText = String(data.content || data.message || "未知错误").trim();
+            agentMsg.value.content += `\n\n> ❌ **服务异常**: ${errText}`;
           }
           scrollToBottom();
         } catch (e) {
@@ -4941,6 +4968,7 @@ const sendMessage = async () => {
     isProcessing.value = false;
     agentMsg.value.isThinking = false;
     clearStallTimer();
+    clearStalePendingTimer();
     showStalledPrompt.value = false;
     if (thoughtTimer) clearInterval(thoughtTimer);
     // Final cleanup: stop any remaining log spinners

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -1740,9 +1740,9 @@
                   <div>
                     <div class="text-[11px] font-black text-gray-800 dark:text-gray-200 uppercase mb-0.5">快捷指令</div>
                     <p class="text-[10px] text-gray-500 mb-2">Web 端支持<b>直接点击</b>快捷按钮；移动端输入斜杠 <span class="font-mono text-blue-500">/</span> 即可快速唤起。</p>
-                    <p class="text-[10px] text-gray-500 mb-2"><span class="font-mono text-blue-500">/dataset_menu</span> 会基于与 ChatBI 相同的数据集目录，由 AI 生成我的数据门户与可点击追问按钮。</p>
+                    <p class="text-[10px] text-gray-500 mb-2"><span class="font-mono text-blue-500">{{ DATASET_PORTAL_SLASH_COMMAND }}</span> 会基于与 ChatBI 相同的数据集目录，由 AI 生成我的数据门户与可点击追问按钮。</p>
                     <div class="flex flex-wrap gap-1.5">
-                      <span class="px-1.5 py-0.5 bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-[9px] rounded border border-blue-100 dark:border-blue-800 font-medium">/dataset_menu</span>
+                      <span class="px-1.5 py-0.5 bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-[9px] rounded border border-blue-100 dark:border-blue-800 font-medium">{{ DATASET_PORTAL_SLASH_COMMAND }}</span>
                       <span class="px-1.5 py-0.5 bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-[9px] rounded border border-blue-100 dark:border-blue-800 font-medium">/new</span>
                       <span class="px-1.5 py-0.5 bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-[9px] rounded border border-blue-100 dark:border-blue-800 font-medium">/history</span>
                     </div>
@@ -2238,6 +2238,11 @@ import axios from "@/utils/axios";
 import { finalizeConversation } from "@/utils/conversationFinalize";
 import { useToast } from "../composables/useToast";
 import { useDatasetPortal } from "@/composables/useDatasetPortal";
+import {
+  DATASET_PORTAL_SLASH_COMMAND,
+  DATASET_PORTAL_SYSTEM_COMMAND_ID,
+  isDatasetPortalSlashCommand,
+} from "@/constants/datasetPortalCommand";
 
 const toast = useToast();
 const showToast = toast.showToast;
@@ -3027,7 +3032,7 @@ const resetStallTimer = () => {
 };
 // Slash Commands
 const SYSTEM_SLASH_COMMANDS = [
-  { id: "sys_dataset_menu", command: "/dataset_menu", label: "📚 数据门户", sort_order: -35 },
+  { id: DATASET_PORTAL_SYSTEM_COMMAND_ID, command: DATASET_PORTAL_SLASH_COMMAND, label: "📚 数据门户", sort_order: -35 },
   { id: "sys_clear", command: "/new", label: "💬 新会话", sort_order: -30 },
   { id: "sys_history", command: "/history", label: "🕒 历史", sort_order: -20 },
   { id: "sys_settings", command: "/settings", label: "⚙️ 设置", sort_order: -15 },
@@ -4114,11 +4119,12 @@ const fetchConversationHistory = async (isLoadMore = false) => {
 };
 // --- Logic ---
 const handleSystemCommand = async (cmd: string): Promise<boolean> => {
+  if (isDatasetPortalSlashCommand(cmd)) {
+    userInput.value = "";
+    await openPortalDrawer();
+    return true;
+  }
   switch (cmd) {
-    case "/dataset_menu":
-      userInput.value = "";
-      await openPortalDrawer();
-      return true;
     case "/history":
       userInput.value = "";
       showHistorySidebar.value = !showHistorySidebar.value;

--- a/tests/ai/runners/test_data_agent_runner.py
+++ b/tests/ai/runners/test_data_agent_runner.py
@@ -2047,6 +2047,74 @@ def test_final_empty_sql_after_diagnostic_can_answer_no_data(data_config):
     assert state.ready_to_answer is True
 
 
+def test_detect_empty_result_ignores_total_zero_when_rows_exist(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-total-zero-rows", trace_buffer=[])
+    parsed = {
+        "rows": [{"region": "华东", "order_cnt": 12840}],
+        "total": 0,
+    }
+
+    assert runner._detect_empty_result(parsed) is None
+    assert runner._result_has_data_rows(parsed) is True
+
+
+def test_is_diagnostic_sql_does_not_flag_limit_only_queries(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-limit-not-diag", trace_buffer=[])
+    assert runner._is_diagnostic_sql("SELECT metric FROM demo LIMIT 10") is False
+    assert runner._is_diagnostic_sql("SELECT DISTINCT room_name FROM demo LIMIT 10") is True
+
+
+def test_final_sql_limit_10_with_data_after_diagnostic_allows_answer(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-final-limit10", trace_buffer=[])
+    state = _DataRunState(
+        requires_fresh_data=True,
+        schema_completed=True,
+        expecting_final_sql_after_diagnostic=True,
+        diagnostic_sql_pending_final=True,
+    )
+
+    parsed, should_save = runner._apply_sql_tool_result(
+        state,
+        tool_args={"sql": "SELECT room_name, count(*) AS total_count FROM demo GROUP BY room_name LIMIT 10"},
+        output={"rows": [{"room_name": "A101", "total_count": 3}], "total": 0},
+    )
+
+    assert should_save is True
+    assert parsed["rows"][0]["room_name"] == "A101"
+    assert state.empty_sql_result is False
+    assert state.diagnostic_sql_pending_final is False
+    assert state.expecting_final_sql_after_diagnostic is False
+    assert state.ready_to_answer is True
+
+
+def test_expecting_final_sql_accepts_non_diagnostic_limit_10_with_data(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-direct-final-limit10", trace_buffer=[])
+    state = _DataRunState(
+        requires_fresh_data=True,
+        schema_completed=True,
+        expecting_final_sql_after_diagnostic=True,
+    )
+
+    parsed, should_save = runner._apply_sql_tool_result(
+        state,
+        tool_args={"sql": "SELECT room_name, count(*) AS total_count FROM demo GROUP BY room_name LIMIT 10"},
+        output={"items": [{"room_name": "A101", "total_count": 3}], "total": 0},
+    )
+
+    assert should_save is True
+    assert state.diagnostic_sql_pending_final is False
+    assert state.empty_sql_result is False
+    assert state.ready_to_answer is True
+
+
 @pytest.mark.asyncio
 async def test_execute_sql_wrapper_blocks_high_risk_sql_before_tool_call(data_config):
     from app.services.ai.runners.data_agent_runner import (

--- a/tests/ai/runtime/test_runtime_messages.py
+++ b/tests/ai/runtime/test_runtime_messages.py
@@ -1,0 +1,18 @@
+from app.services.ai.runtime.agentscope.messages import (
+    DEFAULT_LLM_USER_PROMPT,
+    system_user_prompt_messages,
+)
+
+
+def test_system_user_prompt_messages_defaults_user_prompt():
+    messages = system_user_prompt_messages("system instructions")
+    assert len(messages) == 2
+    assert messages[0].role == "system"
+    assert messages[0].content[0].text == "system instructions"
+    assert messages[1].role == "user"
+    assert messages[1].content[0].text == DEFAULT_LLM_USER_PROMPT
+
+
+def test_system_user_prompt_messages_custom_user_prompt():
+    messages = system_user_prompt_messages("system instructions", user_prompt="custom user")
+    assert messages[1].content[0].text == "custom user"

--- a/tests/ai/test_chatbi_sql_user_messages.py
+++ b/tests/ai/test_chatbi_sql_user_messages.py
@@ -1,0 +1,70 @@
+import pytest
+
+from app.services.ai.chatbi_sql_user_messages import (
+    GENERIC_SQL_ERROR_CONTENT,
+    map_sql_tool_error_for_user,
+)
+
+pytestmark = pytest.mark.no_infrastructure
+
+
+@pytest.mark.parametrize(
+    ("raw", "title_substr", "content_substr"),
+    [
+        (
+            "[Permission Denied] zhangsan(1) 无权访问表 'ods_order'",
+            "无权访问",
+            "ods_order",
+        ),
+        (
+            "[Permission Denied] 无法校验表权限：缺少用户身份",
+            "无法校验",
+            "身份",
+        ),
+        (
+            "Error: Dataset 'sales_dw' not found. Please verify the dataset name.",
+            "数据集不存在",
+            "sales_dw",
+        ),
+        (
+            "[Validation Failed] 表 't_x' 不属于当前指定的数据集 'order_ds'，严禁跨数据集或凭空猜表。",
+            "不匹配",
+            "t_x",
+        ),
+        (
+            "[Validation Failed] '订单' 是业务术语，并非物理表名，不能直接用于 SQL。请改用 get_dataset_schema 返回的物理表名 'ods_order'。",
+            "物理表名",
+            "订单",
+        ),
+        (
+            "[Validation Failed] user(2)物理表 'ghost_tbl' 未在元数据中注册或不存在。",
+            "不存在",
+            "ghost_tbl",
+        ),
+        (
+            "[Security Error] Failed to apply data permissions: boom",
+            "数据权限",
+            "行级",
+        ),
+    ],
+)
+def test_map_sql_tool_error_for_user_specific_cases(raw, title_substr, content_substr):
+    presentation = map_sql_tool_error_for_user(raw)
+    assert presentation.specific is True
+    assert title_substr in presentation.title
+    assert content_substr in presentation.content
+    assert "[Permission Denied]" not in presentation.content
+    assert "[Validation Failed]" not in presentation.content
+
+
+def test_map_sql_tool_error_for_user_preserves_raw_for_repair_is_separate():
+    raw = "[Validation Failed] 表 't_x' 不属于当前指定的数据集 'order_ds'，严禁跨数据集或凭空猜表。"
+    presentation = map_sql_tool_error_for_user(raw)
+    assert raw != presentation.content
+    assert "order_ds" in presentation.content
+
+
+def test_map_sql_tool_error_for_user_generic_fallback():
+    presentation = map_sql_tool_error_for_user("some opaque upstream failure")
+    assert presentation.specific is False
+    assert presentation.content == GENERIC_SQL_ERROR_CONTENT

--- a/tests/frontend/test_dataset_menu_loading_contract.py
+++ b/tests/frontend/test_dataset_menu_loading_contract.py
@@ -28,6 +28,7 @@ def _assert_embed_portal_contract(source: str) -> None:
     assert "📚 数据门户" in source
     assert "embed_portal_keep_open" in source
     assert "onPortalLoadingChange" in source
+    assert "applyPortalViewportLayout" in _source("frontend/src/composables/useDatasetPortal.ts")
 
 
 def _assert_agent_debug_portal_contract(source: str) -> None:
@@ -120,6 +121,8 @@ def test_dataset_portal_drawer_pin_contract():
     assert "已钉住" in source
     assert "translate-y-full" in source
     assert "isMobile" in source
+    assert "mobileSheetHeightClass" in source
+    assert "portal-drawer-scroll" in source
 
 
 def test_portal_prompt_time_anchor_contract():

--- a/tests/frontend/test_dataset_menu_loading_contract.py
+++ b/tests/frontend/test_dataset_menu_loading_contract.py
@@ -61,7 +61,8 @@ def test_dataset_capability_menu_component_contract():
     assert "payload.from_cache" in source
     assert "payload.has_datasets" in source
     assert "isNoPermissionEmpty" in source
-    assert "联系系统管理员" in source
+    assert "showStatusBanner" in source
+    assert "has_datasets === false" in source
     assert "cacheAgeLabel" in source
     assert "我的数据门户" in source
     assert "click_count" in source
@@ -86,8 +87,7 @@ def test_dataset_portal_composable_contract():
     assert "readStoredBoolean" in source
     assert "!isMobileViewport()" in source
     assert "from_cache" in source
-    assert "has_datasets" in source
-    assert "refresh: true" in source
+    assert "has_datasets !== false" in source
     assert "/api/v1/chat/dataset-menu/click" in source
 
 

--- a/tests/frontend/test_dataset_menu_loading_contract.py
+++ b/tests/frontend/test_dataset_menu_loading_contract.py
@@ -121,7 +121,8 @@ def test_dataset_portal_drawer_pin_contract():
     assert "已钉住" in source
     assert "translate-y-full" in source
     assert "isMobile" in source
-    assert "mobileSheetHeightClass" in source
+    assert 'teleport to="body"' in source
+    assert "max-h-[92%]" in source
     assert "portal-drawer-scroll" in source
 
 

--- a/tests/frontend/test_dataset_menu_loading_contract.py
+++ b/tests/frontend/test_dataset_menu_loading_contract.py
@@ -15,7 +15,8 @@ def _assert_embed_portal_contract(source: str) -> None:
     assert "useDatasetPortal" in source
     assert "DatasetPortalDrawer" in source
     assert "const datasetMenuLoading = ref(false);" in source
-    assert "case \"/dataset_menu\":" in source
+    assert "DATASET_PORTAL_SLASH_COMMAND" in source
+    assert "isDatasetPortalSlashCommand" in source
     assert "await openPortalDrawer();" in source
     assert "DatasetCapabilityMenu" in source
     assert "datasetNavigation?: DatasetNavigationPayload;" in source
@@ -32,14 +33,14 @@ def _assert_embed_portal_contract(source: str) -> None:
 def _assert_agent_debug_portal_contract(source: str) -> None:
     assert "useDatasetPortal" in source
     assert "DatasetPortalDrawer" in source
-    assert "const datasetMenuLoading = ref(false);" in source
-    assert "case \"/dataset_menu\":" in source
+    assert "DATASET_PORTAL_SLASH_COMMAND" in source
+    assert "isDatasetPortalSlashCommand" in source
     assert "await openPortalDrawer();" in source
     assert "DatasetCapabilityMenu" in source
     assert "datasetNavigation?: DatasetNavigationPayload;" in source
     assert "lockToDataQueryAgentForDatasetMenu" in source
     assert "refreshDatasetMenuNavigation" in source
-    assert "recordDatasetMenuQuestionClick" in source
+    assert "recordPortalQuestionClick" in source
 
 
 def test_embed_chat_locks_input_while_dataset_menu_loads():

--- a/tests/services/test_dataset_navigation_service.py
+++ b/tests/services/test_dataset_navigation_service.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 import pytest
 
 from app.services.ai.executors.prompts import DataQueryPrompts
+from app.services.ai.runtime.agentscope.stream_reconcile import finalize_visible_reply
 from app.services.dataset_navigation_service import (
     DatasetNavigationService,
     count_datasets_in_menu,
@@ -192,8 +193,9 @@ async def test_generate_navigation_markdown_uses_llm():
         "app.services.dataset_navigation_service.chat_client_from_handle",
         return_value=mock_client,
     ):
-        markdown = await DatasetNavigationService._generate_navigation_markdown(SAMPLE_MENU)
+        markdown, llm_err = await DatasetNavigationService._generate_navigation_markdown(SAMPLE_MENU)
 
+    assert llm_err is None
     assert "我的数据门户" in markdown
     assert "(quick:统计最近一周机房告警记录)" in markdown
     mock_client.generate_text.assert_awaited_once()
@@ -239,8 +241,9 @@ async def test_generate_navigation_markdown_falls_back_when_llm_invalid():
         "app.services.dataset_navigation_service.chat_client_from_handle",
         return_value=mock_client,
     ):
-        markdown = await DatasetNavigationService._generate_navigation_markdown(SAMPLE_MENU)
+        markdown, llm_err = await DatasetNavigationService._generate_navigation_markdown(SAMPLE_MENU)
 
+    assert llm_err == "模型返回内容无效或未包含推荐问题"
     assert "ai_agent_meta" in markdown
     assert "(quick:/dataset_menu)" in markdown
 
@@ -306,7 +309,7 @@ async def test_build_navigation_for_user_refresh_skips_cached_markdown():
     ) as load_cache, patch.object(
         DatasetNavigationService,
         "_generate_navigation_markdown",
-        AsyncMock(return_value="fresh"),
+        AsyncMock(return_value=("fresh", None)),
     ) as generate_markdown, patch.object(
         DatasetNavigationService,
         "_save_cached_navigation",
@@ -473,7 +476,7 @@ async def test_build_navigation_for_user_uses_short_ttl_on_fallback():
     ), patch.object(
         DatasetNavigationService,
         "_generate_navigation_markdown",
-        AsyncMock(return_value=fallback_markdown),
+        AsyncMock(return_value=(fallback_markdown, "模型调用失败")),
     ), patch.object(
         DatasetNavigationService,
         "_save_cached_navigation",
@@ -486,7 +489,62 @@ async def test_build_navigation_for_user_uses_short_ttl_on_fallback():
         )
     
     assert payload["is_fallback"] is True
+    assert payload["llm_generation_failed"] is True
+    assert payload["llm_error_message"] == "模型调用失败"
     save_cache.assert_awaited_once_with(ANY, fallback_markdown, ttl=15)
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_generate_navigation_markdown_returns_error_when_llm_raises():
+    mock_client = MagicMock()
+    mock_client.generate_text = AsyncMock(side_effect=RuntimeError("Qwen 400"))
+
+    with patch(
+        "app.services.dataset_navigation_service.AgentConfigProvider.get_configured_llm",
+        AsyncMock(return_value=object()),
+    ), patch(
+        "app.services.dataset_navigation_service.chat_client_from_handle",
+        return_value=mock_client,
+    ):
+        markdown, llm_err = await DatasetNavigationService._generate_navigation_markdown(SAMPLE_MENU)
+
+    assert llm_err == "Qwen 400"
+    assert "ai_agent_meta" in markdown
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_build_navigation_for_user_sets_llm_generation_failed():
+    fallback_markdown = DataQueryPrompts.build_dataset_navigation_fallback(SAMPLE_MENU)
+    fallback_md = finalize_visible_reply(fallback_markdown, collapse_duplicates=False)
+
+    with patch.object(
+        DatasetNavigationService,
+        "_get_dataset_menu",
+        AsyncMock(return_value=SAMPLE_MENU),
+    ), patch.object(
+        DatasetNavigationService,
+        "_load_cached_navigation",
+        AsyncMock(return_value=None),
+    ), patch.object(
+        DatasetNavigationService,
+        "_generate_navigation_markdown",
+        AsyncMock(return_value=(fallback_md, "模型不可用")),
+    ), patch.object(
+        DatasetNavigationService,
+        "_save_cached_navigation",
+        AsyncMock(),
+    ):
+        payload = await DatasetNavigationService.build_navigation_for_user(
+            AsyncMock(),
+            user_id=7,
+            is_admin=False,
+        )
+
+    assert payload["is_fallback"] is True
+    assert payload["llm_generation_failed"] is True
+    assert payload["llm_error_message"] == "模型不可用"
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_dataset_navigation_service.py
+++ b/tests/services/test_dataset_navigation_service.py
@@ -609,3 +609,42 @@ async def test_recommend_table_questions_uses_frontend_columns_without_db_lookup
     assert questions[0]["query"] == "统计最近30天每日新增用户数"
     mock_db.execute.assert_not_called()
 
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_build_navigation_for_user_skips_llm_when_no_authorized_datasets():
+    empty_menu = "Available Datasets\n  (No authorized datasets available)"
+
+    with patch.object(
+        DatasetNavigationService,
+        "_get_dataset_menu",
+        AsyncMock(return_value=empty_menu),
+    ), patch.object(
+        DatasetNavigationService,
+        "_load_cached_navigation",
+        AsyncMock(return_value=None),
+    ) as load_cache, patch.object(
+        DatasetNavigationService,
+        "_generate_navigation_markdown",
+        AsyncMock(),
+    ) as generate_markdown, patch.object(
+        DatasetNavigationService,
+        "_save_cached_navigation",
+        AsyncMock(),
+    ) as save_cache:
+        payload = await DatasetNavigationService.build_navigation_for_user(
+            AsyncMock(),
+            user_id=7,
+            is_admin=False,
+        )
+
+    assert payload["dataset_count"] == 0
+    assert payload["has_datasets"] is False
+    assert payload["is_fallback"] is False
+    assert payload["groups"] == []
+    assert payload["from_cache"] is False
+    assert "开通" in payload["markdown"] or "权限" in payload["markdown"]
+    load_cache.assert_not_awaited()
+    generate_markdown.assert_not_awaited()
+    save_cache.assert_not_awaited()
+

--- a/tests/services/test_dataset_navigation_service.py
+++ b/tests/services/test_dataset_navigation_service.py
@@ -44,7 +44,7 @@ def test_menu_has_authorized_datasets():
 
 
 @pytest.mark.no_infrastructure
-def test_dataset_navigation_generation_prompt_uses_dataset_menu():
+def test_dataset_navigation_generation_prompt_uses_dataset_portal_command():
     prompt = DataQueryPrompts.dataset_navigation_generation_prompt(SAMPLE_MENU)
     assert "ai_agent_meta" in prompt
     assert "业务场景卡片" in prompt
@@ -52,6 +52,7 @@ def test_dataset_navigation_generation_prompt_uses_dataset_menu():
     assert "示例问题" in prompt
     assert "继续追问" in prompt
     assert "{dataset_menu}" in prompt
+    assert "/dataset_portal" in prompt
 
 
 @pytest.mark.no_infrastructure
@@ -153,7 +154,7 @@ def test_build_dataset_navigation_fallback_uses_business_scene_cards():
     assert "**继续追问：**" in markdown
     assert "智能体访问日志" in markdown
     assert "记录 API 访问" in markdown
-    assert "(quick:/dataset_menu)" in markdown
+    assert "(quick:/dataset_portal)" in markdown
 
 
 @pytest.mark.no_infrastructure
@@ -162,14 +163,14 @@ def test_build_dataset_navigation_fallback_empty():
         "Available Datasets\n  (No authorized datasets available)"
     )
     assert "暂无可查询的数据集" in markdown
-    assert "(quick:/dataset_menu)" in markdown
+    assert "(quick:/dataset_portal)" in markdown
 
 
 @pytest.mark.no_infrastructure
 def test_build_dataset_navigation_fallback_shows_raw_menu():
     markdown = DataQueryPrompts.build_dataset_navigation_fallback("plain text without dataset blocks")
     assert "plain text" in markdown
-    assert "(quick:/dataset_menu)" in markdown
+    assert "(quick:/dataset_portal)" in markdown
 
 
 @pytest.mark.asyncio
@@ -181,7 +182,7 @@ async def test_generate_navigation_markdown_uses_llm():
         "#### 运维监控\n"
         "- [🙋 查机房告警](quick:统计最近一周机房告警记录)\n\n"
         "### 💬 您可能还想了解\n---\n"
-        "- [🙋 重新查看数据门户](quick:/dataset_menu)\n"
+        "- [🙋 重新查看数据门户](quick:/dataset_portal)\n"
     )
     mock_client = MagicMock()
     mock_client.generate_text = AsyncMock(return_value=llm_output)
@@ -245,7 +246,7 @@ async def test_generate_navigation_markdown_falls_back_when_llm_invalid():
 
     assert llm_err == "模型返回内容无效或未包含推荐问题"
     assert "ai_agent_meta" in markdown
-    assert "(quick:/dataset_menu)" in markdown
+    assert "(quick:/dataset_portal)" in markdown
 
 
 @pytest.mark.asyncio
@@ -255,7 +256,7 @@ async def test_build_navigation_for_user_uses_dataset_menu_and_cache():
         "### 📚 我的数据门户\n---\n"
         "- [🙋 查告警](quick:统计最近一周机房告警记录)\n\n"
         "### 💬 您可能还想了解\n---\n"
-        "- [🙋 重新查看数据门户](quick:/dataset_menu)\n"
+        "- [🙋 重新查看数据门户](quick:/dataset_portal)\n"
     )
     mock_client = MagicMock()
     mock_client.generate_text = AsyncMock(return_value=llm_output)
@@ -428,7 +429,7 @@ def test_parse_groups_from_markdown_success():
         "\n"
         "**继续追问：**\n"
         "- [🙋 性能分析](quick:说明智能体响应时长的分布)\n"
-        "- [🙋 重新查看数据门户](quick:/dataset_menu)\n"
+        "- [🙋 重新查看数据门户](quick:/dataset_portal)\n"
     )
 
     parsed = DatasetNavigationService.parse_groups_from_markdown(markdown, static_groups)

--- a/tests/services/test_dataset_navigation_service.py
+++ b/tests/services/test_dataset_navigation_service.py
@@ -197,6 +197,33 @@ async def test_generate_navigation_markdown_uses_llm():
     assert "我的数据门户" in markdown
     assert "(quick:统计最近一周机房告警记录)" in markdown
     mock_client.generate_text.assert_awaited_once()
+    messages = mock_client.generate_text.await_args.args[0]
+    assert len(messages) == 2
+    assert messages[0].role == "system"
+    assert messages[1].role == "user"
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_generate_questions_via_llm_includes_user_message():
+    llm_output = "- [🙋 测试问题](quick:统计最近7天的访问量)"
+    mock_client = MagicMock()
+    mock_client.generate_text = AsyncMock(return_value=llm_output)
+
+    with patch(
+        "app.services.dataset_navigation_service.AgentConfigProvider.get_configured_llm",
+        AsyncMock(return_value=object()),
+    ), patch(
+        "app.services.dataset_navigation_service.chat_client_from_handle",
+        return_value=mock_client,
+    ):
+        questions = await DatasetNavigationService._generate_questions_via_llm("system prompt")
+
+    assert len(questions) == 1
+    messages = mock_client.generate_text.await_args.args[0]
+    assert messages[0].role == "system"
+    assert messages[1].role == "user"
+    assert "推荐问题" in messages[1].content[0].text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

## 概要 (Overview)

本 PR 在 `759c97f`（无数据集权限空态）基础上，集中修复 ChatBI 查数 Guard 误判、SQL 错误提示不友好、数据门户 LLM 失败无感知、移动端 iframe 内门户布局异常等问题；同时将数据门户 slash 指令统一为 `/dataset_portal`，并补齐 Qwen ds-api 网关对 system+user 消息格式的要求。

**变更规模：** 7 commits，21 files，+1003 / -435 行

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)

- [x] **数据门户指令更名**：新增 `/dataset_portal` 为正式指令，保留 `/dataset_menu` 向后兼容；门户 prompt 与缓存版本升至 v5
- [x] **ChatBI SQL 错误用户文案映射**：新增 `chatbi_sql_user_messages.py`，将权限拒绝、数据集不存在、表名校验失败等工具错误映射为中文产品提示
- [x] **system+user 消息统一**：通过 `system_user_prompt_messages` 修复数据门户生成、换一批、轮次分类、澄清引导等 LLM 调用，兼容 Qwen ds-api 网关

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)

- [x] **模型失败可感知**：门户 LLM 失败时返回 `llm_generation_failed`，前端展示明确错误态（红条/Toast），避免误导为「后台生成中」
- [x] **对话 SSE 错误展示**：正确读取 `content` 字段展示服务异常；挂起步骤超过 120 秒标红超时
- [x] **移动端数据门户**：抽屉使用 `teleport` + 相对容器百分比高度（替代 iframe 内 `dvh`），修复顶栏/关闭按钮被裁切、无法滚动；移动端隔离桌面钉住状态

### 3. 🐞 关键修复 (Bug Fixes)

- [x] **SQL 空结果 Guard 误判**：`total=0` 与 `rows` 并存时不再判空；移除 `LIMIT≤10` 泛化诊断规则；诊断完成后非空最终 SQL 允许出答
- [x] **SQL 致命/校验错误提示**：用户侧中文化展示；**repair 与模型上下文仍保留原始工具返回**，不影响 AI 自动修正
- [x] **AgentDebug 死代码清理**：移除未使用的内联门户逻辑，统一走 `useDatasetPortal` composable

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `8be31b6` | fix(llm): 补全 system+user 消息以兼容 Qwen ds-api 网关 |
| `b4b3c06` | fix(chatbi): 修复 SQL 空结果 Guard 误判导致有数据仍被阻断 |
| `f9601d8` | fix(ux): 优化模型失败提示与对话错误感知 |
| `8b612e4` | refactor(portal): 数据门户指令改为 `/dataset_portal` 并清理重复逻辑 |
| `d2ae62e` | fix(portal): 修复移动端数据门户钉住状态与滚动问题 |
| `7fe9a96` | fix(chatbi): 优化 SQL 权限与校验失败的用户可见提示 |
| `00068ae` | fix(portal): 修复 iframe 内移动端门户顶栏裁切与无法滚动 |

---

## 测试覆盖 (Testing)

- [ ] **UI 兼容性**：桌面端门户侧栏/钉住模式；移动端（含 AIChat iframe 内）门户打开、顶栏、关闭、滚动
- [ ] **ChatBI 查数**：有数据 SQL 不再被空结果 Guard 拦截；权限/表名/数据集错误展示中文提示；repair 轮仍能看到原始错误并尝试修正
- [ ] **数据门户**：`/dataset_portal` 与 `/dataset_menu` 均可打开；LLM 失败时红条/Toast；无权限空态仍正常
- [ ] **LLM 网关**：数据门户生成、换一批、轮次分类在 Qwen ds-api 下不再 400
- [x] **自动化测试**：
  - `tests/ai/runners/test_data_agent_runner.py`（空结果 Guard）
  - `tests/ai/test_chatbi_sql_user_messages.py`（错误文案映射）
  - `tests/ai/runtime/test_runtime_messages.py`（system+user 消息）
  - `tests/services/test_dataset_navigation_service.py`（门户 LLM 失败）
  - `tests/frontend/test_dataset_menu_loading_contract.py`（门户组件契约）

> [!IMPORTANT]
> 提交前请务必确认已更新 `tests/CHECKLIST.md` 中的自动化测试清单。

---

## 其他备注 (Notes)

- **无数据库迁移 / 无新增环境变量**
- **门户缓存**：prompt 版本 v5，部署后首次访问可能触发重新生成
- **双轨错误设计**：用户 SSE 正文为中文产品文案；思考步骤 `details` 与 repair 提示仍保留 `[Permission Denied]` / `[Validation Failed]` 等原始工具返回，便于排查与模型修正
- **建议重点回归**：
  1. 手机浏览器打开 Dashboard → AIChat → `/dataset_portal`
  2. ChatBI 故意查无权限表 / 错误数据集名
  3. 有数据但 `total=0` 的 SQL 结果是否正常出答
