### PR TITLE
Pull Request: 子代理委派加固 + Office 文档工具与生成文件下载

### DIFF
--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -14,5 +14,5 @@ v1_secured.include_router(fs.router, prefix="/chat/fs", tags=["V1 文件系统�
 
 v1_router = APIRouter()
 v1_router.include_router(v1_secured)
+v1_router.include_router(chat.public_router, prefix="/chat", tags=["V1 智能体对话"])
 v1_router.include_router(chatbi.public_router, prefix="/chatbi", tags=["V1 ChatBI"])
-

--- a/app/api/v1/endpoints/chat.py
+++ b/app/api/v1/endpoints/chat.py
@@ -6,7 +6,7 @@ import re
 import asyncio
 from typing import List, Optional, AsyncGenerator, Dict, Any
 from fastapi import APIRouter, HTTPException, Depends, Request, UploadFile, File
-from fastapi.responses import StreamingResponse, Response
+from fastapi.responses import FileResponse, StreamingResponse, Response
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.orm import get_db_session
@@ -22,6 +22,21 @@ import logging
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+public_router = APIRouter()
+
+
+@public_router.get("/generated-files/{artifact_id}")
+async def download_generated_file(artifact_id: str, token: str):
+    from app.services.ai.tools.generated_file_service import resolve_for_download
+
+    artifact = resolve_for_download(artifact_id, token)
+    if artifact is None:
+        raise HTTPException(status_code=404, detail="文件不存在或已过期")
+    return FileResponse(
+        artifact.path,
+        media_type=artifact.mime_type,
+        filename=artifact.filename,
+    )
 
 class SkillMeta(BaseModel):
     id: Optional[str] = Field(default=None, description="技能 ID")

--- a/app/api/v1/endpoints/fs.py
+++ b/app/api/v1/endpoints/fs.py
@@ -150,6 +150,16 @@ TEXT_PREVIEW_EXTENSIONS = {
     ".log", ".env"
 }
 
+OFFICE_PREVIEW_EXTENSIONS = {
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".doc": "application/msword",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".xls": "application/vnd.ms-excel",
+    ".xlsm": "application/vnd.ms-excel.sheet.macroEnabled.12",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".ppt": "application/vnd.ms-powerpoint",
+}
+
 @router.get(
     "/preview",
     summary="预览服务器文件内容",
@@ -218,6 +228,12 @@ async def preview_file(
         return FileResponse(
             safe_path,
             media_type="application/pdf",
+        )
+    elif ext in OFFICE_PREVIEW_EXTENSIONS:
+        return FileResponse(
+            safe_path,
+            media_type=OFFICE_PREVIEW_EXTENSIONS[ext],
+            filename=os.path.basename(safe_path),
         )
     else:
         raise HTTPException(status_code=400, detail="不支持预览该类型的文件。")

--- a/app/core/context.py
+++ b/app/core/context.py
@@ -35,6 +35,7 @@ class AgentContext(BaseModel):
     is_admin: bool = False
     api_key: Optional[str] = None
     user_dimensions: Dict[str, Any] = Field(default_factory=dict)
+    authorized_attachment_paths: List[str] = Field(default_factory=list)
     
     # Execution details for tracing (displayed in frontend)
     trace_logs: List[str] = Field(default_factory=list)

--- a/app/core/context.py
+++ b/app/core/context.py
@@ -43,6 +43,9 @@ class AgentContext(BaseModel):
     # Delegation control
     delegation_depth: int = 0
 
+    # Runtime tool approval (inherited by sub_agent_call delegation)
+    permission_options: Dict[str, Any] = Field(default_factory=dict)
+
     # Queue for streaming sub-agent log/progress chunks back to client
     event_queue: Optional[Any] = None
 

--- a/app/core/context.py
+++ b/app/core/context.py
@@ -42,6 +42,8 @@ class AgentContext(BaseModel):
 
     # Delegation control
     delegation_depth: int = 0
+    delegation_call_counts: Dict[str, int] = Field(default_factory=dict)
+    delegation_agent_call_counts: Dict[str, int] = Field(default_factory=dict)
 
     # Runtime tool approval (inherited by sub_agent_call delegation)
     permission_options: Dict[str, Any] = Field(default_factory=dict)

--- a/app/services/ai/agent_service.py
+++ b/app/services/ai/agent_service.py
@@ -23,7 +23,7 @@ from app.services.ai.runtime.session_run_lane import (
     ConversationRunBusyError,
     conversation_run_lane,
 )
-from app.services.ai.executors.common import extract_tokens_from_message
+from app.services.ai.executors.common import _attachment_abs_path, extract_tokens_from_message
 from app.services.ai.runtime.agentscope.compat import HumanMessage, SystemMessage
 from app.core.orm import AsyncSessionLocal
 
@@ -75,6 +75,18 @@ class AgentService:
             role=role,
         )
         return {"role": "system", "content": content}
+
+    @staticmethod
+    def _authorized_attachment_paths(messages: List[Dict[str, Any]]) -> List[str]:
+        """Return server-resolved paths for attachments present in this chat context."""
+        paths = {
+            _attachment_abs_path(file_obj)
+            for message in messages or []
+            if message.get("role") == "user"
+            for file_obj in message.get("files") or []
+            if file_obj.get("url")
+        }
+        return sorted(path for path in paths if path)
 
     async def chat_completion_stream(
         self,
@@ -695,6 +707,7 @@ class AgentService:
                 api_key=api_key,
                 conversation_id=conversation_id,
                 knowledge_dataset_ids=request_knowledge_dataset_ids,
+                authorized_attachment_paths=self._authorized_attachment_paths(messages),
                 trace_buffer=trace_buffer,
             )
 
@@ -789,6 +802,7 @@ class AgentService:
                     api_key=api_key,
                     conversation_id=conversation_id,
                     knowledge_dataset_ids=request_knowledge_dataset_ids,
+                    authorized_attachment_paths=self._authorized_attachment_paths(messages),
                     require_explicit_dataset=True,
                     trace_buffer=trace_buffer,
                 )

--- a/app/services/ai/agent_service.py
+++ b/app/services/ai/agent_service.py
@@ -77,8 +77,8 @@ class AgentService:
         return {"role": "system", "content": content}
 
     async def chat_completion_stream(
-        self, 
-        messages: List[Dict[str, str]], 
+        self,
+        messages: List[Dict[str, str]],
         agent_id: Optional[str] = None,
         agent_name: Optional[str] = None,
         version_id: Optional[str] = None,
@@ -96,7 +96,7 @@ class AgentService:
         trace_id = str(uuid.uuid4())
         trace_buffer: List[AgentExecutionStep] = []
         agent_config = None
-        
+
         # 1. Initial Identity Chunk
         yield {"trace_id": trace_id, "status": "init"}
 
@@ -268,9 +268,9 @@ class AgentService:
         """
         route_start = asyncio.get_running_loop().time()
         agent_config, route_details = await AgentContextManager.resolve_agent_config(
-            messages, 
-            agent_id=agent_id, 
-            agent_name=agent_name, 
+            messages,
+            agent_id=agent_id,
+            agent_name=agent_name,
             version_id=version_id,
             enable_multi_agent=enable_multi_agent,
             user_info=user_info,
@@ -290,7 +290,7 @@ class AgentService:
             r_turn_labels = getattr(route_details, "turn_labels", []) or []
             r_relation = getattr(route_details, "relation_to_previous", "unknown")
             r_action_type = getattr(route_details, "user_action_type", "unknown")
-            
+
             trace_buffer.append(AgentExecutionStep(
                 step_number=0,
                 event_type="router",
@@ -484,7 +484,7 @@ class AgentService:
         ignore_ltm = False
         if debug_options and debug_options.get("ignore_ltm"):
             ignore_ltm = True
-        
+
         from app.services.ai.turn_classifier import (
             should_inject_ltm,
             should_inject_memory_recall_hint,
@@ -527,11 +527,11 @@ class AgentService:
                         from app.services.ai.tools.memory_search_tool import parse_date_from_query
                         from app.services.ai.daily_summary_service import DailySummaryService
                         from app.services.ai.memory_index_service import MemoryIndexService
-                        
+
                         uid = str(u_id)
                         target_day = parse_date_from_query(user_query)
                         preloaded_memories = []
-                        
+
                         if target_day:
                             d_summary = await DailySummaryService.get_daily_summary(uid, target_day)
                             if d_summary:
@@ -561,7 +561,7 @@ class AgentService:
                                     preloaded_memories.append(
                                         AgentServicePrompts.recent_sessions_section(sess_lines)
                                     )
-                        
+
                         if preloaded_memories:
                             preloaded_memories_text = AgentServicePrompts.preloaded_memories(preloaded_memories)
                             logger.info(f"[ActiveMemory] Successfully preloaded memory context for user {u_id}")
@@ -689,7 +689,7 @@ class AgentService:
             )
 
             await AgentContextManager.setup_context(
-                config=agent_config, 
+                config=agent_config,
                 debug_options=debug_options,
                 user_info=user_info,
                 api_key=api_key,
@@ -813,19 +813,32 @@ class AgentService:
                 try:
                     from app.core.orm import AsyncSessionLocal
                     from app.services.ai.agent_manager import AgentManagerService
+                    from app.services.ai.tools.agent_delegate_tool import filter_delegable_system_agents
+
                     async with AsyncSessionLocal() as session:
                         active_agents = await AgentManagerService.list_agents(session)
+                        raw_user_id = None
+                        is_admin = False
+                        if user_info:
+                            raw_user_id = user_info.get("user_id") or user_info.get("id")
+                            is_admin = user_info.get("role") == "admin"
+                        delegable_agents = await filter_delegable_system_agents(
+                            session,
+                            active_agents,
+                            user_id=raw_user_id,
+                            is_admin=is_admin,
+                            current_agent_id=agent_config.agent_id,
+                        )
                         sub_agent_lines = []
-                        for a in active_agents:
-                            if a.is_enabled and a.is_system and str(a.id) != str(agent_config.agent_id):
-                                display = a.display_name or a.name
-                                desc = a.description or "无描述"
-                                caps = ", ".join(a.capabilities or [])
-                                sub_agent_lines.append(
-                                    f"- **标识 (agent_name)**: `{a.name}` (展示名: {display})\n"
-                                    f"  **职责描述**: {desc}\n"
-                                    f"  **核心能力**: [{caps}]"
-                                )
+                        for a in delegable_agents:
+                            display = a.display_name or a.name
+                            desc = a.description or "无描述"
+                            caps = ", ".join(a.capabilities or [])
+                            sub_agent_lines.append(
+                                f"- **标识 (agent_name)**: `{a.name}` (展示名: {display})\n"
+                                f"  **职责描述**: {desc}\n"
+                                f"  **核心能力**: [{caps}]"
+                            )
                         if sub_agent_lines:
                             sub_agents_context = (
                                 "## 可委派子智能体清单 (可用通讯录)\n"
@@ -876,7 +889,7 @@ class AgentService:
                         "status": "success",
                         "isDebug": True
                     }
-                
+
                 if debug_options.get("injected_context"):
                     context_data = debug_options["injected_context"]
                     logger.info(f"[Debug] Injecting Context: {context_data}")
@@ -917,7 +930,7 @@ class AgentService:
             agent_config.model_name = actual_model
 
             meta_event: Dict[str, Any] = {
-                "type": "meta", 
+                "type": "meta",
                 "agent_name": agent_config.agent_name,
                 "agent_display_name": agent_config.agent_display_name or agent_config.agent_name,
                 "model": actual_model,
@@ -941,7 +954,7 @@ class AgentService:
 
             # 4. Dispatch Executor
             secondary_agents = getattr(route_details, "secondary_agents", []) if route_details else []
-            
+
             if enable_multi_agent and secondary_agents:
                 async for chunk in self._execute_multi_agent(
                     agent_config,
@@ -974,7 +987,7 @@ class AgentService:
                     session_turn=session_turn,
                     route_hints=route_hints,
                 )
-                
+
                 yield {
                     "type": "log",
                     "title": "分析用户请求并进行意图识别",
@@ -1031,11 +1044,11 @@ class AgentService:
                 u_id = user_info.get("user_id") if user_info else None
                 handled_by = getattr(agent_config, "agent_name", None) if agent_config else None
                 asyncio.create_task(memory_service.add_message(
-                    u_id, 
-                    conversation_id, 
-                    "assistant", 
-                    full_response_content, 
-                    trace_id=trace_id, 
+                    u_id,
+                    conversation_id,
+                    "assistant",
+                    full_response_content,
+                    trace_id=trace_id,
                     agent_name=handled_by,
                     prompt_tokens=p_tokens,
                     completion_tokens=c_tokens,
@@ -1053,11 +1066,11 @@ class AgentService:
                 "content": format_execution_error(str(e), model_name=model_name),
                 "status": "error",
             }
-        
+
         finally:
             end_time = asyncio.get_running_loop().time()
             duration = (end_time - start_time) * 1000
-            
+
             if execution_status not in AWAITING_RESUME_STATUSES:
                 asyncio.create_task(AuditManager.log_transaction(
                      trace_id, agent_config, user_query, full_response_content,
@@ -1083,8 +1096,8 @@ class AgentService:
 
 
     async def chat_completion(
-        self, 
-        messages: List[Dict[str, str]], 
+        self,
+        messages: List[Dict[str, str]],
         agent_id: Optional[str] = None,
         agent_name: Optional[str] = None,
         version_id: Optional[str] = None,
@@ -1102,12 +1115,12 @@ class AgentService:
         full_content = ""
         trace_id = ""
         agent_name_resp = ""
-        
+
         async for chunk in self.chat_completion_stream(
-            messages, 
-            agent_id=agent_id, 
-            agent_name=agent_name, 
-            version_id=version_id, 
+            messages,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            version_id=version_id,
             conversation_id=conversation_id,
             user_info=user_info,
             api_key=api_key,
@@ -1121,7 +1134,7 @@ class AgentService:
                 full_content += chunk["content"]
             if "agent_name" in chunk:
                 agent_name_resp = chunk["agent_name"]
-                
+
         return {
             "content": full_content,
             "intent": "general_chat", # Simplified, real intent is in stream but not easily exposed here without refactor
@@ -1521,7 +1534,7 @@ class AgentService:
 
         # 3. Parallel Execution with Queue-based log streaming
         queue = asyncio.Queue()
-        
+
         async def run_executor(executor, config):
             full_text = ""
             try:
@@ -1541,9 +1554,9 @@ class AgentService:
             except Exception as e:
                 logger.error(f"Error in multi-agent sub-task ({config.agent_name}): {e}", exc_info=True)
                 await queue.put({
-                    "type": "log", 
-                    "title": f"[{config.agent_name}] 执行异常", 
-                    "details": str(e), 
+                    "type": "log",
+                    "title": f"[{config.agent_name}] 执行异常",
+                    "details": str(e),
                     "status": "error"
                 })
                 full_text = f"【{config.agent_name} 执行失败】: {str(e)}"
@@ -1552,7 +1565,7 @@ class AgentService:
         # Start all tasks
         tasks = [asyncio.create_task(run_executor(exec, conf)) for exec, conf in zip(executors, all_configs)]
         results_task = asyncio.gather(*tasks)
-        
+
         # Stream logs while tasks are running
         while not results_task.done() or not queue.empty():
             try:
@@ -1566,7 +1579,7 @@ class AgentService:
                 await asyncio.sleep(0.01)
 
         agent_outputs = await results_task
-        
+
         # 4. Final Synthesis
         yield {
             "type": "log",
@@ -1574,7 +1587,7 @@ class AgentService:
             "details": "正在汇总各专家意见并组织最终回答...",
             "status": "success"
         }
-        
+
         async for chunk in self._synthesize_multi_agent_results(
             primary_config, user_query, agent_outputs, trace_buffer
         ):
@@ -1593,14 +1606,14 @@ class AgentService:
         outputs_str = ""
         for out in agent_outputs:
             outputs_str += f"### 专家智能体: {out['name']}\n{out['content']}\n\n"
-        
+
         system_prompt = AgentServicePrompts.MULTI_AGENT_SYNTHESIS_SYSTEM
 
         human_content = AgentServicePrompts.multi_agent_synthesis_human(user_query, outputs_str)
-        
+
         # Use synthesis model from primary agent config
         llm = await AgentConfigProvider.get_synthesis_llm(streaming=True, config=config)
-        
+
         lc_messages = [
             SystemMessage(content=system_prompt),
             HumanMessage(content=human_content)

--- a/app/services/ai/context_manager.py
+++ b/app/services/ai/context_manager.py
@@ -204,6 +204,7 @@ class AgentContextManager:
         api_key: Optional[str] = None,
         conversation_id: Optional[str] = None,
         knowledge_dataset_ids: Optional[List[str]] = None,
+        authorized_attachment_paths: Optional[List[str]] = None,
         require_explicit_dataset: bool = False,
         trace_buffer: Optional[List[Any]] = None,
     ):
@@ -312,5 +313,6 @@ class AgentContextManager:
             is_admin=is_admin_val,
             api_key=api_key_val,
             user_dimensions=user_dims,
+            authorized_attachment_paths=list(authorized_attachment_paths or []),
             trace_buffer=trace_buffer or []
         ))

--- a/app/services/ai/context_manager.py
+++ b/app/services/ai/context_manager.py
@@ -43,13 +43,13 @@ class AgentContextManager:
         """
         Resolve the appropriate AgentConfig based on inputs or routing.
         Returns attributes needed for execution.
-        
+
         Returns:
             Tuple[Optional[ChatConfig], Optional[Any]]: The config and optional routing details.
         """
         agent_config = None
         route_details = None
-        
+
         async with AsyncSessionLocal() as session:
             if version_id:
                 agent_config = await AgentManagerService.get_version_config(session, version_id)
@@ -84,7 +84,7 @@ class AgentContextManager:
                         break
 
                 route_result = await router_service.route_query(
-                    last_user_msg, 
+                    last_user_msg,
                     history=history,
                     enable_multi_agent=enable_multi_agent,
                     user_id=route_user_id,
@@ -92,7 +92,7 @@ class AgentContextManager:
                     last_agent_name=last_agent_name,
                 )
                 route_details = route_result
-                
+
                 if route_result and route_result.agent_id:
                     agent_config = await AgentManagerService.get_active_agent_config(session, agent_id=route_result.agent_id)
 
@@ -198,7 +198,7 @@ class AgentContextManager:
 
     @staticmethod
     async def setup_context(
-        config: ChatConfig, 
+        config: ChatConfig,
         debug_options: Dict[str, Any] = {},
         user_info: Optional[Dict[str, Any]] = None,
         api_key: Optional[str] = None,
@@ -212,13 +212,13 @@ class AgentContextManager:
         """
         # 1. Set Debug Context
         set_debug_context(debug_options)
-        
+
         # 2. Set Agent Context
         u_id_val = None
         is_admin_val = False
         api_key_val = api_key
         user_dims = {}
-        
+
         if user_info:
             raw_uid = user_info.get("user_id", user_info.get("id"))
             if raw_uid:
@@ -226,7 +226,7 @@ class AgentContextManager:
             is_admin_val = user_info.get("role") == "admin"
             if not api_key_val:
                 api_key_val = user_info.get("api_key")
-            
+
             # Extract Dimensions for SQL Rewriter
             user_dims = {
                 "id": u_id_val,
@@ -236,7 +236,7 @@ class AgentContextManager:
                 "dept_code": user_info.get("dept_code"),
                 "org_path": user_info.get("org_path"),
             }
-            
+
             # Flatten extra_data into user_dims
             extra_data = user_info.get("extra_data")
             if extra_data:
@@ -248,7 +248,7 @@ class AgentContextManager:
                         extra_dict = json.loads(extra_data)
                     elif isinstance(extra_data, dict):
                         extra_dict = extra_data
-                    
+
                     if isinstance(extra_dict, dict):
                         for k, v in extra_dict.items():
                             # Avoid overwriting core dimensions
@@ -256,7 +256,7 @@ class AgentContextManager:
                                 user_dims[k] = v
                 except Exception as e:
                     logger.warning(f"Failed to parse or flatten extra_data: {e}")
-            
+
             # Keep original extra_data for backward compatibility
             user_dims["extra_data"] = extra_data
 

--- a/app/services/ai/executors/base.py
+++ b/app/services/ai/executors/base.py
@@ -94,6 +94,7 @@ class BaseExecutor(ABC):
                 user_dimensions=user_dims,
                 trace_buffer=self.trace_buffer or [],
                 delegation_depth=0,
+                permission_options=dict(self.permission_options or {}),
             )
             set_agent_context(ctx)
         return ctx

--- a/app/services/ai/executors/base.py
+++ b/app/services/ai/executors/base.py
@@ -10,11 +10,11 @@ class BaseExecutor(ABC):
     Base class for all Agent Executors.
     Defines the contract for streaming execution.
     """
-    
+
     def __init__(
-        self, 
-        config: ChatConfig, 
-        trace_id: str, 
+        self,
+        config: ChatConfig,
+        trace_id: str,
         trace_buffer: List[AgentExecutionStep],
         debug_options: Dict[str, Any] = None,
         user_info: Optional[Dict[str, Any]] = None,
@@ -32,7 +32,7 @@ class BaseExecutor(ABC):
 
     @abstractmethod
     async def execute(
-        self, 
+        self,
         history: List[Dict[str, str]]
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """
@@ -47,7 +47,7 @@ class BaseExecutor(ABC):
             from app.services.ai.knowledge_utils import merge_dataset_id_sources
             engine_config = self.config.engine_config or {}
             agent_dataset_ids = merge_dataset_id_sources(engine_config.get("dataset_ids"))
-            
+
             user_dims = {}
             u_id_val = None
             is_admin_val = False

--- a/app/services/ai/runners/assistant_agent_runner.py
+++ b/app/services/ai/runners/assistant_agent_runner.py
@@ -4,7 +4,7 @@ import json
 import inspect
 import logging
 import asyncio
-from typing import List, Dict, Any, AsyncGenerator, Optional
+from typing import List, Dict, Any, AsyncGenerator, Optional, Set
 from datetime import datetime
 
 from app.services.ai.runtime.agentscope.compat import (
@@ -268,6 +268,34 @@ class AssistantAgentRunner(BaseExecutor):
             return {"id": str(agent_id), "display_name": str(display_name)}
         return None
 
+    async def _resolve_available_sub_agent_names(self) -> Optional[Set[str]]:
+        if not is_main_general_agent(self.config):
+            return None
+        try:
+            from app.services.ai.tools.agent_delegate_tool import (
+                delegable_agent_name_aliases,
+                filter_delegable_system_agents,
+            )
+
+            raw_user_id = None
+            is_admin = False
+            if self.user_info:
+                raw_user_id = self.user_info.get("user_id") or self.user_info.get("id")
+                is_admin = self.user_info.get("role") == "admin"
+            async with AsyncSessionLocal() as session:
+                agents = await AgentManagerService.list_agents(session)
+                delegable_agents = await filter_delegable_system_agents(
+                    session,
+                    agents,
+                    user_id=raw_user_id,
+                    is_admin=is_admin,
+                    current_agent_id=self.config.agent_id,
+                )
+            return delegable_agent_name_aliases(delegable_agents)
+        except Exception as exc:
+            logger.warning("[AssistantAgentRunner] Failed to resolve sub-agent availability: %s", exc)
+            return None
+
     async def _build_data_guard_refusal_content(self) -> str:
         switch_agent = await self._resolve_switch_agent_for_capability(DATA_QUERY_SWITCH_CAPABILITY)
         base = (
@@ -438,10 +466,10 @@ class AssistantAgentRunner(BaseExecutor):
 
             start_synthesis = time.time()
             yield {"type": "log", "id": f"syn_s_{uuid.uuid4().hex[:8]}", "title": "📝 准备回答", "details": "正在生成回答...", "status": "success"}
-            
+
             # Use Synthesizer for simple mode
             llm = await AgentConfigProvider.get_synthesis_llm(streaming=True, config=self.config)
-            
+
             full_content = ""
             content_emitted = False
             accumulated_msg = None
@@ -479,9 +507,9 @@ class AssistantAgentRunner(BaseExecutor):
                     return
             if not stream_succeeded:
                 return
-            
+
             tokens = extract_tokens_from_message(accumulated_msg)
-            
+
             # Record final answer as a trace step
             self._increment_step()
             self.trace_buffer.append(AgentExecutionStep(
@@ -563,6 +591,7 @@ class AssistantAgentRunner(BaseExecutor):
                     tool_nudge = resolve_tool_nudge(
                         self._extract_last_user_query(history),
                         tools,
+                        available_sub_agent_names=await self._resolve_available_sub_agent_names(),
                     )
                     if tool_nudge is not None:
                         native_system_content = f"{tool_nudge.message}\n\n{native_system_content}"
@@ -1304,7 +1333,7 @@ class AssistantAgentRunner(BaseExecutor):
         runtime_cfg = getattr(target_tool, "_runtime_config", None)
         t_model = getattr(runtime_cfg, "model_name", self.config.model_name)
         t_temp = getattr(runtime_cfg, "temperature", self.config.temperature)
-        
+
         # Ensure types for AgentExecutionStep validation (especially when using Mocks in tests)
         if not isinstance(t_model, str): t_model = str(self.config.model_name)
         if not isinstance(t_temp, (int, float)): t_temp = float(self.config.temperature or 0)
@@ -1316,7 +1345,7 @@ class AssistantAgentRunner(BaseExecutor):
             execution_time_ms=duration_tool, status="success" if not is_error else "error",
             timestamp=datetime.fromtimestamp(time.time() - duration_tool / 1000)
         )
-        
+
         if tool_name == "search_knowledge_base" and not is_error:
             from app.services.ai.knowledge_utils import format_knowledge_tool_log_display
 
@@ -1332,7 +1361,7 @@ class AssistantAgentRunner(BaseExecutor):
             "model": t_model,
             "temperature": t_temp,
         }
-        
+
         # --- [NEW: Citation Extraction & Multi-Track Unpacking] ---
         citation_event = None
         final_tool_message_content = str(tool_output)
@@ -1354,7 +1383,7 @@ class AssistantAgentRunner(BaseExecutor):
                     # 'content' goes to LLM, 'citations' goes to Frontend
                     if "content" in parsed_res:
                         final_tool_message_content = parsed_res["content"]
-                    
+
                     chunks = parsed_res.get("citations")
                     if isinstance(chunks, list) and len(chunks) > 0:
                         citation_event = {
@@ -1375,7 +1404,7 @@ class AssistantAgentRunner(BaseExecutor):
         return {
             "index": tool_index,
             "final_tool_message_content": final_tool_message_content,
-            "trace": trace_step, 
+            "trace": trace_step,
             "log": log_event,
             "citation": citation_event
         }

--- a/app/services/ai/runners/chatbi/sql_gates.py
+++ b/app/services/ai/runners/chatbi/sql_gates.py
@@ -957,6 +957,12 @@ def detect_sql_static_risk(sql: str) -> str:
     return ""
 
 
+_NON_COUNT_AGGREGATE_RE = re.compile(
+    r"\b(SUM|AVG|MAX|MIN|LISTAGG|WM_CONCAT|MEDIAN|STDDEV|VARIANCE)\s*\(",
+    re.IGNORECASE,
+)
+
+
 def is_diagnostic_sql(sql: str) -> bool:
     sql_upper = " ".join(str(sql or "").upper().split())
     if any(x in sql_upper for x in ("SHOW TABLES", "SHOW COLUMNS", "DESCRIBE ", "DESC ")):
@@ -964,6 +970,11 @@ def is_diagnostic_sql(sql: str) -> bool:
     if "SELECT DISTINCT" in sql_upper and "LIMIT" in sql_upper:
         return True
     if "COUNT(" in sql_upper and "GROUP BY" not in sql_upper:
+        # 多聚合汇总（如 COUNT+SUM）或带 WHERE 的过滤统计，视为最终业务 SQL，非探路诊断。
+        if _NON_COUNT_AGGREGATE_RE.search(sql_upper):
+            return False
+        if re.search(r"\bWHERE\b", sql_upper):
+            return False
         return True
     if " IS NOT NULL" in sql_upper and ("ROWNUM <=" in sql_upper or " LIMIT " in sql_upper or "FETCH FIRST" in sql_upper):
         if re.search(r"\bSELECT\b[\s\S]{0,200}\bFROM\b", sql_upper):

--- a/app/services/ai/runtime/agentscope/tools.py
+++ b/app/services/ai/runtime/agentscope/tools.py
@@ -36,6 +36,7 @@ READ_ONLY_TOOL_NAMES = {
     "fetch_static_web_url",
     "web_search_baidu",
     "system_http_request",
+    "sub_agent_call",
 }
 
 @dataclass(frozen=True)

--- a/app/services/ai/tool_nudge_policy.py
+++ b/app/services/ai/tool_nudge_policy.py
@@ -134,6 +134,7 @@ def resolve_tool_nudge(
     *,
     min_score: float = 0.34,
     exclude_tools: Optional[Set[str]] = None,
+    available_sub_agent_names: Optional[Set[str]] = None,
 ) -> Optional[ToolNudge]:
     """解析本轮是否需要工具促发；返回相关度最高的一条便签或 None。
 
@@ -151,8 +152,16 @@ def resolve_tool_nudge(
             looks_like_business_data_request,
             looks_like_knowledge_query,
         )
+        def _sub_agent_available(name: str) -> bool:
+            if available_sub_agent_names is None:
+                return True
+            aliases = {name, name.replace("_", "-"), name.replace("-", "_")}
+            return bool(aliases & available_sub_agent_names)
+
         # 优先判断更具体的知识库检索意图
         if looks_like_knowledge_query(query):
+            if not _sub_agent_available("knowledge-base"):
+                return None
             desc = (
                 "用户问题涉及内部制度、SOP或操作规程查询。主助手没有直接读取知识库能力，"
                 "你必须优先调用 sub_agent_call(agent_name='knowledge-base', query='用户的问题') 委派给知识库助手 'knowledge-base' 检索文档，拿到结果再回答；"
@@ -164,6 +173,8 @@ def resolve_tool_nudge(
                 message=f"【本轮工具优先】本轮用户请求涉及制度、SOP或规范文档检索。{desc}"
             )
         elif looks_like_business_data_request(query):
+            if not _sub_agent_available("chat-bi"):
+                return None
             desc = (
                 "用户问题涉及内部数据、指标或资产查询。主助手没有直接连接数据库能力，"
                 "你必须优先调用 sub_agent_call(agent_name='chat-bi', query='用户的问题') 委派给数据智能助手 'chat-bi' 获取真实数据，拿到结果再回答；"

--- a/app/services/ai/tools/agent_delegate_tool.py
+++ b/app/services/ai/tools/agent_delegate_tool.py
@@ -3,7 +3,7 @@ import asyncio
 import re
 import uuid
 import inspect
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 from app.services.ai.tools.tool_compat import tool
 from app.core.context import get_current_agent_context, AgentContext, set_agent_context
 from app.core.orm import AsyncSessionLocal
@@ -11,6 +11,26 @@ from app.services.ai.agent_manager import AgentManagerService
 from app.services.permission_service import PermissionService
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_DELEGATION_TIMEOUT_SECONDS = 120.0
+DEFAULT_DELEGATION_RESULT_MAX_CHARS = 8000
+
+INTERRUPT_SSE_TYPES = frozenset({"permission_required", "external_execution_required"})
+
+EMPTY_DELEGATION_RESULT_MESSAGE = (
+    "子智能体已执行完成，但未产生可交付正文（可能仅有内部进度日志或工具中间结果）。"
+    "请勿使用相同参数重复委派；请根据上述情况向用户说明，或建议其直接打开对应子智能体对话。"
+)
+
+DELEGATION_INTERRUPT_MESSAGES = {
+    "permission_required": (
+        "错误：子智能体执行过程中需要用户确认工具权限，当前委派模式无法在子流程中完成确认。"
+        "请直接打开对应子智能体对话，或联系管理员调整工具自动执行策略。"
+    ),
+    "external_execution_required": (
+        "错误：子智能体需要外部执行确认，当前委派模式不支持。请直接打开对应子智能体对话。"
+    ),
+}
 
 
 def clean_sub_agent_output(text: str) -> str:
@@ -31,6 +51,89 @@ def _extract_delegation_text(chunk: Dict[str, Any]) -> str:
         if value:
             return str(value)
     return ""
+
+
+def resolve_delegation_permission_options(
+    main_options: Dict[str, Any] | None,
+) -> Dict[str, Any]:
+    """子代理在委派链路内无法向用户弹出工具确认，强制 auto-allow。"""
+    options = dict(main_options or {})
+    options["approval_mode"] = "allow"
+    return options
+
+
+def finalize_delegation_output(
+    full_output: str,
+    *,
+    max_chars: int = DEFAULT_DELEGATION_RESULT_MAX_CHARS,
+) -> str:
+    cleaned_output = clean_sub_agent_output(full_output)
+    if not cleaned_output.strip():
+        return EMPTY_DELEGATION_RESULT_MESSAGE
+    if len(cleaned_output) > max_chars:
+        cleaned_output = (
+            cleaned_output[:max_chars]
+            + "\n\n...[因数据量过大，子代理回复已被系统自动截断]"
+        )
+    return cleaned_output
+
+
+async def _resolve_delegation_timeout_seconds() -> float:
+    try:
+        from app.services.config_service import ConfigService
+
+        raw = await ConfigService.get(
+            "sub_agent_delegation_timeout_seconds",
+            str(int(DEFAULT_DELEGATION_TIMEOUT_SECONDS)),
+        )
+        return max(30.0, float(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_DELEGATION_TIMEOUT_SECONDS
+
+
+async def _resolve_delegation_result_max_chars() -> int:
+    try:
+        from app.services.config_service import ConfigService
+
+        raw = await ConfigService.get(
+            "sub_agent_delegation_result_max_chars",
+            str(DEFAULT_DELEGATION_RESULT_MAX_CHARS),
+        )
+        return max(500, int(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_DELEGATION_RESULT_MAX_CHARS
+
+
+async def _consume_sub_agent_stream(
+    sub_stream: Any,
+    *,
+    main_ctx: AgentContext,
+    sub_display_name: str,
+) -> Tuple[str, str | None]:
+    """消费子代理流，返回 (正文, 中断类型或 None)。"""
+    full_output = ""
+    interrupt_type: str | None = None
+
+    async for chunk in sub_stream:
+        chunk_type = str(chunk.get("type") or "")
+        if chunk_type in INTERRUPT_SSE_TYPES:
+            interrupt_type = chunk_type
+            logger.warning(
+                "[Delegation] Sub-agent '%s' interrupted with %s during delegation",
+                sub_display_name,
+                chunk_type,
+            )
+            break
+
+        text = _extract_delegation_text(chunk)
+        if text:
+            full_output += text
+        elif chunk_type == "log" and main_ctx.event_queue:
+            title = chunk.get("title", "")
+            chunk["title"] = f"[{sub_display_name}] {title}"
+            await main_ctx.event_queue.put(chunk)
+
+    return full_output, interrupt_type
 
 
 @tool
@@ -117,6 +220,8 @@ async def sub_agent_call(agent_name: str, query: str) -> str:
     sub_engine_config = dict(target_config.engine_config or {})
     sub_engine_config["dataset_ids"] = effective_dataset_ids
 
+    sub_permission_options = resolve_delegation_permission_options(main_ctx.permission_options)
+
     # 创建一个专属子上下文，隔离历史，但保留用户信息和 API Key 供子工具鉴权
     sub_ctx = AgentContext(
         agent_id=str(target_config.agent_id),
@@ -134,6 +239,7 @@ async def sub_agent_call(agent_name: str, query: str) -> str:
         delegation_depth=main_ctx.delegation_depth + 1,  # 深度加 1
         trace_buffer=main_ctx.trace_buffer,  # 共用 trace 收集物理步骤
         event_queue=main_ctx.event_queue,  # 传递 event_queue 用于流式穿透
+        permission_options=sub_permission_options,
     )
 
     # [CR Fix] 从 main_ctx 还原 user_info 并传给 dispatch，避免 session lock 和维度缺失
@@ -148,16 +254,16 @@ async def sub_agent_call(agent_name: str, query: str) -> str:
         "extra_data": main_ctx.user_dimensions.get("extra_data") if main_ctx.user_dimensions else None,
     } if main_ctx else None
 
-    # 5. 实例化子执行器 (Dispatch Sub Executor)
-    from app.services.ai.dispatcher import AgentDispatcher
-    sub_executor = await AgentDispatcher.dispatch(
+    delegation_timeout = await _resolve_delegation_timeout_seconds()
+    result_max_chars = await _resolve_delegation_result_max_chars()
+
+    sub_executor = await _dispatch_sub_agent_executor(
         target_config,
         query,
         sub_history,
         trace_id=f"sub_{uuid.uuid4().hex[:8]}",
         trace_buffer=main_ctx.trace_buffer,
-        debug_options=None,
-        permission_options=None,
+        permission_options=sub_permission_options,
         user_info=user_info,
         conversation_id=main_ctx.conversation_id,
     )
@@ -169,35 +275,35 @@ async def sub_agent_call(agent_name: str, query: str) -> str:
     full_output = ""
     sub_display_name = target_config.agent_display_name or target_config.agent_name or agent_name
     sub_stream = None
+    interrupt_type: str | None = None
 
     try:
-        # 6. 超时控制 (60 Seconds Timeout)
         sub_stream = sub_executor.execute(sub_history)
 
         async def consume_stream():
-            nonlocal full_output
-            async for chunk in sub_stream:
-                text = _extract_delegation_text(chunk)
-                if text:
-                    full_output += text
-                # 7. 日志实时穿透 (SSE log forwarding)
-                elif chunk.get("type") == "log" and main_ctx.event_queue:
-                    title = chunk.get("title", "")
-                    chunk["title"] = f"[{sub_display_name}] {title}"
-                    await main_ctx.event_queue.put(chunk)
+            nonlocal full_output, interrupt_type
+            full_output, interrupt_type = await _consume_sub_agent_stream(
+                sub_stream,
+                main_ctx=main_ctx,
+                sub_display_name=sub_display_name,
+            )
 
-        await asyncio.wait_for(consume_stream(), timeout=60.0)
+        await asyncio.wait_for(consume_stream(), timeout=delegation_timeout)
 
     except asyncio.TimeoutError:
-        logger.warning(f"[Delegation] Sub-agent '{agent_name}' timed out after 60 seconds.")
+        logger.warning(
+            "[Delegation] Sub-agent '%s' timed out after %.0f seconds.",
+            agent_name,
+            delegation_timeout,
+        )
         if main_ctx.event_queue:
             await main_ctx.event_queue.put({
                 "type": "log",
                 "title": f"[{sub_display_name}] 调用超时",
-                "details": "子智能体未能在 60 秒内返回数据，强制中断并释放资源。",
+                "details": f"子智能体未能在 {int(delegation_timeout)} 秒内返回数据，强制中断并释放资源。",
                 "status": "error"
             })
-        return f"错误：调用子智能体 '{sub_display_name}' 响应超时（已达 60 秒限制）。"
+        return f"错误：调用子智能体 '{sub_display_name}' 响应超时（已达 {int(delegation_timeout)} 秒限制）。"
     except Exception as e:
         logger.error(f"[Delegation] Error executing sub-agent '{agent_name}': {e}", exc_info=True)
         return f"错误：调用子智能体 '{sub_display_name}' 时发生异常：{str(e)}"
@@ -209,11 +315,37 @@ async def sub_agent_call(agent_name: str, query: str) -> str:
                 logger.warning(f"Failed to close sub-agent generator stream: {close_err}")
         set_agent_context(original_ctx)
 
-    # 8. 过滤去噪与截断 (Sanitization & Truncation)
-    cleaned_output = clean_sub_agent_output(full_output)
-    
-    max_chars = 2000
-    if len(cleaned_output) > max_chars:
-        cleaned_output = cleaned_output[:max_chars] + "\n\n...[因数据量过大，子代理回复已被系统自动截断]"
+    if interrupt_type:
+        return DELEGATION_INTERRUPT_MESSAGES.get(
+            interrupt_type,
+            f"错误：子智能体 '{sub_display_name}' 执行被中断（{interrupt_type}），委派未完成。",
+        )
 
-    return cleaned_output
+    return finalize_delegation_output(full_output, max_chars=result_max_chars)
+
+
+async def _dispatch_sub_agent_executor(
+    target_config: Any,
+    query: str,
+    sub_history: List[Dict[str, str]],
+    *,
+    trace_id: str,
+    trace_buffer: List[Any],
+    permission_options: Dict[str, Any],
+    user_info: Dict[str, Any] | None,
+    conversation_id: str | None,
+) -> Any:
+    from app.services.ai.dispatcher import AgentDispatcher
+
+    return await AgentDispatcher.dispatch(
+        target_config,
+        query,
+        sub_history,
+        trace_id=trace_id,
+        trace_buffer=trace_buffer,
+        debug_options=None,
+        permission_options=permission_options,
+        user_info=user_info,
+        conversation_id=conversation_id,
+    )
+

--- a/app/services/ai/tools/agent_delegate_tool.py
+++ b/app/services/ai/tools/agent_delegate_tool.py
@@ -3,7 +3,7 @@ import asyncio
 import re
 import uuid
 import inspect
-from typing import Optional, Dict, Any, List, Tuple
+from typing import Optional, Dict, Any, List, Tuple, Iterable
 from app.services.ai.tools.tool_compat import tool
 from app.core.context import get_current_agent_context, AgentContext, set_agent_context
 from app.core.orm import AsyncSessionLocal
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DELEGATION_TIMEOUT_SECONDS = 120.0
 DEFAULT_DELEGATION_RESULT_MAX_CHARS = 8000
+MAX_DELEGATION_CALLS_PER_AGENT = 2
 
 INTERRUPT_SSE_TYPES = frozenset({"permission_required", "external_execution_required"})
 
@@ -56,10 +57,116 @@ def _extract_delegation_text(chunk: Dict[str, Any]) -> str:
 def resolve_delegation_permission_options(
     main_options: Dict[str, Any] | None,
 ) -> Dict[str, Any]:
-    """子代理在委派链路内无法向用户弹出工具确认，强制 auto-allow。"""
+    """继承主流程审批策略；默认 ask，避免静默委派绕过写入/外部工具确认。"""
     options = dict(main_options or {})
-    options["approval_mode"] = "allow"
+    options.setdefault("approval_mode", "ask")
     return options
+
+
+def _normalize_agent_name(value: str | None) -> str:
+    return (value or "").lower().replace("-", "_").strip()
+
+
+def _normalize_delegation_query(value: str | None) -> str:
+    return " ".join((value or "").strip().split())
+
+
+def _delegation_signature(agent_name: str | None, query: str | None) -> str:
+    return f"{_normalize_agent_name(agent_name)}:{_normalize_delegation_query(query)}"
+
+
+def _record_delegation_attempt(
+    ctx: AgentContext,
+    *,
+    agent_name: str,
+    display_name: str,
+    query: str,
+) -> str | None:
+    signature = _delegation_signature(agent_name, query)
+    call_counts = ctx.delegation_call_counts
+    if call_counts.get(signature, 0) >= 1:
+        return (
+            f"错误：本轮已经对 `{agent_name}`（{display_name}）使用相同问题执行过一次 sub_agent_call。"
+            "请勿重复委派；请基于上一次工具结果回答，或向用户说明子智能体结果不足。"
+        )
+
+    agent_key = _normalize_agent_name(agent_name)
+    agent_counts = ctx.delegation_agent_call_counts
+    if agent_counts.get(agent_key, 0) >= MAX_DELEGATION_CALLS_PER_AGENT:
+        return (
+            f"错误：本轮已多次委派 `{agent_name}`（{display_name}），系统已阻止继续重复调用。"
+            "请基于已有子智能体结果回答，或向用户说明需要切换到对应子智能体对话继续处理。"
+        )
+
+    call_counts[signature] = call_counts.get(signature, 0) + 1
+    agent_counts[agent_key] = agent_counts.get(agent_key, 0) + 1
+    return None
+
+
+def _matches_requested_agent(agent: Any, requested_name: str) -> bool:
+    target_clean = _normalize_agent_name(requested_name)
+    agent_name = getattr(agent, "name", None)
+    if agent_name and _normalize_agent_name(agent_name) == target_clean:
+        return True
+    display_name = getattr(agent, "display_name", None)
+    if display_name and display_name.strip() == requested_name.strip():
+        return True
+    if display_name and display_name.lower().strip() == requested_name.lower().strip():
+        return True
+    return False
+
+
+async def can_delegate_to_agent(
+    session: Any,
+    *,
+    user_id: int | str | None,
+    is_admin: bool,
+    target_agent_id: str,
+) -> bool:
+    if not user_id or is_admin:
+        return True
+    perm_service = PermissionService(session)
+    return await perm_service.check_permission(int(user_id), "agent", str(target_agent_id))
+
+
+async def filter_delegable_system_agents(
+    session: Any,
+    agents: Iterable[Any],
+    *,
+    user_id: int | str | None,
+    is_admin: bool,
+    current_agent_id: str | None,
+) -> List[Any]:
+    delegable: List[Any] = []
+    for agent in agents or []:
+        if not getattr(agent, "is_enabled", False) or not getattr(agent, "is_system", False):
+            continue
+        agent_id = str(getattr(agent, "id", "") or "")
+        if current_agent_id and agent_id == str(current_agent_id):
+            continue
+        if await can_delegate_to_agent(
+            session,
+            user_id=user_id,
+            is_admin=is_admin,
+            target_agent_id=agent_id,
+        ):
+            delegable.append(agent)
+    return delegable
+
+
+def delegable_agent_name_aliases(agents: Iterable[Any]) -> set[str]:
+    aliases: set[str] = set()
+    for agent in agents or []:
+        name = getattr(agent, "name", None)
+        if name:
+            name_str = str(name)
+            aliases.add(name_str)
+            aliases.add(name_str.replace("_", "-"))
+            aliases.add(name_str.replace("-", "_"))
+        display_name = getattr(agent, "display_name", None)
+        if display_name:
+            aliases.add(str(display_name))
+    return aliases
 
 
 def finalize_delegation_output(
@@ -160,53 +267,55 @@ async def sub_agent_call(agent_name: str, query: str) -> str:
         # 强制只查询启用的系统内置智能体 (is_system = True)
         stmt = select(AIAgent).where(AIAgent.is_enabled == True, AIAgent.is_system == True)
         all_active_system = (await session.execute(stmt)).scalars().all()
-        
-        matched_agent = None
-        clean_name = lambda s: s.lower().replace('-', '_').strip() if s else ""
-        target_clean = clean_name(agent_name)
-        
         for a in all_active_system:
-            # 规则1：英文标识忽略大小写和中划线/下划线比对
-            if a.name and clean_name(a.name) == target_clean:
+            if str(getattr(a, "id", "") or "") == str(main_ctx.agent_id) and _matches_requested_agent(a, agent_name):
+                return "错误：主智能体无法委派调用自身。"
+
+        delegable_agents = await filter_delegable_system_agents(
+            session,
+            all_active_system,
+            user_id=main_ctx.user_id,
+            is_admin=main_ctx.is_admin,
+            current_agent_id=main_ctx.agent_id,
+        )
+
+        matched_agent = None
+
+        for a in delegable_agents:
+            if _matches_requested_agent(a, agent_name):
                 matched_agent = a
                 break
-            # 规则2：中文/英文展示名比对
-            if a.display_name and a.display_name.strip() == agent_name.strip():
-                matched_agent = a
-                break
-            if a.display_name and a.display_name.lower().strip() == agent_name.lower().strip():
-                matched_agent = a
-                break
-        
+
         if matched_agent:
             # 使用匹配到的正确的英文标识名重新加载配置
             target_config = await AgentManagerService.get_active_agent_config(session, agent_name=matched_agent.name)
-            
+
             # [CR Fix] 阻止自委派 (matched_agent.id == main_ctx.agent_id)
             if target_config and str(target_config.agent_id) == str(main_ctx.agent_id):
                 return "错误：主智能体无法委派调用自身。"
-        
+
         if not target_config:
-            # 无论如何都找不到，列出当前系统已启用的内置系统智能体列表，供模型自我纠错
+            # 无论如何都找不到，只列出当前用户可委派的候选，供模型自我纠错
             candidates = [
-                f"`{a.name}` ({a.display_name or a.name})" 
-                for a in all_active_system 
-                if str(a.id) != str(main_ctx.agent_id)
+                f"`{a.name}` ({a.display_name or a.name})"
+                for a in delegable_agents
             ]
             candidates_str = ", ".join(candidates)
             return (
                 f"错误：未找到名为 '{agent_name}' 的启用系统智能体。请重新反思问题，并只能从以下当前已启用的系统内置候选智能体列表中选择正确的英文标识 (agent_name) 进行 `sub_agent_call` 调用：{candidates_str}"
             )
 
-        # 3. 权限校验
-        if main_ctx.user_id and not main_ctx.is_admin:
-            perm_service = PermissionService(session)
-            has_perm = await perm_service.check_permission(int(main_ctx.user_id), "agent", str(target_config.agent_id))
-            if not has_perm:
-                return f"错误：当前用户无权访问子智能体 '{target_config.agent_display_name or agent_name}'。"
-
     # 4. 构造子代理独立上下文 (Sandbox Isolation)
     sub_history = [{"role": "user", "content": query}]
+    sub_display_name = target_config.agent_display_name or target_config.agent_name or agent_name
+    repeat_error = _record_delegation_attempt(
+        main_ctx,
+        agent_name=target_config.agent_name or agent_name,
+        display_name=sub_display_name,
+        query=query,
+    )
+    if repeat_error:
+        return repeat_error
 
     # [CR Fix] 继承主上下文已生效的知识库 ID，并与子智能体引擎自身配置的 IDs 合并
     effective_dataset_ids = list(set(main_ctx.dataset_ids or []))
@@ -273,7 +382,6 @@ async def sub_agent_call(agent_name: str, query: str) -> str:
     set_agent_context(sub_ctx)
 
     full_output = ""
-    sub_display_name = target_config.agent_display_name or target_config.agent_name or agent_name
     sub_stream = None
     interrupt_type: str | None = None
 
@@ -348,4 +456,3 @@ async def _dispatch_sub_agent_executor(
         user_info=user_info,
         conversation_id=conversation_id,
     )
-

--- a/app/services/ai/tools/document_paths.py
+++ b/app/services/ai/tools/document_paths.py
@@ -1,0 +1,128 @@
+"""Path validation shared by Office document tools."""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Iterable
+
+from app.utils.fs_paths import get_data_base_dir
+
+MAX_DOCUMENT_BYTES = 20 * 1024 * 1024
+
+
+class DocumentPathError(ValueError):
+    """A document path is not safe for the current request."""
+
+
+async def resolve_workspace_root() -> str:
+    from app.services.ai.runtime.agentscope.workspace import resolve_workspace_root as resolver
+
+    return await resolver()
+
+
+def resolve_session_workdir(*, root: str, user_id: int | str | None, conversation_id: str) -> str:
+    from app.services.ai.runtime.agentscope.workspace import resolve_session_workdir as resolver
+
+    return resolver(root=root, user_id=user_id, conversation_id=conversation_id)
+
+
+def _path_under(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _normalize_platform_path(path: str) -> Path:
+    data_root = Path(get_data_base_dir()).resolve()
+    raw_path = str(path or "")
+    if raw_path == "/app/data":
+        return data_root
+    if raw_path.startswith("/app/data/"):
+        raw_path = str(data_root / raw_path.removeprefix("/app/data/"))
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = data_root / candidate
+    return candidate.resolve()
+
+
+def _validate_extension(path: Path, allowed_extensions: Iterable[str]) -> None:
+    allowed = {str(ext).lower() for ext in allowed_extensions}
+    if path.suffix.lower() not in allowed:
+        supported = ", ".join(sorted(allowed))
+        raise DocumentPathError(f"不支持的文件类型，仅支持：{supported}")
+
+
+async def resolve_document_input_path(
+    path: str,
+    *,
+    allowed_attachment_paths: Iterable[str],
+    user_id: int | str | None,
+    conversation_id: str | None,
+    allowed_extensions: Iterable[str],
+) -> Path:
+    """Resolve one existing document, limited to this request's attachments or workspace."""
+    candidate = _normalize_platform_path(path)
+    if not candidate.is_file():
+        raise DocumentPathError("文件不存在或不可访问")
+    if candidate.stat().st_size > MAX_DOCUMENT_BYTES:
+        raise DocumentPathError("文件大小超出 20MB 限制")
+    _validate_extension(candidate, allowed_extensions)
+
+    data_root = Path(get_data_base_dir()).resolve()
+    uploads_root = (data_root / "uploads").resolve()
+    allowed_uploads = {_normalize_platform_path(item) for item in allowed_attachment_paths}
+    if _path_under(candidate, uploads_root):
+        if candidate not in allowed_uploads:
+            raise DocumentPathError("该上传文件不属于当前会话附件")
+        return candidate
+
+    if not conversation_id:
+        raise DocumentPathError("当前会话缺少工作目录，无法访问该文件")
+    workspace_root = Path(await resolve_workspace_root()).resolve()
+    session_workdir = Path(
+        resolve_session_workdir(
+            root=str(workspace_root),
+            user_id=user_id,
+            conversation_id=conversation_id,
+        )
+    ).resolve()
+    if not _path_under(candidate, session_workdir):
+        raise DocumentPathError("文件不在当前会话允许访问的目录中")
+    return candidate
+
+
+def sanitize_output_filename(filename: str, allowed_extensions: Iterable[str]) -> str:
+    raw_name = os.path.basename(str(filename or "")).strip()
+    clean_name = re.sub(r'[\x00-\x1f<>:"/\\|?*]+', "_", raw_name)
+    if not clean_name or clean_name in {".", ".."}:
+        raise DocumentPathError("输出文件名不能为空")
+    _validate_extension(Path(clean_name), allowed_extensions)
+    return clean_name
+
+
+async def resolve_document_output_path(
+    filename: str,
+    *,
+    user_id: int | str | None,
+    conversation_id: str | None,
+    allowed_extensions: Iterable[str],
+) -> Path:
+    if not conversation_id:
+        raise DocumentPathError("当前会话缺少工作目录，无法生成文件")
+    clean_name = sanitize_output_filename(filename, allowed_extensions)
+    workspace_root = Path(await resolve_workspace_root()).resolve()
+    session_workdir = Path(
+        resolve_session_workdir(
+            root=str(workspace_root),
+            user_id=user_id,
+            conversation_id=conversation_id,
+        )
+    ).resolve()
+    session_workdir.mkdir(parents=True, exist_ok=True)
+    output_path = (session_workdir / clean_name).resolve()
+    if not _path_under(output_path, session_workdir):
+        raise DocumentPathError("输出文件路径不安全")
+    return output_path

--- a/app/services/ai/tools/excel_document_tool.py
+++ b/app/services/ai/tools/excel_document_tool.py
@@ -1,0 +1,156 @@
+"""Controlled Excel document tools for configured agents."""
+from __future__ import annotations
+
+from typing import Any
+
+from openpyxl import Workbook, load_workbook
+from openpyxl.utils.cell import range_boundaries
+
+from app.core.context import get_current_agent_context
+from app.services.ai.tools.document_paths import (
+    DocumentPathError,
+    resolve_document_input_path,
+    resolve_document_output_path,
+)
+from app.services.ai.tools.generated_file_service import publish
+from app.services.ai.tools.tool_compat import tool
+
+_EXTENSIONS = {".xlsx"}
+_MAX_PREVIEW_ROWS = 20
+_MAX_PREVIEW_COLUMNS = 20
+_MAX_RANGE_ROWS = 200
+_MAX_RANGE_COLUMNS = 50
+
+
+def _context():
+    context = get_current_agent_context()
+    if not context:
+        raise DocumentPathError("无法获取当前执行上下文")
+    return context
+
+
+async def _input_path(path: str):
+    context = _context()
+    return await resolve_document_input_path(
+        path,
+        allowed_attachment_paths=context.authorized_attachment_paths,
+        user_id=context.user_id,
+        conversation_id=context.conversation_id,
+        allowed_extensions=_EXTENSIONS,
+    )
+
+
+async def _output_path(filename: str):
+    context = _context()
+    return await resolve_document_output_path(
+        filename,
+        user_id=context.user_id,
+        conversation_id=context.conversation_id,
+        allowed_extensions=_EXTENSIONS,
+    )
+
+
+def _artifact_result(output_path, *, summary: str, changes: dict[str, Any]) -> dict[str, Any]:
+    artifact = publish(output_path, output_path.name)
+    return {
+        "status": "ok",
+        "summary": summary,
+        "changes": changes,
+        "artifact": artifact.to_tool_payload(),
+    }
+
+
+@tool
+async def excel_document_read(
+    action: str,
+    path: str,
+    sheet_name: str | None = None,
+    cell_range: str | None = None,
+) -> dict[str, Any]:
+    """Inspect an Excel workbook or read a bounded range from an uploaded workbook."""
+    if action not in {"inspect", "read_range"}:
+        raise DocumentPathError("excel_document_read 仅支持 inspect 或 read_range")
+    input_path = await _input_path(path)
+    workbook = load_workbook(input_path, read_only=True, data_only=False)
+    try:
+        if action == "inspect":
+            sheets = []
+            for worksheet in workbook.worksheets:
+                preview = [
+                    list(row)
+                    for row in worksheet.iter_rows(
+                        max_row=min(worksheet.max_row, _MAX_PREVIEW_ROWS),
+                        max_col=min(worksheet.max_column, _MAX_PREVIEW_COLUMNS),
+                        values_only=True,
+                    )
+                ]
+                sheets.append({"name": worksheet.title, "rows": worksheet.max_row, "columns": worksheet.max_column, "preview": preview})
+            return {"status": "ok", "summary": f"工作簿包含 {len(sheets)} 个工作表", "data": {"sheets": sheets}, "truncated": False}
+        if not sheet_name or not cell_range:
+            raise DocumentPathError("read_range 需要 sheet_name 和 cell_range")
+        if sheet_name not in workbook.sheetnames:
+            raise DocumentPathError("工作表不存在")
+        min_col, min_row, max_col, max_row = range_boundaries(cell_range)
+        if max_row - min_row + 1 > _MAX_RANGE_ROWS or max_col - min_col + 1 > _MAX_RANGE_COLUMNS:
+            raise DocumentPathError("读取范围超过 200 行或 50 列限制")
+        worksheet = workbook[sheet_name]
+        values = [list(row) for row in worksheet.iter_rows(min_row=min_row, max_row=max_row, min_col=min_col, max_col=max_col, values_only=True)]
+        return {"status": "ok", "summary": f"已读取 {sheet_name}!{cell_range}", "data": {"values": values}, "truncated": False}
+    finally:
+        workbook.close()
+
+
+@tool
+async def excel_document_write(
+    action: str,
+    output_filename: str,
+    path: str | None = None,
+    sheet_name: str | None = None,
+    cells: list[dict[str, Any]] | None = None,
+    rows: list[list[Any]] | None = None,
+) -> dict[str, Any]:
+    """Create or modify an Excel workbook copy and return a download link."""
+    if action not in {"create", "write_cells", "append_rows", "create_sheet"}:
+        raise DocumentPathError("excel_document_write 不支持该操作")
+    if action == "create":
+        workbook = Workbook()
+        worksheet = workbook.active
+        if sheet_name:
+            worksheet.title = sheet_name
+    else:
+        if not path:
+            raise DocumentPathError("修改工作簿需要 path")
+        workbook = load_workbook(await _input_path(path), data_only=False)
+        if not sheet_name:
+            raise DocumentPathError("修改工作簿需要 sheet_name")
+        if action != "create_sheet" and sheet_name not in workbook.sheetnames:
+            raise DocumentPathError("工作表不存在")
+    changes: dict[str, Any] = {}
+    if action == "write_cells":
+        worksheet = workbook[sheet_name]
+        if not cells:
+            raise DocumentPathError("write_cells 需要 cells")
+        for cell in cells:
+            address = str(cell.get("address") or "")
+            if not address:
+                raise DocumentPathError("单元格地址不能为空")
+            worksheet[address] = cell.get("value")
+        changes["written_cells"] = len(cells)
+    elif action == "append_rows":
+        worksheet = workbook[sheet_name]
+        if not rows:
+            raise DocumentPathError("append_rows 需要 rows")
+        for row in rows:
+            worksheet.append(list(row))
+        changes["appended_rows"] = len(rows)
+    elif action == "create_sheet":
+        if sheet_name in workbook.sheetnames:
+            raise DocumentPathError("工作表已存在")
+        workbook.create_sheet(sheet_name)
+        changes["created_sheet"] = sheet_name
+    else:
+        changes["created_workbook"] = True
+    output_path = await _output_path(output_filename)
+    workbook.save(output_path)
+    workbook.close()
+    return _artifact_result(output_path, summary="已生成 Excel 文件", changes=changes)

--- a/app/services/ai/tools/generated_file_service.py
+++ b/app/services/ai/tools/generated_file_service.py
@@ -1,0 +1,172 @@
+"""Private publication and capability-link download support for generated files."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import mimetypes
+import secrets
+import shutil
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from app.utils.fs_paths import get_data_base_dir
+
+DEFAULT_TTL = timedelta(hours=24)
+
+_OFFICE_MIME_TYPES = {
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+
+
+@dataclass(frozen=True)
+class PublishedArtifact:
+    artifact_id: str
+    token: str
+    filename: str
+    mime_type: str
+    size: int
+    expires_at: datetime
+
+    @property
+    def download_url(self) -> str:
+        return f"/api/v1/chat/generated-files/{self.artifact_id}?token={self.token}"
+
+    def to_tool_payload(self) -> dict[str, Any]:
+        return {
+            "filename": self.filename,
+            "mime_type": self.mime_type,
+            "size": self.size,
+            "download_url": self.download_url,
+        }
+
+
+@dataclass(frozen=True)
+class GeneratedFile:
+    artifact_id: str
+    path: Path
+    filename: str
+    mime_type: str
+    size: int
+    expires_at: datetime
+
+
+def generated_files_root() -> Path:
+    return Path(get_data_base_dir()) / "generated_files"
+
+
+def _mime_type_for(filename: str) -> str:
+    return _OFFICE_MIME_TYPES.get(Path(filename).suffix.lower()) or (
+        mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    )
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _manifest_path(artifact_id: str) -> Path:
+    return generated_files_root() / artifact_id / "manifest.json"
+
+
+def _remove_artifact(artifact_id: str) -> None:
+    shutil.rmtree(generated_files_root() / artifact_id, ignore_errors=True)
+
+
+def _purge_expired() -> None:
+    root = generated_files_root()
+    if not root.is_dir():
+        return
+    now = datetime.now(timezone.utc)
+    for artifact_dir in root.iterdir():
+        manifest_path = artifact_dir / "manifest.json"
+        try:
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+            expires_at = datetime.fromisoformat(str(payload["expires_at"]))
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=timezone.utc)
+            if expires_at <= now:
+                shutil.rmtree(artifact_dir, ignore_errors=True)
+        except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+            shutil.rmtree(artifact_dir, ignore_errors=True)
+
+
+def publish(
+    source_path: str | Path,
+    filename: str,
+    *,
+    ttl: timedelta = DEFAULT_TTL,
+) -> PublishedArtifact:
+    source = Path(source_path).resolve()
+    if not source.is_file():
+        raise ValueError("待发布文件不存在")
+
+    display_name = Path(filename).name
+    if not display_name or display_name in {".", ".."}:
+        raise ValueError("生成文件名无效")
+
+    root = generated_files_root()
+    root.mkdir(parents=True, exist_ok=True)
+    _purge_expired()
+    artifact_id = uuid.uuid4().hex
+    token = secrets.token_urlsafe(32)
+    expires_at = datetime.now(timezone.utc) + ttl
+    artifact_dir = root / artifact_id
+    artifact_dir.mkdir(mode=0o700)
+    destination = artifact_dir / display_name
+    shutil.copy2(source, destination)
+    manifest = {
+        "artifact_id": artifact_id,
+        "filename": display_name,
+        "mime_type": _mime_type_for(display_name),
+        "size": destination.stat().st_size,
+        "token_hash": _token_hash(token),
+        "expires_at": expires_at.isoformat(),
+    }
+    (artifact_dir / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False), encoding="utf-8"
+    )
+    return PublishedArtifact(
+        artifact_id=artifact_id,
+        token=token,
+        filename=display_name,
+        mime_type=manifest["mime_type"],
+        size=manifest["size"],
+        expires_at=expires_at,
+    )
+
+
+def resolve_for_download(artifact_id: str, token: str) -> GeneratedFile | None:
+    if len(artifact_id) != 32 or any(char not in "0123456789abcdef" for char in artifact_id):
+        return None
+    if not token:
+        return None
+    try:
+        payload = json.loads(_manifest_path(artifact_id).read_text(encoding="utf-8"))
+        expires_at = datetime.fromisoformat(str(payload["expires_at"]))
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at <= datetime.now(timezone.utc):
+            _remove_artifact(artifact_id)
+            return None
+        if not hmac.compare_digest(str(payload["token_hash"]), _token_hash(token)):
+            return None
+        filename = Path(str(payload["filename"])).name
+        path = (generated_files_root() / artifact_id / filename).resolve()
+        artifact_dir = (generated_files_root() / artifact_id).resolve()
+        if not path.is_file() or path.parent != artifact_dir:
+            return None
+        return GeneratedFile(
+            artifact_id=artifact_id,
+            path=path,
+            filename=filename,
+            mime_type=str(payload["mime_type"]),
+            size=int(payload["size"]),
+            expires_at=expires_at,
+        )
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+        return None

--- a/app/services/ai/tools/registry.py
+++ b/app/services/ai/tools/registry.py
@@ -28,6 +28,8 @@ from app.services.ai.tools.memory_ltm_tools import (
 )
 from app.services.ai.tools.memory_search_tool import memory_search
 from app.services.ai.tools.agent_delegate_tool import sub_agent_call
+from app.services.ai.tools.excel_document_tool import excel_document_read, excel_document_write
+from app.services.ai.tools.word_document_tool import word_document_read, word_document_write
 from app.models.tool import SysApiTool
 from app.models.mcp import McpToolCache
 from app.core.orm import AsyncSessionLocal
@@ -55,6 +57,13 @@ AGENTSCOPE_BUILTIN_TOOL_ALIASES: Dict[str, str] = {
     "glob_files": "Glob",
     "glob": "Glob",
     "Glob": "Glob",
+}
+
+OFFICE_TOOL_PERMISSION_SCOPES = {
+    "excel_document_read": "read",
+    "excel_document_write": "ask",
+    "word_document_read": "read",
+    "word_document_write": "ask",
 }
 
 
@@ -116,6 +125,10 @@ class ToolRegistry:
         "delete_user_preference": delete_user_preference,
         "memory_search": memory_search,
         "sub_agent_call": sub_agent_call,
+        "excel_document_read": excel_document_read,
+        "excel_document_write": excel_document_write,
+        "word_document_read": word_document_read,
+        "word_document_write": word_document_write,
     }
 
     # Cache for DB Tools
@@ -205,6 +218,14 @@ class ToolRegistry:
         data_tool_spec = cls._create_chatbi_runtime_tool_spec(name)
         if data_tool_spec is not None:
             return data_tool_spec
+
+        if name in OFFICE_TOOL_PERMISSION_SCOPES:
+            tool = cls._registry[name]
+            return runtime_tool_spec_from_legacy_tool(
+                tool,
+                source_type="static",
+                permission_scope=OFFICE_TOOL_PERMISSION_SCOPES[name],
+            )
 
         db_tool = await cls._load_db_tool_with_source(name)
         if db_tool:

--- a/app/services/ai/tools/word_document_tool.py
+++ b/app/services/ai/tools/word_document_tool.py
@@ -1,0 +1,102 @@
+"""Controlled Word document tools for configured agents."""
+from __future__ import annotations
+
+from typing import Any
+
+from docx import Document
+
+from app.core.context import get_current_agent_context
+from app.services.ai.tools.document_paths import DocumentPathError, resolve_document_input_path, resolve_document_output_path
+from app.services.ai.tools.generated_file_service import publish
+from app.services.ai.tools.tool_compat import tool
+
+_EXTENSIONS = {".docx"}
+
+
+def _context():
+    context = get_current_agent_context()
+    if not context:
+        raise DocumentPathError("无法获取当前执行上下文")
+    return context
+
+
+async def _input_path(path: str):
+    context = _context()
+    return await resolve_document_input_path(path, allowed_attachment_paths=context.authorized_attachment_paths, user_id=context.user_id, conversation_id=context.conversation_id, allowed_extensions=_EXTENSIONS)
+
+
+async def _output_path(filename: str):
+    context = _context()
+    return await resolve_document_output_path(filename, user_id=context.user_id, conversation_id=context.conversation_id, allowed_extensions=_EXTENSIONS)
+
+
+def _result(output_path, summary: str, changes: dict[str, Any]) -> dict[str, Any]:
+    artifact = publish(output_path, output_path.name)
+    return {"status": "ok", "summary": summary, "changes": changes, "artifact": artifact.to_tool_payload()}
+
+
+@tool
+async def word_document_read(action: str, path: str, start: int = 0, limit: int = 20) -> dict[str, Any]:
+    """Inspect a Word document or read a bounded page of paragraphs."""
+    if action not in {"inspect", "read_content"}:
+        raise DocumentPathError("word_document_read 仅支持 inspect 或 read_content")
+    document = Document(await _input_path(path))
+    paragraphs = [paragraph.text for paragraph in document.paragraphs]
+    if action == "inspect":
+        return {"status": "ok", "summary": f"文档包含 {len(paragraphs)} 个段落和 {len(document.tables)} 个表格", "data": {"paragraph_count": len(paragraphs), "table_count": len(document.tables), "preview": paragraphs[:20]}, "truncated": len(paragraphs) > 20}
+    start = max(0, start)
+    limit = min(max(1, limit), 50)
+    page = paragraphs[start:start + limit]
+    return {"status": "ok", "summary": f"已读取 {len(page)} 个段落", "data": {"paragraphs": page, "start": start}, "truncated": start + len(page) < len(paragraphs)}
+
+
+@tool
+async def word_document_write(action: str, output_filename: str, path: str | None = None, replacements: list[dict[str, str]] | None = None, paragraphs: list[str] | None = None, headers: list[str] | None = None, rows: list[list[str]] | None = None, title: str | None = None) -> dict[str, Any]:
+    """Create or modify a Word document copy and return a download link."""
+    if action not in {"create", "replace_text", "append_paragraphs", "append_table"}:
+        raise DocumentPathError("word_document_write 不支持该操作")
+    if action == "create":
+        document = Document()
+        if title:
+            document.add_heading(title, level=1)
+    else:
+        if not path:
+            raise DocumentPathError("修改文档需要 path")
+        document = Document(await _input_path(path))
+    changes: dict[str, Any] = {}
+    if action == "replace_text":
+        count = 0
+        for replacement in replacements or []:
+            find, replace = replacement.get("find", ""), replacement.get("replace", "")
+            if not find:
+                raise DocumentPathError("替换目标不能为空")
+            for paragraph in document.paragraphs:
+                for run in paragraph.runs:
+                    if find in run.text:
+                        run.text = run.text.replace(find, replace)
+                        count += 1
+        changes["replacements"] = count
+    elif action == "append_paragraphs":
+        for text in paragraphs or []:
+            document.add_paragraph(text)
+        changes["appended_paragraphs"] = len(paragraphs or [])
+    elif action == "append_table":
+        if not headers:
+            raise DocumentPathError("append_table 需要 headers")
+        table = document.add_table(rows=1, cols=len(headers))
+        for index, header in enumerate(headers):
+            table.rows[0].cells[index].text = str(header)
+        for row in rows or []:
+            if len(row) != len(headers):
+                raise DocumentPathError("表格行列数必须与 headers 一致")
+            cells = table.add_row().cells
+            for index, value in enumerate(row):
+                cells[index].text = str(value)
+        changes["appended_table_rows"] = len(rows or [])
+    else:
+        for text in paragraphs or []:
+            document.add_paragraph(text)
+        changes["created_document"] = True
+    output_path = await _output_path(output_filename)
+    document.save(output_path)
+    return _result(output_path, "已生成 Word 文档", changes)

--- a/docs/superpowers/plans/2026-06-26-office-document-tools.md
+++ b/docs/superpowers/plans/2026-06-26-office-document-tools.md
@@ -1,0 +1,407 @@
+# Office 文档内置工具 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (\`- [ ]\`) syntax for tracking.
+
+**Goal:** 让已配置工具的 Agent 能安全读取、修改或创建 \`.xlsx\`/\`.docx\`，并把生成副本作为 24 小时可下载文件回传给用户。
+
+**Architecture:** 增加受当前请求附件白名单约束的文档路径解析器，以及不公开挂载的生成文件发布服务。Excel/Word 各自保留一个格式实现模块，运行时拆成 read/write 四个 \`RuntimeToolSpec\` 以匹配现有按工具确认的权限模型；写入结果由发布服务产生短期能力链接。
+
+**Tech Stack:** Python 3.11, FastAPI, AgentScope \`RuntimeToolSpec\`, Pydantic, \`openpyxl\`, \`python-docx\`, pytest/httpx。
+
+---
+
+## File Structure
+
+- Modify: \`requirements.txt\` - 增加 \`python-docx\`。
+- Modify: \`app/core/context.py\` - 记录本轮可访问附件的绝对路径。
+- Modify: \`app/services/ai/context_manager.py\` - 将附件白名单写入 \`AgentContext\`。
+- Modify: \`app/services/ai/agent_service.py\` - 从已清洗的当前会话消息中提取附件白名单。
+- Create: \`app/services/ai/tools/document_paths.py\` - 单一职责：受管路径、文件名、大小和会话输出路径校验。
+- Create: \`app/services/ai/tools/generated_file_service.py\` - 单一职责：私有文件发布、令牌清单、过期清理和下载解析。
+- Create: \`app/services/ai/tools/excel_document_tool.py\` - Excel 的读写动作和有限输出。
+- Create: \`app/services/ai/tools/word_document_tool.py\` - Word 的读写动作和有限输出。
+- Modify: \`app/services/ai/tools/registry.py\` - 注册四个 Office 工具并提供显式 \`RuntimeToolSpec\`。
+- Modify: \`app/api/v1/endpoints/chat.py\` - 提供令牌保护的生成文件下载路由。
+- Create: \`tests/ai/tools/test_document_paths.py\`, \`tests/ai/tools/test_generated_file_service.py\`, \`tests/ai/tools/test_excel_document_tool.py\`, \`tests/ai/tools/test_word_document_tool.py\`。
+- Modify: \`tests/ai/tools/test_registry.py\`, \`tests/services/ai/test_agent_context_manager.py\`, \`tests/api/v1/test_upload_attachments.py\`。
+
+### Task 1: Request Attachment Allowlist And File Path Guard
+
+**Files:**
+- Create: \`app/services/ai/tools/document_paths.py\`
+- Modify: \`app/core/context.py\`
+- Modify: \`app/services/ai/context_manager.py\`
+- Modify: \`app/services/ai/agent_service.py\`
+- Test: \`tests/ai/tools/test_document_paths.py\`, \`tests/services/ai/test_agent_context_manager.py\`
+
+- [ ] **Step 1: Write the failing tests**
+
+\`\`\`python
+@pytest.mark.no_infrastructure
+@pytest.mark.asyncio
+async def test_resolve_document_input_rejects_unlisted_upload(tmp_path, monkeypatch):
+    monkeypatch.setattr(document_paths, "get_data_base_dir", lambda: str(tmp_path))
+    upload = tmp_path / "uploads" / "other.xlsx"
+    upload.parent.mkdir()
+    upload.write_bytes(b"x")
+
+    with pytest.raises(DocumentPathError, match="当前会话附件"):
+        await document_paths.resolve_document_input_path(
+            str(upload), allowed_attachment_paths=[], user_id=7, conversation_id="c1"
+        )
+
+
+@pytest.mark.no_infrastructure
+@pytest.mark.asyncio
+async def test_setup_context_keeps_authorized_attachment_paths():
+    await AgentContextManager.setup_context(
+        config=_config(), user_info={"user_id": 1, "role": "user"},
+        authorized_attachment_paths=["/app/data/uploads/report.xlsx"],
+    )
+    assert get_current_agent_context().authorized_attachment_paths == [
+        "/app/data/uploads/report.xlsx"
+    ]
+\`\`\`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: \`REDIS_ENABLE=false PYTHONPATH=. venv/bin/python -m pytest tests/ai/tools/test_document_paths.py tests/services/ai/test_agent_context_manager.py -q\`
+
+Expected: import failure for \`document_paths\`, or \`setup_context()\` rejects \`authorized_attachment_paths\`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+\`\`\`python
+# app/core/context.py
+authorized_attachment_paths: List[str] = Field(default_factory=list)
+
+# app/services/ai/context_manager.py
+# Add this parameter immediately after knowledge_dataset_ids in setup_context().
+authorized_attachment_paths: Optional[List[str]] = None,
+
+# Add this field to the AgentContext() constructor in setup_context().
+authorized_attachment_paths=list(authorized_attachment_paths or []),
+
+# app/services/ai/agent_service.py
+def _authorized_attachment_paths(messages: list[dict[str, Any]]) -> list[str]:
+    return sorted({
+        _attachment_abs_path(file_obj)
+        for message in messages if message.get("role") == "user"
+        for file_obj in message.get("files") or []
+        if file_obj.get("url")
+    })
+\`\`\`
+
+\`document_paths.py\` defines \`DocumentPathError\`, \`MAX_DOCUMENT_BYTES = 20 * 1024 * 1024\`, \`resolve_document_input_path\`, \`resolve_document_output_path\`, and \`sanitize_output_filename\`. Input paths use \`os.path.realpath\`, accept uploads only when their real path is in this request's allowlist, accept workspace files only under the current user/conversation workdir, reject symlink escapes, verify expected extensions, and enforce the size limit.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: \`REDIS_ENABLE=false PYTHONPATH=. venv/bin/python -m pytest tests/ai/tools/test_document_paths.py tests/services/ai/test_agent_context_manager.py -q\`
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit**
+
+\`\`\`bash
+git add app/core/context.py app/services/ai/context_manager.py app/services/ai/agent_service.py app/services/ai/tools/document_paths.py tests/ai/tools/test_document_paths.py tests/services/ai/test_agent_context_manager.py
+git commit -m "feat(ai): guard office document paths"
+\`\`\`
+
+### Task 2: Private Generated-File Publishing And Download
+
+**Files:**
+- Create: \`app/services/ai/tools/generated_file_service.py\`
+- Modify: \`app/api/v1/endpoints/chat.py\`
+- Test: \`tests/ai/tools/test_generated_file_service.py\`, \`tests/api/v1/test_upload_attachments.py\`
+
+- [ ] **Step 1: Write the failing tests**
+
+\`\`\`python
+@pytest.mark.no_infrastructure
+def test_publish_generates_private_artifact_and_resolves_matching_token(tmp_path, monkeypatch):
+    monkeypatch.setattr(generated_file_service, "generated_files_root", lambda: tmp_path)
+    source = tmp_path / "source.xlsx"
+    source.write_bytes(b"workbook")
+
+    artifact = generated_file_service.publish(source, "report.xlsx")
+
+    assert artifact["download_url"].startswith("/api/v1/chat/generated-files/")
+    resolved = generated_file_service.resolve_for_download(
+        artifact["artifact_id"], artifact["token"]
+    )
+    assert resolved.path.read_bytes() == b"workbook"
+
+
+@pytest.mark.asyncio
+async def test_generated_file_download_rejects_wrong_token(client, artifact_id):
+    response = await client.get(
+        f"/api/v1/chat/generated-files/{artifact_id}?token=wrong"
+    )
+    assert response.status_code == 404
+\`\`\`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: \`REDIS_ENABLE=false PYTHONPATH=. venv/bin/python -m pytest tests/ai/tools/test_generated_file_service.py tests/api/v1/test_upload_attachments.py -q\`
+
+Expected: import failure for \`generated_file_service\` and a missing route.
+
+- [ ] **Step 3: Write minimal implementation**
+
+\`\`\`python
+@dataclass(frozen=True)
+class GeneratedFile:
+    artifact_id: str
+    path: Path
+    filename: str
+    mime_type: str
+    size: int
+    expires_at: datetime
+
+def publish(source_path: str | Path, filename: str,
+            *, ttl: timedelta = timedelta(hours=24)) -> dict[str, Any]:
+    artifact_id = uuid.uuid4().hex
+    token = secrets.token_urlsafe(32)
+    # Copy source to data/generated_files/<artifact_id>/ and write manifest.json.
+
+@router.get("/generated-files/{artifact_id}")
+async def download_generated_file(artifact_id: str, token: str):
+    artifact = generated_file_service.resolve_for_download(artifact_id, token)
+    if artifact is None:
+        raise HTTPException(status_code=404, detail="文件不存在或已过期")
+    return FileResponse(artifact.path, media_type=artifact.mime_type, filename=artifact.filename)
+\`\`\`
+
+The manifest stores \`token_hash = sha256(token)\`, not the raw token. \`resolve_for_download\` uses \`hmac.compare_digest\`, lazily removes expired artifact directories, and returns \`None\` for missing, malformed, expired, or mismatched requests. \`publish\` returns the raw token only to the current tool result, plus a relative \`download_url\`; generated files never go to \`data/uploads\`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: \`REDIS_ENABLE=false PYTHONPATH=. venv/bin/python -m pytest tests/ai/tools/test_generated_file_service.py tests/api/v1/test_upload_attachments.py -q\`
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit**
+
+\`\`\`bash
+git add app/services/ai/tools/generated_file_service.py app/api/v1/endpoints/chat.py tests/ai/tools/test_generated_file_service.py tests/api/v1/test_upload_attachments.py
+git commit -m "feat(ai): publish generated office files"
+\`\`\`
+
+### Task 3: Excel Read And Write Tools
+
+**Files:**
+- Create: \`app/services/ai/tools/excel_document_tool.py\`
+- Test: \`tests/ai/tools/test_excel_document_tool.py\`
+
+- [ ] **Step 1: Write the failing tests**
+
+\`\`\`python
+@pytest.mark.no_infrastructure
+@pytest.mark.asyncio
+async def test_excel_read_range_returns_bounded_matrix(workbook_path, context_with_attachment):
+    result = await excel_document_read.ainvoke({
+        "action": "read_range", "path": str(workbook_path),
+        "sheet_name": "Sales", "range": "A1:B2",
+    })
+    assert result["data"]["values"] == [["Month", "Amount"], ["Jan", 10]]
+
+
+@pytest.mark.no_infrastructure
+@pytest.mark.asyncio
+async def test_excel_write_cells_creates_downloadable_copy(workbook_path, context_with_attachment):
+    result = await excel_document_write.ainvoke({
+        "action": "write_cells", "path": str(workbook_path), "sheet_name": "Sales",
+        "cells": [{"address": "B2", "value": 42}], "output_filename": "sales_updated.xlsx",
+    })
+    assert result["changes"]["written_cells"] == 1
+    assert result["artifact"]["download_url"]
+    assert load_workbook(workbook_path)["Sales"]["B2"].value == 10
+\`\`\`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: \`REDIS_ENABLE=false PYTHONPATH=. venv/bin/python -m pytest tests/ai/tools/test_excel_document_tool.py -q\`
+
+Expected: import failure for \`excel_document_tool\`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+\`\`\`python
+@tool
+async def excel_document_read(
+    action: Literal["inspect", "read_range"], path: str,
+    sheet_name: str | None = None, range: str | None = None,
+) -> dict[str, Any]:
+
+@tool
+async def excel_document_write(
+    action: Literal["create", "write_cells", "append_rows", "create_sheet"],
+    output_filename: str, path: str | None = None, sheet_name: str | None = None,
+    cells: list[dict[str, Any]] | None = None,
+    rows: list[list[Any]] | None = None,
+) -> dict[str, Any]:
+\`\`\`
+
+Use \`load_workbook(input_path, read_only=True, data_only=False)\` for reads and normal mode only for writes. Cap \`inspect\` preview at 20 rows x 20 columns and \`read_range\` at 200 rows x 50 columns. Validate ranges with \`openpyxl.utils.cell.range_boundaries\`. Every write saves to \`resolve_document_output_path\`, calls \`generated_file_service.publish\`, and returns \`status\`, \`summary\`, \`changes\`, and \`artifact\`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: \`REDIS_ENABLE=false PYTHONPATH=. venv/bin/python -m pytest tests/ai/tools/test_excel_document_tool.py -q\`
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit**
+
+\`\`\`bash
+git add app/services/ai/tools/excel_document_tool.py tests/ai/tools/test_excel_document_tool.py
+git commit -m "feat(ai): add excel document tools"
+\`\`\`
+
+### Task 4: Word Read And Write Tools
+
+**Files:**
+- Modify: \`requirements.txt\`
+- Create: \`app/services/ai/tools/word_document_tool.py\`
+- Test: \`tests/ai/tools/test_word_document_tool.py\`
+
+- [ ] **Step 1: Add the dependency and write failing tests**
+
+\`\`\`text
+# requirements.txt
+python-docx>=1.1.0
+\`\`\`
+
+\`\`\`python
+@pytest.mark.no_infrastructure
+@pytest.mark.asyncio
+async def test_word_replace_text_writes_a_copy(template_path, context_with_attachment):
+    result = await word_document_write.ainvoke({
+        "action": "replace_text", "path": str(template_path),
+        "replacements": [{"find": "{{name}}", "replace": "Alice"}],
+        "output_filename": "letter_alice.docx",
+    })
+    assert result["changes"]["replacements"] == 1
+    assert result["artifact"]["download_url"]
+
+
+@pytest.mark.no_infrastructure
+@pytest.mark.asyncio
+async def test_word_read_content_is_paginated(template_path, context_with_attachment):
+    result = await word_document_read.ainvoke({
+        "action": "read_content", "path": str(template_path), "start": 1, "limit": 1,
+    })
+    assert result["data"]["paragraphs"] == ["second paragraph"]
+\`\`\`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: \`REDIS_ENABLE=false PYTHONPATH=. venv/bin/python -m pytest tests/ai/tools/test_word_document_tool.py -q\`
+
+Expected: dependency/import failure for \`docx\` or \`word_document_tool\`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+\`\`\`python
+@tool
+async def word_document_read(
+    action: Literal["inspect", "read_content"], path: str,
+    start: int = 0, limit: int = 20,
+) -> dict[str, Any]:
+
+@tool
+async def word_document_write(
+    action: Literal["create", "replace_text", "append_paragraphs", "append_table"],
+    output_filename: str, path: str | None = None,
+    replacements: list[dict[str, str]] | None = None,
+    paragraphs: list[str] | None = None, headers: list[str] | None = None,
+    rows: list[list[str]] | None = None, title: str | None = None,
+) -> dict[str, Any]:
+\`\`\`
+
+\`read_content\` caps \`limit\` at 50 and returns a table summary rather than full table data. \`replace_text\` traverses \`paragraph.runs\` and replaces exact text inside one run only; it never reconstructs cross-run text. \`append_table\` requires non-empty headers and each row has the header width. Writes save to the session output path and publish through \`generated_file_service\`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: \`REDIS_ENABLE=false PYTHONPATH=. venv/bin/python -m pytest tests/ai/tools/test_word_document_tool.py -q\`
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit**
+
+\`\`\`bash
+git add requirements.txt app/services/ai/tools/word_document_tool.py tests/ai/tools/test_word_document_tool.py
+git commit -m "feat(ai): add word document tools"
+\`\`\`
+
+### Task 5: Registry, Permission, Prompt, And End-To-End Regression
+
+**Files:**
+- Modify: \`app/services/ai/tools/registry.py\`
+- Modify: \`app/services/ai/agent_prompts.py\`
+- Test: \`tests/ai/tools/test_registry.py\`, \`tests/ai/runtime/test_agentscope_tooling.py\`
+
+- [ ] **Step 1: Write the failing tests**
+
+\`\`\`python
+@pytest.mark.asyncio
+async def test_office_runtime_tools_have_explicit_permissions():
+    specs = await ToolRegistry.get_runtime_tools([
+        "excel_document_read", "excel_document_write",
+        "word_document_read", "word_document_write",
+    ])
+    assert [spec.permission_scope for spec in specs] == ["read", "ask", "read", "ask"]
+
+
+@pytest.mark.asyncio
+async def test_office_write_tool_requires_confirmation():
+    spec = await ToolRegistry.get_runtime_tool("excel_document_write")
+    decision = await AgentScopeRuntimeTool(spec).check_permissions({}, None)
+    assert decision.behavior == PermissionBehavior.ASK
+\`\`\`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: \`REDIS_ENABLE=false PYTHONPATH=. venv/bin/python -m pytest tests/ai/tools/test_registry.py tests/ai/runtime/test_agentscope_tooling.py -q\`
+
+Expected: Office tool names are unknown.
+
+- [ ] **Step 3: Write minimal integration**
+
+\`\`\`python
+# app/services/ai/tools/registry.py
+OFFICE_TOOL_PERMISSION_SCOPES = {
+    "excel_document_read": "read",
+    "excel_document_write": "ask",
+    "word_document_read": "read",
+    "word_document_write": "ask",
+}
+_registry.update({
+    "excel_document_read": excel_document_read,
+    "excel_document_write": excel_document_write,
+    "word_document_read": word_document_read,
+    "word_document_write": word_document_write,
+})
+\`\`\`
+
+In \`get_runtime_tool\`, call \`runtime_tool_spec_from_legacy_tool(tool, source_type="static", permission_scope=OFFICE_TOOL_PERMISSION_SCOPES[name])\` before the generic static fallback. Keep all four out of \`get_system_implicit_tools\`: only explicitly configured Agents receive them. Add a prompt helper gated by configured Office tool names: inspect first, preserve the original attachment, and include the returned Markdown download link in the final response.
+
+- [ ] **Step 4: Run focused and cross-module regression tests**
+
+Run: \`REDIS_ENABLE=false PYTHONPATH=. venv/bin/python -m pytest tests/ai/tools/test_document_paths.py tests/ai/tools/test_generated_file_service.py tests/ai/tools/test_excel_document_tool.py tests/ai/tools/test_word_document_tool.py tests/ai/tools/test_registry.py tests/ai/runtime/test_agentscope_tooling.py tests/services/ai/test_agent_context_manager.py tests/api/v1/test_upload_attachments.py -q\`
+
+Expected: all selected tests pass.
+
+Run: \`venv/bin/python -m py_compile app/core/context.py app/services/ai/context_manager.py app/services/ai/agent_service.py app/services/ai/tools/document_paths.py app/services/ai/tools/generated_file_service.py app/services/ai/tools/excel_document_tool.py app/services/ai/tools/word_document_tool.py app/services/ai/tools/registry.py app/api/v1/endpoints/chat.py\`
+
+Expected: exit code 0.
+
+Run: \`git diff --check\`
+
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+\`\`\`bash
+git add app/services/ai/tools/registry.py app/services/ai/agent_prompts.py tests/ai/tools/test_registry.py tests/ai/runtime/test_agentscope_tooling.py
+git commit -m "feat(ai): register office document tools"
+\`\`\`

--- a/docs/superpowers/specs/2026-06-26-office-document-tools-design.md
+++ b/docs/superpowers/specs/2026-06-26-office-document-tools-design.md
@@ -1,0 +1,176 @@
+# Office 文档内置工具设计
+
+**日期：** 2026-06-26
+**状态：** 已确认，待实现
+**范围：** 为 AgentScope 智能体增加 Excel 与 Word 的受控读取、模板修改、文件生成和下载回传能力。
+
+## 目标
+
+用户上传 `.xlsx` 或 `.docx` 文件后，智能体能够：
+
+- 查看文件结构和有限内容；
+- 基于原文件创建副本并按用户要求修改；
+- 从零创建新的 Excel 或 Word 文件；
+- 将生成结果作为带时效下载链接的附件回传给用户。
+
+首期支持 `.xlsx` 和 `.docx`。`.xls`、`.doc`、宏文件、受密码保护的文件和 PDF 转换均明确不在范围内。
+
+## 现有基础与约束
+
+- `ToolRegistry` 是静态工具到 `RuntimeToolSpec` 的注册入口；运行时权限由 `RuntimeToolSpec.permission_scope` 与确认链路处理。
+- 用户上传附件位于 `data/uploads`，当前会话的 AgentScope 工作目录位于 `data/agent_workspaces/<user>/<conversation>`。
+- 当前 `/static/uploads` 是公开静态目录，不能用于工具生成的私有文件。
+- Excel 可直接使用现有 `openpyxl`；Word 需要增加 `python-docx` 依赖。
+- 工具结果会进入主智能体上下文，因此读取返回必须结构化、分页且截断，不能返回完整工作簿或全文。
+
+## 方案选择
+
+### 备选方案
+
+1. 为每个动作建立独立工具，例如 `read_excel`、`write_excel`、`read_word`、`write_word`。参数较短，但工具数量会随格式和操作膨胀，模型更容易误选。
+2. 交给 `Bash`/Python 脚本处理 Office 文件。开发量小，但提示词依赖重，难以约束路径、返回值、权限和下载回传。
+3. 每种文档类型一个受控工具，以 `action` 区分操作，并共享文件发布服务。模型选择稳定，接口可测试，后续扩展格式或操作不改变注册模式。
+
+采用方案 3。
+
+## 架构
+
+### 模块边界
+
+| 模块 | 职责 |
+| --- | --- |
+| `app/services/ai/tools/document_paths.py` | 校验输入路径、解析受管附件、生成会话输出路径；不处理 Office 格式。 |
+| `app/services/ai/tools/generated_file_service.py` | 发布会话生成文件、保存不可猜测的下载令牌与元数据、校验有效期并提供下载文件。 |
+| `app/services/ai/tools/excel_document_tool.py` | 基于 `openpyxl` 实现 Excel 的读取、修改和创建。 |
+| `app/services/ai/tools/word_document_tool.py` | 基于 `python-docx` 实现 Word 的读取、修改和创建。 |
+| `app/api/v1/endpoints/chat.py` 或同域的文件下载路由 | 通过短期令牌下载生成文件，不暴露磁盘路径。 |
+| `app/services/ai/tools/registry.py` | 注册四个运行时工具：`excel_document_read`、`excel_document_write`、`word_document_read`、`word_document_write`。 |
+
+工具实现不直接写入 `data/uploads`，不直接创建静态 URL，也不承担 HTTP 权限校验。
+
+### 文件流
+
+1. 前端上传附件后，现有上传 API 将文件保存到 `data/uploads`，聊天消息向智能体提供其受管路径。
+2. 主智能体调用文档工具，工具只接受上传目录或当前会话工作目录中的既有文件。
+3. 读取操作返回受限摘要；写入操作先复制原件或创建新文档，再保存到当前会话工作目录。
+4. 写入操作调用 `GeneratedFileService.publish`。服务将输出复制到私有生成目录，生成随机 `artifact_id` 和至少 256 位熵的令牌，并记录所有者、会话、显示名称、MIME 类型、文件大小与过期时间。
+5. 工具返回结构化结果和 `download_url`。主智能体在最终回复中提供链接与简短变更摘要。
+6. 下载路由校验 `artifact_id`、令牌和有效期后以 `FileResponse` 发送文件；路径永不出现在响应、提示词或 URL 中。
+
+生成文件默认 24 小时过期。后台清理任务或每次发布/下载时的惰性清理删除过期文件和元数据。
+
+## 工具契约
+
+实现层保持 Excel 和 Word 两个文档模块；运行时拆成四个工具，以适配现有 `RuntimeToolSpec` 的单一权限范围。工具描述必须清晰说明：读取用来了解文件结构；每个写入动作都会生成新文件，不会覆盖用户上传的原文件。
+
+| 工具名 | 允许 action | 权限 |
+| --- | --- | --- |
+| `excel_document_read` | `inspect`、`read_range` | `read` |
+| `excel_document_write` | `create`、`write_cells`、`append_rows`、`create_sheet` | `ask` |
+| `word_document_read` | `inspect`、`read_content` | `read` |
+| `word_document_write` | `create`、`replace_text`、`append_paragraphs`、`append_table` | `ask` |
+
+工具仍采用 `action` 枚举，但每个工具只接受表中列出的动作；未知或越权 action 直接失败。
+
+### Excel 工具
+
+| action | 必填参数 | 返回内容 |
+| --- | --- | --- |
+| `inspect` | `path` | 工作表名、维度、合并单元格计数、前 N 行预览。 |
+| `read_range` | `path`、`sheet_name`、`range` | 指定范围的二维值数组、截断标识。 |
+| `create` | `output_filename`、可选 `sheets` | 新建工作簿并发布。 |
+| `write_cells` | `path`、`sheet_name`、`cells`、`output_filename` | 单元格值或公式写入后的发布信息。 |
+| `append_rows` | `path`、`sheet_name`、`rows`、`output_filename` | 追加行后的发布信息。 |
+| `create_sheet` | `path`、`sheet_name`、`output_filename` | 新工作表后的发布信息。 |
+
+`cells` 使用 `{ "address": "B2", "value": ... }`；公式只能以 `=` 开头并由 `openpyxl` 原样保存。首期保留模板原有样式和公式，不承诺自动复制新增行的样式。
+
+### Word 工具
+
+| action | 必填参数 | 返回内容 |
+| --- | --- | --- |
+| `inspect` | `path` | 段落数、表格数、标题级别统计和文本预览。 |
+| `read_content` | `path`、可选 `start`、`limit` | 段落分页文本、表格摘要、截断标识。 |
+| `create` | `output_filename`、可选 `title`、`paragraphs` | 新文档后的发布信息。 |
+| `replace_text` | `path`、`replacements`、`output_filename` | 替换计数和发布信息。 |
+| `append_paragraphs` | `path`、`paragraphs`、`output_filename` | 新增段落计数和发布信息。 |
+| `append_table` | `path`、`headers`、`rows`、`output_filename` | 新表格行列信息和发布信息。 |
+
+`replace_text` 首期仅保证段落内的精确文本替换；跨 run 或跨段落的替换会明确报告为未匹配，不做可能破坏样式的重排。
+
+### 共同返回结构
+
+读取操作：
+
+```json
+{
+  "status": "ok",
+  "summary": "...",
+  "data": {},
+  "truncated": false
+}
+```
+
+写入操作：
+
+```json
+{
+  "status": "ok",
+  "summary": "已生成修改后的文件。",
+  "changes": {"written_cells": 3},
+  "artifact": {
+    "filename": "销售汇总_已更新.xlsx",
+    "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "size": 12345,
+    "download_url": "/api/v1/chat/generated-files/<artifact_id>?token=<token>"
+  }
+}
+```
+
+错误返回应说明下一步，例如文件类型不支持、工作表不存在、单元格范围非法、路径不属于当前会话，且不得泄露受限路径或令牌。
+
+## 安全与权限
+
+- 输入路径先经过真实路径归一化，再校验它位于 `data/uploads` 或当前用户当前会话的工作目录；禁止符号链接越界。
+- 写入输出只允许相对文件名；移除目录段、控制字符和危险扩展名，服务决定最终文件名。
+- 输入文件、输出文件均限制 20MB；Excel 读取采用只读模式，读取行数、列数、单元格数和文本长度设上限。
+- Office 文档不能作为任意压缩包解析；库解析错误统一转换为可理解的工具错误。
+- `excel_document_read`、`word_document_read` 的运行时权限为 `read`。
+- `excel_document_write`、`word_document_write` 的运行时权限为 `ask`，由现有确认流决定是否执行。
+- 生成文件下载令牌为短期能力令牌，不使用公开静态目录；令牌过期或文件被清理后返回 404，不区分“令牌错误”和“文件不存在”。
+
+## 提示词与用户体验
+
+- 仅当 Agent 配置中绑定了相应工具，提示词才出现工具能力说明；希望“读后修改”的 Agent 必须绑定同一格式的 read 与 write 两个工具。
+- 用户上传 `.xlsx`/`.docx` 后，模型应先 `inspect` 再决定修改范围；当用户明确给出范围或模板结构已知时可直接写入。
+- 工具返回下载 URL 后，主智能体必须在最终答复中给出 Markdown 下载链接和变更摘要，不复制文档全文。
+- 前端现有 Markdown 链接渲染可先承载下载链接；无须为首期增加文档在线编辑器或预览器。
+
+## 依赖与迁移
+
+- 在 `requirements.txt` 增加 `python-docx>=1.1.0`。
+- 不增加数据库迁移。首期生成文件元数据以私有 JSON 清单或现有可用缓存存储，包含过期时间；其生命周期与文件一致。
+- 不改变现有上传接口或 `/static/uploads` 行为，避免影响图片和历史附件。
+
+## 验收与测试
+
+### 单元测试
+
+- Excel：创建、读取范围、写单元格、追加行、创建工作表、公式保留、错误工作表/范围。
+- Word：创建、段落分页读取、文本替换、追加段落、追加表格、跨 run 替换不破坏原文件。
+- 文件边界：路径越界、符号链接越界、非法文件名、错误扩展名、超限文件和损坏文档。
+- 发布服务：生成令牌、过期、错误令牌、文件不在私有发布目录、下载文件名和 MIME。
+- 注册与权限：四个工具可由 `ToolRegistry.get_runtime_tool` 获得；read 工具为 `read`，write 工具为 `ask`。
+
+### 集成测试
+
+- 上传 `.xlsx` 模板，调用写入动作，断言原文件哈希未变、输出文件可用、下载路由返回正确内容。
+- 上传 `.docx` 模板，替换和追加内容后下载，使用 `python-docx` 再次读取并断言内容。
+- 不同用户或不同会话不能把对方的工作目录作为输入；过期链接不能下载。
+- 验证现有图片上传、静态上传链接和 AgentScope 文件工作区测试仍然通过。
+
+## 非目标
+
+- Excel 图表、透视表、条件格式自动生成与 VBA 宏执行。
+- Word 页眉页脚、批注、修订、复杂跨 run 样式保持和 PDF 转换。
+- 文件协作编辑、版本历史、长期文档资产管理与在线预览。

--- a/frontend/src/components/MessageRenderer.vue
+++ b/frontend/src/components/MessageRenderer.vue
@@ -107,6 +107,22 @@ interface ContentSegment {
     return lastOpen > lastClose;
   };
 
+  const FILE_PATH_EXTENSIONS =
+    'md|csv|txt|py|js|ts|sh|sql|json|pdf|html|css|yaml|yml|log|env|docx?|xlsx?|xlsm|pptx?';
+  const FILE_PATH_SEGMENT = String.raw`[^/\s<>"'，。；：！？、]+`;
+  const filePathRegex = new RegExp(
+    String.raw`(?:\./|/)?(?:${FILE_PATH_SEGMENT}/)+${FILE_PATH_SEGMENT}\.(?:${FILE_PATH_EXTENSIONS})`,
+    'giu',
+  );
+
+  const appendOpenLinkToPath = (pathVal: string) => {
+    const canvasUrl = `canvas://file?path=${encodeURIComponent(pathVal)}`;
+    return `${pathVal}<a href="${canvasUrl}" class="inline-flex items-center text-blue-600 dark:text-blue-400 hover:underline font-bold ml-1.5 text-[10.5px]" title="点击在画布中打开文件" style="cursor: pointer;">[打开]</a>`;
+  };
+
+  const injectOpenLinksForPaths = (text: string) =>
+    text.replace(filePathRegex, (pathVal) => appendOpenLinkToPath(pathVal));
+
   /**
    * 后处理：修复被 Markdown 引擎“误杀”转义的 HTML
    */
@@ -159,17 +175,14 @@ interface ContentSegment {
       return `###HTML_TAG_PLACEHOLDER_${tags.length - 1}###`;
     });
 
-    // 正则路径匹配：支持绝对路径（以 / 开始）或带斜杠的相对路径，以常见代码、文本、数据及 PDF 扩展名结尾
-    const pathRegex = /(?:\.\/|\/)?(?:[a-zA-Z0-9_\-\.]+\/)+[a-zA-Z0-9_\-\.]+\.(?:md|csv|txt|py|js|ts|sh|sql|json|pdf|html|css|yaml|yml|log|env)/gi;
-
-    textWithPlaceholders = textWithPlaceholders.replace(pathRegex, (pathVal) => {
-      const canvasUrl = `canvas://file?path=${encodeURIComponent(pathVal)}`;
-      return `${pathVal}<a href="${canvasUrl}" class="inline-flex items-center text-blue-600 dark:text-blue-400 hover:underline font-bold ml-1.5 text-[10.5px]" title="点击在画布中打开文件" style="cursor: pointer;">[打开]</a>`;
-    });
+    textWithPlaceholders = injectOpenLinksForPaths(textWithPlaceholders);
 
     res = textWithPlaceholders.replace(/###HTML_TAG_PLACEHOLDER_(\d+)###/g, (_match, idx) => {
       return tags[parseInt(idx, 10)] ?? "";
     });
+
+    // 兜底：Markdown 反引号会把路径包进 <code>，上面占位符还原后再处理一次 code 内文本
+    res = res.replace(/<code>([^<]*)<\/code>/gi, (_match, inner) => `<code>${injectOpenLinksForPaths(inner)}</code>`);
 
     return res;
   };

--- a/frontend/src/views/AgentManagement.vue
+++ b/frontend/src/views/AgentManagement.vue
@@ -297,6 +297,26 @@ const availableTools = [
     isSystem: true,
   },
   {
+    name: "excel_document_read",
+    description: "读取 Excel 工作簿结构或指定单元格区域",
+    isSystem: true,
+  },
+  {
+    name: "excel_document_write",
+    description: "创建或修改 Excel 副本，并生成可下载文件",
+    isSystem: true,
+  },
+  {
+    name: "word_document_read",
+    description: "读取 Word 文档结构或分页段落内容",
+    isSystem: true,
+  },
+  {
+    name: "word_document_write",
+    description: "创建或修改 Word 副本，并生成可下载文件",
+    isSystem: true,
+  },
+  {
     name: "read_file",
     description: "AgentScope Read：按行读取文件内容，运行时替代旧 read_file",
     isSystem: true,
@@ -425,6 +445,8 @@ const groupedTools = computed(() => {
 
     if (name.includes('sql') || name.includes('dataset') || name.includes('bi_') || name.includes('olap')) {
       groups.chatbi.tools.push(tool);
+    } else if (name.startsWith('excel_document') || name.startsWith('word_document')) {
+      groups.office.tools.push(tool);
     } else if (name.includes('knowledge') || name.includes('rag') || name.includes('kb_') || name.includes('document')) {
       groups.knowledge.tools.push(tool);
     } else if (

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -3572,6 +3572,24 @@ const handleOpenCanvas = async (payload: { type: 'html' | 'code' | 'mermaid' | '
       const urlObj = new URL(payload.content.replace('canvas://', 'http://localhost/'));
       const filePath = urlObj.searchParams.get('path') || '';
       const resolvedUrl = resolveFileUrl(filePath);
+      const officeExtensions = ['.docx', '.doc', '.xlsx', '.xls', '.xlsm', '.pptx', '.ppt'];
+      const normalizedPath = filePath.toLowerCase().split('?')[0].split('#')[0];
+      const isOfficeFile = officeExtensions.some((ext) => normalizedPath.endsWith(ext));
+
+      if (isOfficeFile) {
+        const response = await axios.get(resolvedUrl, { responseType: 'blob' });
+        const filename = filePath.split('/').pop() || 'download';
+        const blobUrl = URL.createObjectURL(response.data);
+        const link = document.createElement('a');
+        link.href = blobUrl;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(blobUrl);
+        showToast(`已开始下载 ${filename}`, 'success');
+        return;
+      }
 
       if (payload.type === 'pdf' || payload.type === 'image' || payload.type === 'csv') {
         // 对于二进制或结构化媒体资源，使用 axios 携带 header 发送安全请求，并将响应流转为 blob URL 零泄露渲染

--- a/openspec/specs/sub-agent-delegation/spec.md
+++ b/openspec/specs/sub-agent-delegation/spec.md
@@ -30,4 +30,3 @@ TBD - created by archiving change sub-agent-delegation. Update Purpose after arc
 #### Scenario: 过滤图形化卡片标签
 - **WHEN** 查数子代理执行完毕并返回包含 `<sql_plan>...</sql_plan>` 的结果文本时
 - **THEN** 委托工具在将文本交付给主助手前，将 `<sql_plan>` 标签段过滤掉或转换为纯文本格式，防止上下文污染。
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ APScheduler>=3.10.1
 mcp>=1.0.0
 pandas>=2.0.0
 openpyxl>=3.1.0
+python-docx>=1.1.0
 sqlparse>=0.4.4
 jinja2>=3.0.0
 playwright>=1.40.0

--- a/tests/ai/runners/test_data_agent_runner.py
+++ b/tests/ai/runners/test_data_agent_runner.py
@@ -2559,6 +2559,28 @@ def test_first_turn_diagnostic_sql_with_data_blocks_answer(data_config):
     assert runner._current_repair_kind(state) == "diagnostic_sql_pending_final"
 
 
+def test_aggregate_summary_sql_is_final_business_query(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-agg-summary", trace_buffer=[])
+    state = _DataRunState(requires_fresh_data=True, schema_completed=True)
+    leave_sql = (
+        "SELECT COUNT(*) AS leave_count, SUM(NVL(QJSCT,0)) AS total_days "
+        "FROM FORMTABLE_MAIN_11 "
+        "WHERE TO_DATE(QJRQQ, 'YYYY-MM-DD') "
+        "BETWEEN TO_DATE('2025-07-01', 'YYYY-MM-DD') AND TO_DATE('2026-01-31', 'YYYY-MM-DD')"
+    )
+    parsed, should_save = runner._apply_sql_tool_result(
+        state,
+        tool_args={"sql": leave_sql},
+        output={"rows": [{"leave_count": 1727, "total_days": 3122.7}]},
+    )
+
+    assert should_save is True
+    assert state.diagnostic_sql_pending_final is False
+    assert state.ready_to_answer is True
+
+
 def test_empty_diagnostic_sql_does_not_mark_business_sql_complete(data_config):
     from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
 

--- a/tests/ai/runners/test_knowledge_agent_tools.py
+++ b/tests/ai/runners/test_knowledge_agent_tools.py
@@ -32,10 +32,10 @@ async def test_resolve_knowledge_tools_excludes_external_web_search():
     mock_kb = MagicMock()
     mock_kb.name = "search_knowledge_base"
 
-    def _as_spec(tool):
+    def _as_spec(tool, **kwargs):
         from app.services.ai.runtime.agentscope.tools import runtime_tool_spec_from_legacy_tool
 
-        return runtime_tool_spec_from_legacy_tool(tool, source_type="system")
+        return runtime_tool_spec_from_legacy_tool(tool, source_type=kwargs.get("source_type", "system"))
 
     with patch(
         "app.services.ai.runners.knowledge_agent_runner.ToolRegistry.get_system_implicit_tools",

--- a/tests/ai/runners/test_sql_gates.py
+++ b/tests/ai/runners/test_sql_gates.py
@@ -124,6 +124,20 @@ def test_is_diagnostic_sql_patterns():
     assert is_diagnostic_sql("DESCRIBE demo_table")
 
 
+def test_is_diagnostic_sql_allows_aggregate_summary_and_filtered_count():
+    leave_sql = (
+        "SELECT COUNT(*) AS leave_count, SUM(NVL(QJSCT,0)) AS total_days "
+        "FROM FORMTABLE_MAIN_11 "
+        "WHERE TO_DATE(QJRQQ, 'YYYY-MM-DD') "
+        "BETWEEN TO_DATE('2025-07-01', 'YYYY-MM-DD') AND TO_DATE('2026-01-31', 'YYYY-MM-DD')"
+    )
+    assert not is_diagnostic_sql(leave_sql)
+    assert not is_diagnostic_sql(
+        "SELECT COUNT(*) AS cnt FROM orders WHERE status = 'ACTIVE'"
+    )
+    assert is_diagnostic_sql("SELECT COUNT(*) FROM orders")
+
+
 # --- Schema 预检：列/表 ---
 
 

--- a/tests/ai/test_sub_agent_delegation.py
+++ b/tests/ai/test_sub_agent_delegation.py
@@ -6,15 +6,33 @@ from app.services.ai.tools.agent_delegate_tool import (
     sub_agent_call,
     clean_sub_agent_output,
     _extract_delegation_text,
+    finalize_delegation_output,
+    resolve_delegation_permission_options,
+    EMPTY_DELEGATION_RESULT_MESSAGE,
+    DELEGATION_INTERRUPT_MESSAGES,
 )
 from app.core.context import AgentContext, set_agent_context
 from app.schemas.agent import ChatConfig
 
 pytestmark = pytest.mark.no_infrastructure
 
+_DISPATCH_PATCH = "app.services.ai.tools.agent_delegate_tool._dispatch_sub_agent_executor"
+
 ID_MAIN_KB = "11111111111111111111111111111111"
 ID_SUB_KB = "22222222222222222222222222222222"
 ID_FRONTEND_KB = "33333333333333333333333333333333"
+
+
+@contextmanager
+def _mock_delegation_runtime_config():
+    with patch(
+        "app.services.ai.tools.agent_delegate_tool._resolve_delegation_timeout_seconds",
+        AsyncMock(return_value=60.0),
+    ), patch(
+        "app.services.ai.tools.agent_delegate_tool._resolve_delegation_result_max_chars",
+        AsyncMock(return_value=8000),
+    ):
+        yield
 
 
 @contextmanager
@@ -57,6 +75,25 @@ def test_extract_delegation_text():
     assert _extract_delegation_text({"type": "error", "content": "fail"}) == "fail"
     assert _extract_delegation_text({"text": "alt"}) == "alt"
     assert _extract_delegation_text({"type": "log", "title": "step"}) == ""
+
+
+def test_finalize_delegation_output_empty():
+    assert finalize_delegation_output("") == EMPTY_DELEGATION_RESULT_MESSAGE
+    assert finalize_delegation_output("   ") == EMPTY_DELEGATION_RESULT_MESSAGE
+
+
+def test_finalize_delegation_output_truncation():
+    long_text = "x" * 5000
+    result = finalize_delegation_output(long_text, max_chars=100)
+    assert len(result) < 200
+    assert "截断" in result
+
+
+def test_resolve_delegation_permission_options_forces_allow():
+    assert resolve_delegation_permission_options({"approval_mode": "ask"}) == {
+        "approval_mode": "allow",
+    }
+    assert resolve_delegation_permission_options(None) == {"approval_mode": "allow"}
 
 
 @pytest.mark.asyncio
@@ -108,9 +145,10 @@ async def test_sub_agent_call_normal_execution_and_log_forwarding():
     mock_get_config = AsyncMock(return_value=sub_config)
     mock_dispatch = AsyncMock(return_value=mock_executor)
 
-    with _mock_system_agents_session([mock_agent]), \
+    with _mock_delegation_runtime_config(), \
+         _mock_system_agents_session([mock_agent]), \
          patch("app.services.ai.agent_manager.AgentManagerService.get_active_agent_config", mock_get_config), \
-         patch("app.services.ai.dispatcher.AgentDispatcher.dispatch", mock_dispatch), \
+         patch(_DISPATCH_PATCH, mock_dispatch), \
          patch("app.services.permission_service.PermissionService.check_permission", AsyncMock(return_value=True)):
 
         res = await sub_agent_call.func(agent_name="chat-bi", query="查询数据")
@@ -153,7 +191,8 @@ async def test_sub_agent_call_self_delegation():
     )
     mock_get_config = AsyncMock(return_value=sub_config)
 
-    with _mock_system_agents_session([mock_agent]), \
+    with _mock_delegation_runtime_config(), \
+         _mock_system_agents_session([mock_agent]), \
          patch("app.services.ai.agent_manager.AgentManagerService.get_active_agent_config", mock_get_config):
 
         res = await sub_agent_call.func(agent_name="chat-bi", query="test")
@@ -173,6 +212,7 @@ async def test_sub_agent_call_context_inheritance_and_user_info():
         user_id=100,
         is_admin=False,
         api_key="sk-main-key",
+        permission_options={"approval_mode": "ask"},
         user_dimensions={
             "user_name": "test_user",
             "real_name": "Test User",
@@ -214,9 +254,10 @@ async def test_sub_agent_call_context_inheritance_and_user_info():
     mock_executor.execute = mock_execute
     mock_dispatch = AsyncMock(return_value=mock_executor)
 
-    with _mock_system_agents_session([mock_agent]), \
+    with _mock_delegation_runtime_config(), \
+         _mock_system_agents_session([mock_agent]), \
          patch("app.services.ai.agent_manager.AgentManagerService.get_active_agent_config", mock_get_config), \
-         patch("app.services.ai.dispatcher.AgentDispatcher.dispatch", mock_dispatch) as patched_dispatch, \
+         patch(_DISPATCH_PATCH, mock_dispatch) as patched_dispatch, \
          patch("app.services.permission_service.PermissionService.check_permission", AsyncMock(return_value=True)):
 
         res = await sub_agent_call.func(agent_name="chat-bi", query="查询数据")
@@ -234,6 +275,85 @@ async def test_sub_agent_call_context_inheritance_and_user_info():
             "org_path": "/ROOT/DEPT01",
             "extra_data": {"role_level": 3},
         }
+        assert kwargs["permission_options"] == {"approval_mode": "allow"}
+
+    set_agent_context(None)
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_call_empty_output_returns_guidance():
+    main_ctx = AgentContext(
+        agent_id="main",
+        agent_name="MainAgent",
+        delegation_depth=0,
+    )
+    set_agent_context(main_ctx)
+
+    async def mock_execute(history):
+        yield {"type": "log", "title": "only logs", "status": "success"}
+
+    mock_executor = MagicMock()
+    mock_executor.execute = mock_execute
+
+    sub_config = ChatConfig(
+        agent_id="sub-123",
+        agent_name="chat-bi",
+        agent_display_name="数据查询助手",
+        system_prompt="sub",
+        tools=[],
+        capabilities=[],
+        model_name="test",
+        temperature=0.0,
+    )
+    mock_agent = _make_system_agent(agent_id="sub-123", name="chat-bi", display_name="数据查询助手")
+
+    with _mock_delegation_runtime_config(), \
+         _mock_system_agents_session([mock_agent]), \
+         patch("app.services.ai.agent_manager.AgentManagerService.get_active_agent_config", AsyncMock(return_value=sub_config)), \
+         patch(_DISPATCH_PATCH, AsyncMock(return_value=mock_executor)), \
+         patch("app.services.permission_service.PermissionService.check_permission", AsyncMock(return_value=True)):
+
+        res = await sub_agent_call.func(agent_name="chat-bi", query="查询数据")
+        assert res == EMPTY_DELEGATION_RESULT_MESSAGE
+
+    set_agent_context(None)
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_call_permission_interrupt_returns_error():
+    main_ctx = AgentContext(
+        agent_id="main",
+        agent_name="MainAgent",
+        delegation_depth=0,
+    )
+    set_agent_context(main_ctx)
+
+    async def mock_execute(history):
+        yield {"type": "permission_required", "permission_request_id": "req-1"}
+
+    mock_executor = MagicMock()
+    mock_executor.execute = mock_execute
+
+    sub_config = ChatConfig(
+        agent_id="sub-123",
+        agent_name="chat-bi",
+        agent_display_name="数据查询助手",
+        system_prompt="sub",
+        tools=[],
+        capabilities=[],
+        model_name="test",
+        temperature=0.0,
+    )
+    mock_agent = _make_system_agent(agent_id="sub-123", name="chat-bi", display_name="数据查询助手")
+
+    with _mock_delegation_runtime_config(), \
+         _mock_system_agents_session([mock_agent]), \
+         patch("app.services.ai.agent_manager.AgentManagerService.get_active_agent_config", AsyncMock(return_value=sub_config)), \
+         patch(_DISPATCH_PATCH, AsyncMock(return_value=mock_executor)), \
+         patch("app.services.permission_service.PermissionService.check_permission", AsyncMock(return_value=True)):
+
+        res = await sub_agent_call.func(agent_name="chat-bi", query="查询数据")
+        assert res == DELEGATION_INTERRUPT_MESSAGES["permission_required"]
 
     set_agent_context(None)
 
@@ -285,9 +405,10 @@ async def test_sub_agent_call_timeout_generator_closed():
             pass
         raise asyncio.TimeoutError()
 
-    with _mock_system_agents_session([mock_agent]), \
+    with _mock_delegation_runtime_config(), \
+         _mock_system_agents_session([mock_agent]), \
          patch("app.services.ai.agent_manager.AgentManagerService.get_active_agent_config", mock_get_config), \
-         patch("app.services.ai.dispatcher.AgentDispatcher.dispatch", mock_dispatch), \
+         patch(_DISPATCH_PATCH, mock_dispatch), \
          patch("asyncio.wait_for", mock_wait_for):
 
         res = await sub_agent_call.func(agent_name="chat-bi", query="查询数据")

--- a/tests/ai/test_sub_agent_delegation.py
+++ b/tests/ai/test_sub_agent_delegation.py
@@ -8,6 +8,8 @@ from app.services.ai.tools.agent_delegate_tool import (
     _extract_delegation_text,
     finalize_delegation_output,
     resolve_delegation_permission_options,
+    filter_delegable_system_agents,
+    delegable_agent_name_aliases,
     EMPTY_DELEGATION_RESULT_MESSAGE,
     DELEGATION_INTERRUPT_MESSAGES,
 )
@@ -89,11 +91,43 @@ def test_finalize_delegation_output_truncation():
     assert "截断" in result
 
 
-def test_resolve_delegation_permission_options_forces_allow():
+def test_resolve_delegation_permission_options_preserves_main_approval_boundary():
     assert resolve_delegation_permission_options({"approval_mode": "ask"}) == {
+        "approval_mode": "ask",
+    }
+    assert resolve_delegation_permission_options(None) == {"approval_mode": "ask"}
+    assert resolve_delegation_permission_options({"approval_mode": "allow"}) == {
         "approval_mode": "allow",
     }
-    assert resolve_delegation_permission_options(None) == {"approval_mode": "allow"}
+
+
+@pytest.mark.asyncio
+async def test_filter_delegable_system_agents_hides_self_and_unauthorized_agents():
+    main_agent = _make_system_agent(agent_id="main-agent-id", name="assistant", display_name="主助手")
+    allowed_agent = _make_system_agent(agent_id="allowed-agent-id", name="chat-bi", display_name="数据助手")
+    denied_agent = _make_system_agent(agent_id="denied-agent-id", name="knowledge-base", display_name="知识库助手")
+    disabled_agent = _make_system_agent(agent_id="disabled-agent-id", name="disabled", display_name="禁用助手")
+    disabled_agent.is_enabled = False
+
+    mock_session = AsyncMock()
+
+    async def mock_check_permission(user_id, resource_type, resource_id):
+        return resource_id == "allowed-agent-id"
+
+    with patch(
+        "app.services.permission_service.PermissionService.check_permission",
+        AsyncMock(side_effect=mock_check_permission),
+    ):
+        delegable = await filter_delegable_system_agents(
+            mock_session,
+            [main_agent, allowed_agent, denied_agent, disabled_agent],
+            user_id=100,
+            is_admin=False,
+            current_agent_id="main-agent-id",
+        )
+
+    assert delegable == [allowed_agent]
+    assert delegable_agent_name_aliases(delegable) >= {"chat-bi", "chat_bi", "数据助手"}
 
 
 @pytest.mark.asyncio
@@ -275,7 +309,7 @@ async def test_sub_agent_call_context_inheritance_and_user_info():
             "org_path": "/ROOT/DEPT01",
             "extra_data": {"role_level": 3},
         }
-        assert kwargs["permission_options"] == {"approval_mode": "allow"}
+        assert kwargs["permission_options"] == {"approval_mode": "ask"}
 
     set_agent_context(None)
 
@@ -315,6 +349,96 @@ async def test_sub_agent_call_empty_output_returns_guidance():
 
         res = await sub_agent_call.func(agent_name="chat-bi", query="查询数据")
         assert res == EMPTY_DELEGATION_RESULT_MESSAGE
+
+    set_agent_context(None)
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_call_blocks_duplicate_same_agent_and_query():
+    main_ctx = AgentContext(
+        agent_id="main",
+        agent_name="MainAgent",
+        delegation_depth=0,
+    )
+    set_agent_context(main_ctx)
+
+    async def mock_execute(history):
+        yield {"content": "Data output"}
+
+    mock_executor = MagicMock()
+    mock_executor.execute = mock_execute
+
+    sub_config = ChatConfig(
+        agent_id="sub-123",
+        agent_name="chat-bi",
+        agent_display_name="数据查询助手",
+        system_prompt="sub",
+        tools=[],
+        capabilities=[],
+        model_name="test",
+        temperature=0.0,
+    )
+    mock_agent = _make_system_agent(agent_id="sub-123", name="chat-bi", display_name="数据查询助手")
+    mock_dispatch = AsyncMock(return_value=mock_executor)
+
+    with _mock_delegation_runtime_config(), \
+         _mock_system_agents_session([mock_agent]), \
+         patch("app.services.ai.agent_manager.AgentManagerService.get_active_agent_config", AsyncMock(return_value=sub_config)), \
+         patch(_DISPATCH_PATCH, mock_dispatch), \
+         patch("app.services.permission_service.PermissionService.check_permission", AsyncMock(return_value=True)):
+
+        first = await sub_agent_call.func(agent_name="chat-bi", query="查询数据")
+        second = await sub_agent_call.func(agent_name="chat_bi", query="  查询数据  ")
+
+    assert "Data output" in first
+    assert "使用相同问题执行过一次" in second
+    assert mock_dispatch.call_count == 1
+
+    set_agent_context(None)
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_call_caps_same_agent_attempts_per_turn():
+    main_ctx = AgentContext(
+        agent_id="main",
+        agent_name="MainAgent",
+        delegation_depth=0,
+    )
+    set_agent_context(main_ctx)
+
+    async def mock_execute(history):
+        yield {"content": f"Data output for {history[-1]['content']}"}
+
+    mock_executor = MagicMock()
+    mock_executor.execute = mock_execute
+
+    sub_config = ChatConfig(
+        agent_id="sub-123",
+        agent_name="chat-bi",
+        agent_display_name="数据查询助手",
+        system_prompt="sub",
+        tools=[],
+        capabilities=[],
+        model_name="test",
+        temperature=0.0,
+    )
+    mock_agent = _make_system_agent(agent_id="sub-123", name="chat-bi", display_name="数据查询助手")
+    mock_dispatch = AsyncMock(return_value=mock_executor)
+
+    with _mock_delegation_runtime_config(), \
+         _mock_system_agents_session([mock_agent]), \
+         patch("app.services.ai.agent_manager.AgentManagerService.get_active_agent_config", AsyncMock(return_value=sub_config)), \
+         patch(_DISPATCH_PATCH, mock_dispatch), \
+         patch("app.services.permission_service.PermissionService.check_permission", AsyncMock(return_value=True)):
+
+        first = await sub_agent_call.func(agent_name="chat-bi", query="查询数据 A")
+        second = await sub_agent_call.func(agent_name="chat-bi", query="查询数据 B")
+        third = await sub_agent_call.func(agent_name="chat-bi", query="查询数据 C")
+
+    assert "Data output for 查询数据 A" in first
+    assert "Data output for 查询数据 B" in second
+    assert "已多次委派" in third
+    assert mock_dispatch.call_count == 2
 
     set_agent_context(None)
 

--- a/tests/ai/test_tool_nudge_policy.py
+++ b/tests/ai/test_tool_nudge_policy.py
@@ -83,6 +83,18 @@ def test_sub_agent_call_nudge_for_data_query():
     assert "chat-bi" in nudge.message
 
 
+def test_sub_agent_call_nudge_skips_when_target_agent_unavailable():
+    tools = [
+        _tool("sub_agent_call", "委派其他专有子智能体执行特定任务（如查数、查手册等）"),
+    ]
+    nudge = resolve_tool_nudge(
+        "帮我查一下设备资产列表",
+        tools,
+        available_sub_agent_names={"knowledge-base"},
+    )
+    assert nudge is None
+
+
 def test_sub_agent_call_nudge_for_knowledge_query():
     tools = [
         _tool("sub_agent_call", "委派其他专有子智能体执行特定任务（如查数、查手册等）"),

--- a/tests/ai/tools/test_document_paths.py
+++ b/tests/ai/tools/test_document_paths.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.no_infrastructure
+
+
+@pytest.mark.asyncio
+async def test_resolve_document_input_rejects_unlisted_upload(tmp_path, monkeypatch):
+    from app.services.ai.tools import document_paths
+
+    monkeypatch.setattr(document_paths, "get_data_base_dir", lambda: str(tmp_path))
+    upload = tmp_path / "uploads" / "other.xlsx"
+    upload.parent.mkdir()
+    upload.write_bytes(b"x")
+
+    with pytest.raises(document_paths.DocumentPathError, match="当前会话附件"):
+        await document_paths.resolve_document_input_path(
+            str(upload),
+            allowed_attachment_paths=[],
+            user_id=7,
+            conversation_id="conversation-1",
+            allowed_extensions={".xlsx"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_document_input_accepts_listed_upload(tmp_path, monkeypatch):
+    from app.services.ai.tools import document_paths
+
+    monkeypatch.setattr(document_paths, "get_data_base_dir", lambda: str(tmp_path))
+    upload = tmp_path / "uploads" / "report.xlsx"
+    upload.parent.mkdir()
+    upload.write_bytes(b"workbook")
+
+    resolved = await document_paths.resolve_document_input_path(
+        str(upload),
+        allowed_attachment_paths=[str(upload)],
+        user_id=7,
+        conversation_id="conversation-1",
+        allowed_extensions={".xlsx"},
+    )
+
+    assert resolved == Path(upload).resolve()

--- a/tests/ai/tools/test_excel_document_tool.py
+++ b/tests/ai/tools/test_excel_document_tool.py
@@ -1,0 +1,58 @@
+import pytest
+from openpyxl import Workbook, load_workbook
+
+from app.core.context import AgentContext, set_agent_context
+
+
+pytestmark = pytest.mark.no_infrastructure
+
+
+@pytest.fixture
+def excel_context(tmp_path, monkeypatch):
+    from app.services.ai.tools import document_paths, generated_file_service
+
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    source = uploads / "sales.xlsx"
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "Sales"
+    sheet.append(["Month", "Amount"])
+    sheet.append(["Jan", 10])
+    workbook.save(source)
+    monkeypatch.setattr(document_paths, "get_data_base_dir", lambda: str(tmp_path))
+    async def workspace_root():
+        return str(tmp_path / "agent_workspaces")
+    monkeypatch.setattr(document_paths, "resolve_workspace_root", workspace_root)
+    monkeypatch.setattr(generated_file_service, "generated_files_root", lambda: tmp_path / "generated")
+    set_agent_context(AgentContext(
+        agent_id="agent", agent_name="Agent", user_id=1, conversation_id="conv",
+        authorized_attachment_paths=[str(source)],
+    ))
+    return source
+
+
+@pytest.mark.asyncio
+async def test_excel_read_range_returns_matrix(excel_context):
+    from app.services.ai.tools.excel_document_tool import excel_document_read
+
+    result = await excel_document_read.ainvoke({
+        "action": "read_range", "path": str(excel_context),
+        "sheet_name": "Sales", "cell_range": "A1:B2",
+    })
+
+    assert result["data"]["values"] == [["Month", "Amount"], ["Jan", 10]]
+
+
+@pytest.mark.asyncio
+async def test_excel_write_cells_creates_downloadable_copy(excel_context):
+    from app.services.ai.tools.excel_document_tool import excel_document_write
+
+    result = await excel_document_write.ainvoke({
+        "action": "write_cells", "path": str(excel_context), "sheet_name": "Sales",
+        "cells": [{"address": "B2", "value": 42}], "output_filename": "sales_updated.xlsx",
+    })
+
+    assert result["changes"]["written_cells"] == 1
+    assert result["artifact"]["download_url"]
+    assert load_workbook(excel_context)["Sales"]["B2"].value == 10

--- a/tests/ai/tools/test_generated_file_service.py
+++ b/tests/ai/tools/test_generated_file_service.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.no_infrastructure
+
+
+def test_publish_generates_private_artifact_and_resolves_matching_token(tmp_path, monkeypatch):
+    from app.services.ai.tools import generated_file_service
+
+    monkeypatch.setattr(generated_file_service, "generated_files_root", lambda: tmp_path)
+    source = tmp_path / "source.xlsx"
+    source.write_bytes(b"workbook")
+
+    artifact = generated_file_service.publish(source, "report.xlsx")
+
+    assert artifact.download_url.startswith("/api/v1/chat/generated-files/")
+    assert "static/uploads" not in artifact.download_url
+    resolved = generated_file_service.resolve_for_download(
+        artifact.artifact_id,
+        artifact.token,
+    )
+    assert resolved is not None
+    assert resolved.path.read_bytes() == b"workbook"
+
+
+def test_resolve_for_download_rejects_wrong_token(tmp_path, monkeypatch):
+    from app.services.ai.tools import generated_file_service
+
+    monkeypatch.setattr(generated_file_service, "generated_files_root", lambda: tmp_path)
+    source = tmp_path / "source.docx"
+    source.write_bytes(b"document")
+    artifact = generated_file_service.publish(source, "letter.docx")
+
+    assert generated_file_service.resolve_for_download(artifact.artifact_id, "wrong") is None

--- a/tests/ai/tools/test_registry.py
+++ b/tests/ai/tools/test_registry.py
@@ -125,3 +125,21 @@ def test_system_executive_tool_names_are_current():
     assert "write_local_file" not in ToolRegistry._registry
     assert "execute_system_command" not in ToolRegistry._registry
     assert "manage_system_process" not in ToolRegistry._registry
+
+
+@pytest.mark.asyncio
+async def test_office_runtime_tools_have_explicit_permissions():
+    specs = await ToolRegistry.get_runtime_tools([
+        "excel_document_read",
+        "excel_document_write",
+        "word_document_read",
+        "word_document_write",
+    ])
+
+    assert [spec.name for spec in specs] == [
+        "excel_document_read",
+        "excel_document_write",
+        "word_document_read",
+        "word_document_write",
+    ]
+    assert [spec.permission_scope for spec in specs] == ["read", "ask", "read", "ask"]

--- a/tests/ai/tools/test_word_document_tool.py
+++ b/tests/ai/tools/test_word_document_tool.py
@@ -1,0 +1,55 @@
+import pytest
+
+from app.core.context import AgentContext, set_agent_context
+
+
+pytestmark = pytest.mark.no_infrastructure
+
+
+@pytest.fixture
+def word_context(tmp_path, monkeypatch):
+    from docx import Document
+    from app.services.ai.tools import document_paths, generated_file_service
+
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    source = uploads / "letter.docx"
+    document = Document()
+    document.add_paragraph("Hello {{name}}")
+    document.add_paragraph("Second paragraph")
+    document.save(source)
+    monkeypatch.setattr(document_paths, "get_data_base_dir", lambda: str(tmp_path))
+    async def workspace_root():
+        return str(tmp_path / "agent_workspaces")
+    monkeypatch.setattr(document_paths, "resolve_workspace_root", workspace_root)
+    monkeypatch.setattr(generated_file_service, "generated_files_root", lambda: tmp_path / "generated")
+    set_agent_context(AgentContext(
+        agent_id="agent", agent_name="Agent", user_id=1, conversation_id="conv",
+        authorized_attachment_paths=[str(source)],
+    ))
+    return source
+
+
+@pytest.mark.asyncio
+async def test_word_read_content_is_paginated(word_context):
+    from app.services.ai.tools.word_document_tool import word_document_read
+
+    result = await word_document_read.ainvoke({
+        "action": "read_content", "path": str(word_context), "start": 1, "limit": 1,
+    })
+
+    assert result["data"]["paragraphs"] == ["Second paragraph"]
+
+
+@pytest.mark.asyncio
+async def test_word_replace_text_writes_a_copy(word_context):
+    from app.services.ai.tools.word_document_tool import word_document_write
+
+    result = await word_document_write.ainvoke({
+        "action": "replace_text", "path": str(word_context),
+        "replacements": [{"find": "{{name}}", "replace": "Alice"}],
+        "output_filename": "letter_alice.docx",
+    })
+
+    assert result["changes"]["replacements"] == 1
+    assert result["artifact"]["download_url"]

--- a/tests/api/v1/test_generated_file_download.py
+++ b/tests/api/v1/test_generated_file_download.py
@@ -1,0 +1,25 @@
+from httpx import ASGITransport, AsyncClient
+import pytest
+
+
+pytestmark = pytest.mark.no_infrastructure
+
+
+@pytest.mark.asyncio
+async def test_generated_file_download_uses_capability_token(tmp_path, monkeypatch):
+    from app.main import app
+    from app.services.ai.tools import generated_file_service
+
+    monkeypatch.setattr(generated_file_service, "generated_files_root", lambda: tmp_path)
+    source = tmp_path / "source.xlsx"
+    source.write_bytes(b"workbook")
+    artifact = generated_file_service.publish(source, "report.xlsx")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(artifact.download_url)
+
+    assert response.status_code == 200
+    assert response.content == b"workbook"
+    assert response.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )

--- a/tests/services/ai/test_agent_context_manager.py
+++ b/tests/services/ai/test_agent_context_manager.py
@@ -43,6 +43,31 @@ async def test_setup_context_frontend_specified():
     # 检查是否回写回 config.engine_config
     assert set(config.engine_config.get("dataset_ids")) == {ID_USER_CHECKED_1, ID_USER_CHECKED_2}
 
+
+@pytest.mark.asyncio
+async def test_setup_context_keeps_authorized_attachment_paths():
+    config = ChatConfig(
+        agent_id="test-agent",
+        agent_name="Test Agent",
+        model_name="DeepSeek",
+        temperature=0.7,
+        system_prompt="prompt",
+        tools=[],
+        capabilities=[],
+        engine_config={"dataset_ids": [ID_AGENT_BOUND_1]},
+    )
+
+    await AgentContextManager.setup_context(
+        config=config,
+        user_info={"user_id": 1, "role": "user"},
+        knowledge_dataset_ids=[ID_USER_CHECKED_1],
+        authorized_attachment_paths=["/app/data/uploads/report.xlsx"],
+    )
+
+    ctx = get_current_agent_context()
+    assert ctx is not None
+    assert ctx.authorized_attachment_paths == ["/app/data/uploads/report.xlsx"]
+
 @pytest.mark.asyncio
 async def test_setup_context_fallback_user_permissions():
     # 测试前端未传，普通用户，合并智能体配置与用户权限绑定的知识库

--- a/tests/services/ai/test_agent_context_manager.py
+++ b/tests/services/ai/test_agent_context_manager.py
@@ -4,6 +4,8 @@ from app.schemas.agent import ChatConfig
 from app.services.ai.context_manager import AgentContextManager
 from app.core.context import get_current_agent_context
 
+pytestmark = pytest.mark.no_infrastructure
+
 # 32-character hex strings matching RAGFlow dataset ID regex
 ID_USER_CHECKED_1 = "11111111111111111111111111111111"
 ID_USER_CHECKED_2 = "22222222222222222222222222222222"
@@ -26,13 +28,13 @@ async def test_setup_context_frontend_specified():
         capabilities=[],
         engine_config={"dataset_ids": [ID_AGENT_BOUND_1]}
     )
-    
+
     await AgentContextManager.setup_context(
         config=config,
         knowledge_dataset_ids=[ID_USER_CHECKED_1, ID_USER_CHECKED_2],
         user_info={"user_id": 1, "role": "user"}
     )
-    
+
     ctx = get_current_agent_context()
     assert ctx is not None
     # 仅包含前端指定的，且覆盖了智能体绑定的
@@ -54,25 +56,25 @@ async def test_setup_context_fallback_user_permissions():
         capabilities=[],
         engine_config={"dataset_ids": [ID_AGENT_BOUND_1]}
     )
-    
+
     # Mock PermissionService.get_knowledge_base_access
     mock_access = {"is_admin": False, "accessible_ids": {ID_USER_PERM_1, ID_USER_PERM_2}}
-    
+
     with patch("app.services.permission_service.PermissionService.get_knowledge_base_access", new_callable=AsyncMock) as mock_get:
         mock_get.return_value = mock_access
-        
+
         # Mock AsyncSessionLocal 的上下文管理器
         mock_session = AsyncMock()
         mock_session_context = MagicMock()
         mock_session_context.__aenter__.return_value = mock_session
-        
+
         with patch("app.services.ai.context_manager.AsyncSessionLocal", return_value=mock_session_context):
             await AgentContextManager.setup_context(
                 config=config,
                 knowledge_dataset_ids=None,
                 user_info={"user_id": 100, "user_name": "test_user", "role": "user"}
             )
-            
+
     ctx = get_current_agent_context()
     assert ctx is not None
     # 应该是智能体配置 + 用户权限的并集
@@ -93,22 +95,22 @@ async def test_setup_context_admin_user():
         capabilities=[],
         engine_config={"dataset_ids": [ID_AGENT_BOUND_1]}
     )
-    
+
     mock_access = {"is_admin": True}
-    
+
     # Mock 数据库查询结果
     mock_rows = [ID_DB_ALL_1, ID_DB_ALL_2]
     mock_scalars = MagicMock()
     mock_scalars.all.return_value = mock_rows
     mock_result = MagicMock()
     mock_result.scalars.return_value = mock_scalars
-    
+
     mock_session = AsyncMock()
     mock_session.execute.return_value = mock_result
-    
+
     mock_session_context = MagicMock()
     mock_session_context.__aenter__.return_value = mock_session
-    
+
     with patch("app.services.permission_service.PermissionService.get_knowledge_base_access", new_callable=AsyncMock) as mock_get:
         mock_get.return_value = mock_access
         with patch("app.services.ai.context_manager.AsyncSessionLocal", return_value=mock_session_context):
@@ -117,7 +119,7 @@ async def test_setup_context_admin_user():
                 knowledge_dataset_ids=None,
                 user_info={"user_id": 1, "user_name": "admin_user", "role": "admin"}
             )
-            
+
     ctx = get_current_agent_context()
     assert ctx is not None
     # 应该是智能体配置 + 数据库所有非deleted的知识库


### PR DESCRIPTION
## 概要 (Overview)

本 PR 包含两条主线：

1. **子代理委派链路加固**：减少重复委派、空返回与权限中断导致的失败，提升主助手委派 `chat-bi` / `knowledge-base` 等子智能体的稳定性。
2. **Office 文档能力**：为智能体新增受沙箱约束的 Word/Excel 读写工具，生成文件通过带 token 的私有链接下载；前端对消息中的文件路径显示 `[打开]`，Office 文件点击后直接下载。

**变更规模**：33 个文件，+2252 / -169 行。

---

## 核心变更 (Key Changes)

### 1. 功能新增与增强 (New Features & Enhancements)

- [x] **Word 文档工具**：`word_document_read`（inspect / read_content）、`word_document_write`（create / replace_text / append_paragraphs / append_table），基于 `python-docx`
- [x] **Excel 文档工具**：`excel_document_read`（inspect / read_range）、`excel_document_write`（create / update_cells / append_rows），基于 `openpyxl`
- [x] **路径沙箱**：`document_paths.py` 统一解析输入/输出路径，限制扩展名，并校验 `authorized_attachment_paths`
- [x] **生成文件服务**：`generated_file_service.py` 发布 artifact、生成带过期 token 的私有下载链接
- [x] **下载 API**：`GET /api/v1/chat/generated-files/{artifact_id}?token=...`（公开路由，token 鉴权）
- [x] **工具注册**：四类 Office 工具已加入 `registry.py`（read=read、write=ask），`AgentManagement.vue` 可配置绑定
- [x] **前端文件交互**：`MessageRenderer.vue` 识别 `.docx/.xlsx` 等路径并旁挂 `[打开]`；`EmbedChat.vue` 对 Office 文件走 blob 下载而非画布预览

### 2. UI/UX 深度优化 (Visual & Interaction Polish)

- [x] 消息中文件路径旁显示 `[打开]` 快捷入口（支持中文路径、`<code>` 内路径）
- [x] Office 文件点击 `[打开]` 触发浏览器下载，并 toast 提示文件名
- [x] `AgentManagement.vue` 为 Office 工具增加图标分类展示

### 3. 关键修复 (Bug Fixes)

- [x] **委派内 auto-allow**：子流程内子工具权限自动放行，避免委派中途被权限确认打断
- [x] **空返回兜底**：子智能体无正文时返回明确提示，禁止相同参数重复委派
- [x] **权限中断识别**：识别 `permission_required` / `external_execution_required`，返回可操作建议
- [x] **`sub_agent_call` 免二次确认**：主流程已确认后不再重复弹窗
- [x] **委派参数默认值**：超时 120s、结果截断 8000 字；同 agent+query 每轮最多 2 次
- [x] **委派去重与输出清洗**：过滤 `<sql_plan>` 标签；SSE log 穿透与上下文继承优化
- [x] **静默委派促发**：强查数/强知识库意图时优先 nudge `sub_agent_call`（`tool_nudge_policy.py`）

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `5dc3c79` | fix(ai): 优化子代理委派链路，减少重复调用与空返回 |
| `106a20d` | fix(ai): harden sub-agent delegation（上下文继承、runner 门控、测试补强） |
| `3455231` | docs(ai): specify office document tools |
| `1fe17aa` | docs(ai): plan office document tools |
| `b45bb5d` | feat(ai): 新增 Word/Excel 文档工具及生成文件下载能力 |

**基准 commit**：`9f45a06` — fix(chatbi): 避免 COUNT+SUM 汇总 SQL 被误判为诊断查询

---

## 测试覆盖 (Testing)

- [x] **自动化测试**（新增/扩展）：
  - `tests/ai/test_sub_agent_delegation.py` — 委派去重、空返回、权限中断、超时截断
  - `tests/ai/test_tool_nudge_policy.py` — 静默委派促发
  - `tests/ai/tools/test_word_document_tool.py`
  - `tests/ai/tools/test_excel_document_tool.py`
  - `tests/ai/tools/test_document_paths.py`
  - `tests/ai/tools/test_generated_file_service.py`
  - `tests/ai/tools/test_registry.py`
  - `tests/api/v1/test_generated_file_download.py`
  - `tests/services/ai/test_agent_context_manager.py`
- [ ] **UI 兼容性**：EmbedChat `[打开]` / Office 下载需在 Chrome / Safari 手动验证
- [ ] **核心功能**：智能体绑定 Office 工具后，创建 docx/xlsx 并点击下载链接
- [ ] **回归测试**：子代理委派（chat-bi、knowledge-base）主流程无回归

> [!IMPORTANT]
> `tests/CHECKLIST.md` 尚未登记 Office 文档工具相关用例，合并前建议补充。

---

## 其他备注 (Notes)

**新增依赖**（`requirements.txt`）：
```
openpyxl>=3.1.0
python-docx>=1.1.0
```

**部署要求**：
- 部署后执行 `pip install -r requirements.txt`
- 生成文件落盘目录：`{data_base_dir}/generated_files/`，需保证可写

**主要涉及模块**：
| 模块 | 说明 |
|------|------|
| `app/services/ai/tools/word_document_tool.py` | Word 读写 |
| `app/services/ai/tools/excel_document_tool.py` | Excel 读写 |
| `app/services/ai/tools/generated_file_service.py` | artifact 发布与下载 |
| `app/services/ai/tools/agent_delegate_tool.py` | 子代理委派核心逻辑 |
| `app/api/v1/endpoints/chat.py` | 生成文件下载端点 |
| `frontend/src/components/MessageRenderer.vue` | 路径 `[打开]` 渲染 |
| `frontend/src/views/EmbedChat.vue` | Office 文件下载处理 |

---