### PR TITLE
Pull Request: 数据源扩展、品牌个性化与系统诊断增强

### DIFF
--- a/app/api/portal/endpoints/agents.py
+++ b/app/api/portal/endpoints/agents.py
@@ -6,8 +6,9 @@ from app.core.dependencies import require_admin, get_current_user, require_permi
 from typing import Dict, Any
 from app.services.ai.agent_manager import AgentManagerService
 from app.schemas.agent import (
-    AIAgentResponse, AIAgentBase, 
-    AIAgentVersionResponse, AIAgentVersionBase, 
+    AIAgentResponse, AIAgentBase,
+    AIAgentReorderRequest,
+    AIAgentVersionResponse, AIAgentVersionBase,
     AgentExecutionHistoryResponse
 )
 
@@ -27,6 +28,18 @@ async def list_allowed_agents(
 async def list_agents(session: AsyncSession = Depends(get_db_session), user: Dict[str, Any] = Depends(require_permission("menu", "menu:agent_management"))):
     """获取所有智能体列表 (基于权限过滤)"""
     return await AgentManagerService.list_agents(session, user=user)
+
+@router.post("/reorder")
+async def reorder_agents(
+    data: AIAgentReorderRequest,
+    session: AsyncSession = Depends(get_db_session),
+    user: Dict[str, Any] = Depends(require_admin),
+):
+    """批量更新智能体排序权重（值越大越靠前）"""
+    success = await AgentManagerService.reorder_agents(session, data.items, user=user)
+    if not success:
+        raise HTTPException(status_code=403, detail="Forbidden: Only admins can reorder agents")
+    return {"status": "success"}
 
 @router.post("/", response_model=AIAgentResponse, dependencies=[Depends(require_permission("element", "element:agent:create"))])
 async def create_agent(data: AIAgentBase, session: AsyncSession = Depends(get_db_session), user: Dict[str, Any] = Depends(get_current_user)):

--- a/app/api/portal/endpoints/auth.py
+++ b/app/api/portal/endpoints/auth.py
@@ -313,3 +313,14 @@ async def get_public_config(
             "yovole_sso_enabled": sso_enabled
         }
     }
+
+
+@router.get("/branding", summary="获取公开品牌配置")
+async def get_public_branding():
+    """登录页与前端展示用，无需鉴权。"""
+    from app.services.branding_settings_service import BrandingSettingsService
+
+    return {
+        "status": "success",
+        "data": await BrandingSettingsService.get_public_branding(),
+    }

--- a/app/api/portal/endpoints/metadata.py
+++ b/app/api/portal/endpoints/metadata.py
@@ -378,6 +378,8 @@ async def test_db_connection(config: DBConnectionConfig):
             await DBImportService.test_clickhouse_connection(config.model_dump())
         elif config.type == "oracle":
             await DBImportService.test_oracle_connection(config.model_dump())
+        elif config.type in DBImportService._sqlserver_type_aliases():
+            await DBImportService.test_sqlserver_connection(config.model_dump())
         else:
             raise HTTPException(status_code=400, detail=f"Unsupported DB type: {config.type}")
         return {"code": 200, "message": "Connection successful"}
@@ -394,6 +396,8 @@ async def list_db_tables(config: DBConnectionConfig):
             tables = await DBImportService.get_clickhouse_tables(config.model_dump())
         elif config.type == "oracle":
             tables = await DBImportService.get_oracle_tables(config.model_dump())
+        elif config.type in DBImportService._sqlserver_type_aliases():
+            tables = await DBImportService.get_sqlserver_tables(config.model_dump())
         else:
             raise HTTPException(status_code=400, detail=f"Unsupported DB type: {config.type}")
         return {"code": 200, "data": tables}
@@ -411,6 +415,8 @@ async def get_db_ddl(request: DDLRequest):
             ddl = await DBImportService.get_clickhouse_ddl(config.model_dump(), request.tables)
         elif config.type == "oracle":
             ddl = await DBImportService.get_oracle_ddl(config.model_dump(), request.tables)
+        elif config.type in DBImportService._sqlserver_type_aliases():
+            ddl = await DBImportService.get_sqlserver_ddl(config.model_dump(), request.tables)
         else:
             raise HTTPException(status_code=400, detail=f"Unsupported DB type: {config.type}")
         return {"code": 200, "data": ddl}

--- a/app/api/portal/endpoints/saved_reports.py
+++ b/app/api/portal/endpoints/saved_reports.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import inspect
 import re
 import uuid
 from datetime import date, datetime, timedelta, timezone
@@ -20,7 +21,10 @@ from app.models.saved_report import PortalSavedReport, PortalSavedReportShare, P
 from app.models.user import User
 from app.schemas.response import StandardResponse
 from app.services.ai.chatbi_sql_user_messages import map_sql_tool_error_for_user
-from app.services.sql_query_execution_service import execute_sql_query_core
+from app.services.sql_query_execution_service import (
+    attach_permission_notice_to_payload,
+    execute_sql_query_core,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +177,22 @@ def _chatbi_user_dimensions(user_info: Dict[str, Any], user_id: int) -> Dict[str
         "org_path": user_info.get("org_path"),
         "extra_data": user_info.get("extra_data"),
     }
+
+
+async def _dataset_name_from_id(db: AsyncSession, dataset_id: Optional[int]) -> Optional[str]:
+    if not dataset_id:
+        return None
+    result = await db.execute(select(MetaDataset.name).where(MetaDataset.id == dataset_id))
+    dataset_name = result.scalar_one_or_none()
+    if inspect.isawaitable(dataset_name):
+        dataset_name = await dataset_name
+    if not isinstance(dataset_name, str):
+        return None
+    return str(dataset_name).strip() if dataset_name else None
+
+
+def _attach_permission_notice(payload: Dict[str, Any], permission_notice: Dict[str, Any]) -> Dict[str, Any]:
+    return attach_permission_notice_to_payload(payload, permission_notice)
 
 
 def _detect_default_date_range_template(sql: str) -> Tuple[Optional[str], List[Dict[str, Any]], Dict[str, Any]]:
@@ -535,11 +555,12 @@ async def _precheck_saved_report_sql_permissions(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
     try:
+        dataset_name = await _dataset_name_from_id(db, report.dataset_id)
         result_str = await execute_sql_query_core(
             db,
             sql=sql_to_check,
             data_source=report.data_source,
-            dataset_name=None,
+            dataset_name=dataset_name,
             user_id=user_id,
             user_dimensions=_chatbi_user_dimensions(user_info, user_id),
             trace_logs=None,
@@ -1374,11 +1395,13 @@ async def execute_saved_report(
 
     try:
         # 参数化报表会在执行前重新经过底层 SQL 校验、沙箱与表权限校验。
+        dataset_name = await _dataset_name_from_id(db, report.dataset_id)
+        permission_notice: Dict[str, Any] = {}
         result_str = await execute_sql_query_core(
             db,
             sql=sql_to_execute,
             data_source=report.data_source,
-            dataset_name=None,
+            dataset_name=dataset_name,
             user_id=user_id,
             user_dimensions=user_dimensions,
             trace_logs=None,
@@ -1387,6 +1410,7 @@ async def execute_saved_report(
             dry_run=False,
             is_admin=is_admin,
             bypass_table_auth=False,
+            permission_notice=permission_notice,
         )
     except Exception as e:
         logger.error("Failed to execute SQL from saved report: %s", e)
@@ -1415,8 +1439,9 @@ async def execute_saved_report(
                 cache_payload = {
                     "sql": sql_to_execute,
                     "data_source": report.data_source,
-                    "dataset_name": None,
+                    "dataset_name": dataset_name,
                     "rows": parsed,
+                    "permission_notice": permission_notice if permission_notice.get("row_filter_applied") is True else None,
                     "params": resolved_params,
                     "report_id": report.id,
                     "report_title": report.title,
@@ -1437,7 +1462,7 @@ async def execute_saved_report(
         except Exception as pref_err:
             logger.warning("Failed to record saved report run preference for %s: %s", report.id, pref_err)
         await db.flush()
-        return StandardResponse(data=parsed)
+        return StandardResponse(data=_attach_permission_notice(parsed, permission_notice))
     except json.JSONDecodeError:
         pass
 
@@ -1455,4 +1480,4 @@ async def execute_saved_report(
     except Exception as pref_err:
         logger.warning("Failed to record saved report run preference for %s: %s", report.id, pref_err)
     await db.flush()
-    return StandardResponse(data={"rows": raw_res})
+    return StandardResponse(data=_attach_permission_notice({"rows": raw_res}, permission_notice))

--- a/app/api/portal/endpoints/system.py
+++ b/app/api/portal/endpoints/system.py
@@ -278,6 +278,62 @@ async def flush_redis_keys(
         logging.error(f"Failed to flush redis keys: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
+class RedisDeleteKeysRequest(BaseModel):
+    keys: List[str]
+
+class RedisDeleteKeysResponse(BaseModel):
+    status: str
+    deleted_count: int
+    message: str
+
+@router.post("/redis/delete-keys", response_model=RedisDeleteKeysResponse)
+async def delete_redis_keys_batch(
+    data: RedisDeleteKeysRequest,
+    user: Dict = Depends(require_permission("element", "element:system:config_save")),
+):
+    """Batch delete selected Redis keys."""
+    try:
+        if not settings.REDIS_ENABLE:
+            raise HTTPException(status_code=400, detail="Redis is disabled")
+
+        if not data.keys:
+            raise HTTPException(status_code=400, detail="No keys specified")
+
+        if len(data.keys) > 5000:
+            raise HTTPException(status_code=400, detail="Too many keys (max 5000)")
+
+        r = await redis.get_redis()
+        if not r:
+            await redis.init_redis()
+            r = await redis.get_redis()
+
+        if not r:
+            raise HTTPException(status_code=500, detail="Redis client not available")
+
+        deleted_count = 0
+        chunk_size = 500
+        for i in range(0, len(data.keys), chunk_size):
+            chunk = data.keys[i : i + chunk_size]
+            if chunk:
+                deleted_count += await r.delete(*chunk)
+
+        logging.info(
+            "Redis selective cleanup by %s: deleted %s keys",
+            user.get("user_name"),
+            deleted_count,
+        )
+        return RedisDeleteKeysResponse(
+            status="success",
+            deleted_count=deleted_count,
+            message=f"Deleted {deleted_count} key(s).",
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logging.error(f"Failed to batch delete redis keys: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
 @router.post("/redis/rebuild-vectors")
 async def rebuild_vector_indexes(
     user: Dict = Depends(require_permission("element", "element:system:config_save"))

--- a/app/api/portal/endpoints/system.py
+++ b/app/api/portal/endpoints/system.py
@@ -1,16 +1,29 @@
-from fastapi import APIRouter, Depends, HTTPException, Body
+from fastapi import APIRouter, Depends, HTTPException, Body, File, UploadFile
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel
 from app.core.dependencies import require_admin, require_permission
 from app.core.config import settings
 from app.core import redis
 from app.services.config_service import ConfigService
+from app.schemas.branding import BrandingSettingsUpdate
+from app.services.branding_settings_service import BrandingSettingsService
 from app.schemas.system_config import ConfigHistoryItem
 import logging
 import asyncio
 import traceback
+import os
+import time
 
 router = APIRouter()
+
+BRANDING_UPLOAD_DIR = "data/branding"
+ALLOWED_ICON_TYPES = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+    "image/svg+xml": ".svg",
+}
+MAX_ICON_BYTES = 512 * 1024
 
 @router.get("/configs/{key}/history", response_model=List[ConfigHistoryItem])
 async def get_config_history(
@@ -634,6 +647,59 @@ async def update_system_configs(
     except Exception as e:
         logging.error(f"Failed to update configs: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/branding")
+async def get_branding_settings(
+    user: Dict = Depends(require_permission("menu", "menu:system:config"))
+):
+    """获取品牌个性化配置（管理端）。"""
+    return await BrandingSettingsService.get_raw_settings()
+
+
+@router.put("/branding")
+async def update_branding_settings(
+    body: BrandingSettingsUpdate,
+    user: Dict = Depends(require_permission("element", "element:system:config_save")),
+):
+    """保存品牌个性化配置。"""
+    await BrandingSettingsService.update_settings(
+        enabled=body.enabled,
+        product_name=body.product_name,
+        login_subtitle=body.login_subtitle,
+        icon_url=body.icon_url,
+        hide_login_sso=body.hide_login_sso,
+        hide_version_link=body.hide_version_link,
+        contact_markdown=body.contact_markdown,
+        copyright_text=body.copyright_text,
+        changed_by=user.get("user_name", "admin"),
+    )
+    return await BrandingSettingsService.get_raw_settings()
+
+
+@router.post("/branding/icon")
+async def upload_branding_icon(
+    file: UploadFile = File(...),
+    user: Dict = Depends(require_permission("element", "element:system:config_save")),
+):
+    """上传品牌 Logo / Favicon（PNG/JPEG/WebP/SVG，最大 512KB）。"""
+    content_type = (file.content_type or "").lower()
+    ext = ALLOWED_ICON_TYPES.get(content_type)
+    if not ext:
+        raise HTTPException(status_code=400, detail="仅支持 PNG、JPEG、WebP、SVG 图片")
+
+    data = await file.read()
+    if len(data) > MAX_ICON_BYTES:
+        raise HTTPException(status_code=400, detail="图片大小不能超过 512KB")
+
+    os.makedirs(BRANDING_UPLOAD_DIR, exist_ok=True)
+    filename = f"icon{ext}"
+    save_path = os.path.join(BRANDING_UPLOAD_DIR, filename)
+    with open(save_path, "wb") as f:
+        f.write(data)
+
+    icon_url = f"/branding/{filename}?t={int(time.time())}"
+    return {"icon_url": icon_url}
 
 
 # --- Log & Partition Management Endpoints (Admin Only) ---

--- a/app/api/v1/endpoints/chat.py
+++ b/app/api/v1/endpoints/chat.py
@@ -138,10 +138,13 @@ class DatasetNavigationResponse(BaseModel):
 
 
 class DatasetMenuClickRequest(BaseModel):
-    dataset_menu_hash: str = Field(..., description="当前数据目录 hash")
     query: str = Field(..., description="用户点击的完整 quick 问题")
     label: Optional[str] = Field(default=None, description="按钮短标签")
     group_id: Optional[str] = Field(default=None, description="业务场景卡片 ID")
+    dataset_menu_hash: Optional[str] = Field(
+        default=None,
+        description="已废弃，仅保留兼容；点击统计按 user_id 存储",
+    )
 
 
 class DatasetGroupRefreshRequest(BaseModel):
@@ -270,7 +273,6 @@ async def record_dataset_menu_question_click(
     await DatasetNavigationService.record_question_click(
         user_id=user_id,
         is_admin=is_admin,
-        dataset_menu_hash=request.dataset_menu_hash,
         query=request.query,
         label=request.label,
         group_id=request.group_id,
@@ -296,7 +298,6 @@ async def clear_dataset_menu_question_click(
     cleared = await DatasetNavigationService.clear_question_click(
         user_id=user_id,
         is_admin=is_admin,
-        dataset_menu_hash=request.dataset_menu_hash,
         query=request.query,
     )
     return StandardResponse(data={"success": cleared})
@@ -329,7 +330,6 @@ async def refresh_group_questions(
             tables=request.tables,
             user_id=user_id,
             is_admin=is_admin,
-            dataset_menu_hash=request.dataset_menu_hash or "",
             group_id=request.group_id or "",
             exclude_questions=request.exclude_questions,
         )
@@ -340,7 +340,6 @@ async def refresh_group_questions(
             tables=request.tables,
             user_id=user_id,
             is_admin=is_admin,
-            dataset_menu_hash=request.dataset_menu_hash or "",
             group_id=request.group_id or "",
             exclude_questions=request.exclude_questions,
         )

--- a/app/api/v1/endpoints/chatbi.py
+++ b/app/api/v1/endpoints/chatbi.py
@@ -11,7 +11,17 @@ from app.core.dependencies import require_api_key
 from app.core.orm import get_db_session
 from app.schemas.response import StandardResponse
 from app.services.auth_service import AuthService
-from app.services.sql_query_execution_service import execute_sql_query_core
+from app.services.ai.chatbi_sql_query_binding import (
+    normalize_sql_identifier,
+    resolve_table_bindings_from_db,
+)
+from app.services.metadata_service import MetadataService
+from app.services.sql_query_execution_service import (
+    attach_permission_notice_to_payload,
+    dialect_from_data_source,
+    execute_sql_query_core,
+    extract_physical_table_refs_from_select_sql,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +40,7 @@ public_router = APIRouter()
 class ChatBiSqlExecuteRequest(BaseModel):
     sql: str = Field(..., description="只读 SELECT 语句")
     data_source: str = Field(..., description="数据源标识，如 default_clickhouse、mysql_oa")
+    dataset_name: Optional[str] = Field(default=None, description="可选数据集名称；用于行级数据权限重写")
     sessionid: str = Field(..., description="OpenClaw 会话 ID，用于后续通过 session_status 工具获取会话状态")
 
 
@@ -37,6 +48,10 @@ class ChatBiSqlExecuteData(BaseModel):
     """外部 SQL 执行 API 返回的 data 负载（常见为 columns / items）。"""
 
     model_config = ConfigDict(extra="allow")
+    permission_notice: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="当本次结果已应用行级数据权限过滤时返回的非敏感提示信息",
+    )
 
 
 class ChatBiSqlCheckAuthData(BaseModel):
@@ -49,6 +64,7 @@ class ChatBiSqlCheckAuthRequest(BaseModel):
     username: str = Field(..., description="平台用户登录名，对应 ai_agent_users.user_name")
     sql: str = Field(..., description="只读 SELECT 语句")
     data_source: str = Field(..., description="数据源标识，如 default_clickhouse、mysql_oa")
+    dataset_name: Optional[str] = Field(default=None, description="可选数据集名称；用于行级数据权限重写")
 
 
 def _map_sql_tool_error_to_http(result: str) -> None:
@@ -76,6 +92,126 @@ def _chatbi_user_dimensions(user_info: Dict[str, Any], user_id: int) -> Dict[str
     }
 
 
+def _attach_permission_notice(payload: Dict[str, Any], permission_notice: Dict[str, Any]) -> Dict[str, Any]:
+    return attach_permission_notice_to_payload(payload, permission_notice)
+
+
+async def _dataset_names_with_row_filter(db: AsyncSession, dataset_names: set[str]) -> set[str]:
+    enabled: set[str] = set()
+    for name in dataset_names:
+        dn = str(name or "").strip()
+        if not dn:
+            continue
+        ds = await MetadataService.get_dataset_by_name(db, dn)
+        if ds and ds.enable_data_perm:
+            enabled.add(dn)
+    return enabled
+
+
+async def _collect_candidate_dataset_names(
+    db: AsyncSession,
+    *,
+    refs: Dict[str, str],
+    bindings: Dict[str, Any],
+) -> set[str]:
+    from app.services.ai.chatbi_sql_query_binding import _fetch_table_binding_candidates_from_db
+
+    dataset_names = {
+        str(binding.dataset_name or "").strip()
+        for binding in bindings.values()
+        if str(getattr(binding, "dataset_name", "") or "").strip()
+    }
+    if len(bindings) >= len(refs):
+        return dataset_names
+
+    candidates_map = await _fetch_table_binding_candidates_from_db(db, list(refs.values()))
+    for physical_name in refs.values():
+        key = normalize_sql_identifier(physical_name)
+        if key in bindings:
+            continue
+        for candidate in candidates_map.get(key, []):
+            dn = str(candidate.dataset_name or "").strip()
+            if dn:
+                dataset_names.add(dn)
+    return dataset_names
+
+
+async def _raise_if_row_filter_requires_dataset_resolution(
+    db: AsyncSession,
+    *,
+    refs: Dict[str, str],
+    bindings: Dict[str, Any],
+    reason: str,
+) -> None:
+    dataset_names = await _collect_candidate_dataset_names(db, refs=refs, bindings=bindings)
+    if not dataset_names:
+        return
+    if await _dataset_names_with_row_filter(db, dataset_names):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "[Validation Failed] 无法安全确定 SQL 所属数据集，但涉及的表已开启行级数据权限；"
+                "请在请求中显式传入 dataset_name，或将 SQL 限定到单一数据集。"
+                f"（{reason}）"
+            ),
+        )
+
+
+async def _resolve_direct_sql_dataset_name(
+    db: AsyncSession,
+    *,
+    sql: str,
+    data_source: str,
+    explicit_dataset_name: Optional[str],
+) -> Optional[str]:
+    explicit = str(explicit_dataset_name or "").strip()
+    if explicit:
+        return explicit
+
+    dialect = dialect_from_data_source(data_source)
+    parse_error, refs = extract_physical_table_refs_from_select_sql(sql, dialect)
+    if parse_error or not refs:
+        return None
+
+    try:
+        bindings = await resolve_table_bindings_from_db(db, list(refs.values()))
+    except Exception as exc:
+        logger.warning("[ChatBI SQL] Failed to infer dataset from SQL refs: %s", exc)
+        return None
+    if len(bindings) < len(refs):
+        await _raise_if_row_filter_requires_dataset_resolution(
+            db,
+            refs=refs,
+            bindings=bindings,
+            reason="部分物理表无法唯一绑定到数据集",
+        )
+        return None
+
+    dataset_names = {
+        str(binding.dataset_name or "").strip()
+        for binding in bindings.values()
+        if str(binding.dataset_name or "").strip()
+    }
+    if len(dataset_names) == 1:
+        return next(iter(dataset_names))
+    if len(dataset_names) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "[Validation Failed] 直连 SQL 引用了多个数据集，属于跨数据集查询，"
+                "无法安全自动应用行级权限；"
+                "请改走联邦查询流程，或将 SQL 限定到单一数据集。"
+            ),
+        )
+    await _raise_if_row_filter_requires_dataset_resolution(
+        db,
+        refs=refs,
+        bindings=bindings,
+        reason="未能从 SQL 引用表推断出数据集名称",
+    )
+    return None
+
+
 def _openclaw_openai_username_from_sessionid(sessionid: str) -> Optional[str]:
     match = OPENCLAW_OPENAI_SESSION_PATTERN.match((sessionid or "").strip())
     if not match:
@@ -97,11 +233,18 @@ async def _enforce_openclaw_session_sql_auth(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="OpenClaw 会话用户不存在或已禁用")
 
     session_user_id = int(session_user_info["user_id"])
+    dataset_name = await _resolve_direct_sql_dataset_name(
+        db,
+        sql=body.sql,
+        data_source=body.data_source,
+        explicit_dataset_name=body.dataset_name,
+    )
+    permission_notice: Dict[str, Any] = {}
     result_str = await execute_sql_query_core(
         db,
         sql=body.sql,
         data_source=body.data_source,
-        dataset_name=None,
+        dataset_name=dataset_name,
         user_id=session_user_id,
         user_dimensions=_chatbi_user_dimensions(session_user_info, session_user_id),
         trace_logs=None,
@@ -156,12 +299,19 @@ async def chatbi_sql_execute(
 
     is_openclaw_user = bool(_openclaw_openai_username_from_sessionid(body.sessionid))
     bypass_table_auth = not is_openclaw_user
+    dataset_name = await _resolve_direct_sql_dataset_name(
+        db,
+        sql=body.sql,
+        data_source=body.data_source,
+        explicit_dataset_name=body.dataset_name,
+    )
 
+    permission_notice: Dict[str, Any] = {}
     result_str = await execute_sql_query_core(
         db,
         sql=body.sql,
         data_source=body.data_source,
-        dataset_name=None,
+        dataset_name=dataset_name,
         user_id=user_id,
         user_dimensions=user_dimensions,
         trace_logs=None,
@@ -170,6 +320,7 @@ async def chatbi_sql_execute(
         dry_run=False,
         is_admin=user_info.get("role") == "admin",
         bypass_table_auth=bypass_table_auth,
+        permission_notice=permission_notice,
     )
 
     # 动态判定当前物理执行分流模式
@@ -191,11 +342,13 @@ async def chatbi_sql_execute(
         parsed = json.loads(raw)
         if isinstance(parsed, dict):
             return StandardResponse(
-                data=ChatBiSqlExecuteData.model_validate(parsed),
+                data=ChatBiSqlExecuteData.model_validate(_attach_permission_notice(parsed, permission_notice)),
                 execution_mode=execution_mode
             )
         return StandardResponse(
-            data=ChatBiSqlExecuteData.model_validate({"rows": parsed}),
+            data=ChatBiSqlExecuteData.model_validate(
+                _attach_permission_notice({"rows": parsed}, permission_notice)
+            ),
             execution_mode=execution_mode
         )
     except json.JSONDecodeError:
@@ -234,12 +387,18 @@ async def chatbi_sql_checkauth(
 
     user_id = int(user_info["user_id"])
     user_dimensions = _chatbi_user_dimensions(user_info, user_id)
+    dataset_name = await _resolve_direct_sql_dataset_name(
+        db,
+        sql=body.sql,
+        data_source=body.data_source,
+        explicit_dataset_name=body.dataset_name,
+    )
 
     result_str = await execute_sql_query_core(
         db,
         sql=body.sql,
         data_source=body.data_source,
-        dataset_name=None,
+        dataset_name=dataset_name,
         user_id=user_id,
         user_dimensions=user_dimensions,
         trace_logs=None,

--- a/app/main.py
+++ b/app/main.py
@@ -345,6 +345,10 @@ uploads_dir = os.path.join(base_dir, "data", "uploads")
 os.makedirs(uploads_dir, exist_ok=True)
 app.mount("/static/uploads", StaticFiles(directory=uploads_dir), name="uploads")
 
+branding_dir = os.path.join(base_dir, "data", "branding")
+os.makedirs(branding_dir, exist_ok=True)
+app.mount("/branding", StaticFiles(directory=branding_dir), name="branding")
+
 
 @app.get("/{full_path:path}")
 async def serve_spa(full_path: str):

--- a/app/models/db_connection.py
+++ b/app/models/db_connection.py
@@ -12,7 +12,7 @@ class MetaDbConnectionConfig(Base):
 
     id            = Column(Integer, primary_key=True, index=True)
     name          = Column(String(100), nullable=False, comment='连接别名，如"生产-业务库"')
-    db_type       = Column(String(20), nullable=False, comment='数据库类型: mysql|clickhouse|oracle')
+    db_type       = Column(String(20), nullable=False, comment='数据库类型: mysql|clickhouse|oracle|sqlserver')
     host          = Column(String(255), nullable=False, comment='主机地址')
     port          = Column(Integer, nullable=False, comment='端口号')
     db_user       = Column(String(100), nullable=False, comment='数据库用户名')

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -43,6 +43,13 @@ class AIAgentBase(BaseModel):
     engine_type: str = "LOCAL"
     engine_config: Optional[Dict[str, Any]] = None
 
+class AIAgentReorderItem(BaseModel):
+    id: str
+    sort_order: int
+
+class AIAgentReorderRequest(BaseModel):
+    items: List[AIAgentReorderItem]
+
 class AIAgentResponse(AIAgentBase):
     id: str
     is_system: bool

--- a/app/schemas/branding.py
+++ b/app/schemas/branding.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel
+
+from app.services.branding_settings_service import (
+    DEFAULT_ICON_URL,
+    DEFAULT_LOGIN_SUBTITLE,
+    DEFAULT_PRODUCT_NAME,
+)
+
+
+class BrandingSettings(BaseModel):
+    enabled: bool = False
+    product_name: str = DEFAULT_PRODUCT_NAME
+    login_subtitle: str = DEFAULT_LOGIN_SUBTITLE
+    icon_url: str = DEFAULT_ICON_URL
+    hide_login_sso: bool = False
+    hide_version_link: bool = False
+    contact_markdown: str = ""
+    copyright_text: str = ""
+
+
+class BrandingSettingsUpdate(BrandingSettings):
+    pass
+
+
+class PublicBrandingResponse(BaseModel):
+    enabled: bool = False
+    product_name: str
+    login_subtitle: str
+    icon_url: str
+    hide_login_sso: bool = False
+    hide_version_link: bool = False
+    contact_markdown: str = ""
+    copyright_text: str = ""

--- a/app/services/ai/agent_manager.py
+++ b/app/services/ai/agent_manager.py
@@ -300,6 +300,37 @@ class AgentManagerService:
         return agent
 
     @staticmethod
+    async def reorder_agents(session: AsyncSession, items: List[Any], user: Any = None) -> bool:
+        """Batch update sort_order for agents (admin only)."""
+        if isinstance(user, dict):
+            is_admin = user.get('role', '') == 'admin'
+        else:
+            is_admin = user and getattr(user, 'role', '') == 'admin'
+
+        if not is_admin:
+            return False
+
+        ids = [item.id for item in items]
+        if not ids:
+            return True
+
+        stmt = select(AIAgent).where(AIAgent.id.in_(ids))
+        result = await session.execute(stmt)
+        agents = {agent.id: agent for agent in result.scalars().all()}
+
+        for item in items:
+            agent = agents.get(item.id)
+            if agent:
+                agent.sort_order = item.sort_order
+
+        await session.commit()
+
+        from app.services.ai.router_service import router_service
+        router_service.invalidate_cache()
+
+        return True
+
+    @staticmethod
     async def update_agent(session: AsyncSession, agent_id: str, data: AIAgentBase, user: Any = None) -> Optional[AIAgent]:
         """Update existing agent metadata"""
         agent = await session.get(AIAgent, agent_id)

--- a/app/services/ai/config.py
+++ b/app/services/ai/config.py
@@ -264,10 +264,10 @@ class AgentConfigProvider:
         # 2. Cache Miss: Fetch from DB
         content = await AgentConfigProvider._generate_dataset_menu_content(user_id, is_admin)
 
-        # 3. Save to Cache (TTL: 7 days)
+        # 3. Save to Cache (TTL: 90 days)
         try:
             if redis:
-                await redis.set(cache_key, content, ex=604800)
+                await redis.set(cache_key, content, ex=90 * 24 * 60 * 60)
         except Exception as e:
             logger.warning(f"Redis set error: {e}")
         
@@ -288,7 +288,7 @@ class AgentConfigProvider:
                 async for key in redis.scan_iter(match="agent:dataset_menu:*", count=200):
                     await redis.delete(key)
                 await redis.delete("agent:dataset_menu")
-            await DatasetNavigationService.bump_navigation_cache_generation()
+            await DatasetNavigationService.invalidate_all_navigation_caches()
             logger.info("Dataset menu and navigation caches invalidated.")
             # 异步启动后台预热任务，温和预热最近活跃用户的门户缓存
             import asyncio
@@ -308,5 +308,10 @@ class AgentConfigProvider:
                 cache_key = f"agent:dataset_menu:{'admin' if is_admin else user_id or 'anon'}"
                 await redis.delete(cache_key)
                 logger.info(f"Dataset menu cache invalidated for key: {cache_key}")
+            from app.services.dataset_navigation_service import DatasetNavigationService
+            await DatasetNavigationService.invalidate_navigation_cache_for_user(
+                user_id=user_id,
+                is_admin=is_admin,
+            )
         except Exception as e:
             logger.warning(f"Failed to invalidate dataset menu cache for user {user_id}: {e}")

--- a/app/services/ai/rewriters/sql_rewriter.py
+++ b/app/services/ai/rewriters/sql_rewriter.py
@@ -17,18 +17,19 @@ class SQLRewriter:
 
     def __init__(self, dialect: str = "clickhouse", table_metadata: Optional[Dict[str, Set[str]]] = None):
         self.dialect = dialect
-        self.table_metadata = table_metadata or {}  # {table_name: {field1, field2, ...}}
+        self.table_metadata = self._normalize_table_metadata(table_metadata or {})  # {table_name: {field1, field2, ...}}
 
     def set_table_metadata(self, table_metadata: Dict[str, Set[str]]):
         """设置表元数据，用于字段验证"""
-        self.table_metadata = table_metadata
+        self.table_metadata = self._normalize_table_metadata(table_metadata)
 
     def rewrite(
-        self, 
-        sql: str, 
-        filters: List[Dict[str, Any]], 
+        self,
+        sql: str,
+        filters: List[Dict[str, Any]],
         user_context: Dict[str, Any],
-        is_admin: bool = False
+        is_admin: bool = False,
+        rewrite_stats: Optional[Dict[str, int]] = None,
     ) -> str:
         """
         优化版SQL重写：添加字段验证和智能表匹配
@@ -47,28 +48,41 @@ class SQLRewriter:
                 logger.info(f"[SQLRewriter] No relevant filters found for tables: {query_tables}")
                 return sql
             
-            # 3. 处理过滤条件（替换变量 + 字段验证）
-            processed_conditions = self._prepare_conditions_with_validation(relevant_filters, user_context, query_tables)
-            if not processed_conditions:
-                raise SQLRewriteError("No valid permission filter conditions could be applied")
+            applied_count = 0
+            cte_aliases = self._collect_cte_aliases(expression)
 
-            # 4. 应用条件到AST
-            def transform_node(node):
-                if isinstance(node, exp.Select):
-                    new_node = node.copy()
-                    for cond in processed_conditions:
-                        new_node = new_node.where(cond, append=True)
-                    return new_node
-                return node
+            # 3. 按 SELECT 作用域应用条件到 AST。先收集节点，避免 transform 返回新节点后剪枝子查询。
+            select_nodes = list(expression.find_all(exp.Select))
+            select_nodes.sort(key=self._expression_depth, reverse=True)
+            for select_node in select_nodes:
+                table_aliases = self._extract_select_table_aliases(select_node, cte_aliases=cte_aliases)
+                scoped_filters = self._filter_relevant_conditions_for_scope(relevant_filters, table_aliases)
+                if not scoped_filters:
+                    continue
+                processed_conditions = self._prepare_conditions_for_scope(
+                    scoped_filters,
+                    user_context,
+                    table_aliases,
+                )
+                if not processed_conditions:
+                    raise SQLRewriteError("No valid permission filter conditions could be applied")
+                for cond in processed_conditions:
+                    select_node.where(cond, append=True, copy=False)
+                applied_count += len(processed_conditions)
+            if applied_count == 0:
+                logger.info(f"[SQLRewriter] No scoped filters applied for tables: {query_tables}")
+                if rewrite_stats is not None:
+                    rewrite_stats["applied_rule_count"] = 0
+                return sql
 
-            expression = expression.transform(transform_node)
-            
-            # 5. 生成最终SQL
+            if rewrite_stats is not None:
+                rewrite_stats["applied_rule_count"] = applied_count
+
+            # 4. 生成最终SQL
             result_sql = expression.sql(dialect=self.dialect)
             
-            # 6. 记录应用的条件信息
-            applied_count = len(processed_conditions)
-            skipped_count = len(filters) - applied_count
+            # 5. 记录应用的条件信息
+            skipped_count = len(filters) - len(relevant_filters)
             logger.info(f"[SQLRewriter] Applied {applied_count} filters, skipped {skipped_count} invalid filters")
             
             return result_sql
@@ -95,6 +109,69 @@ class SQLRewriter:
                 tables.add(table_name)
         
         return tables
+
+    @staticmethod
+    def _normalize_table_metadata(table_metadata: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
+        return {
+            str(table_name).lower(): {str(field) for field in fields}
+            for table_name, fields in (table_metadata or {}).items()
+        }
+
+    @staticmethod
+    def _expression_depth(node: exp.Expression) -> int:
+        depth = 0
+        parent = node.parent
+        while parent is not None:
+            depth += 1
+            parent = parent.parent
+        return depth
+
+    @staticmethod
+    def _collect_cte_aliases(expression: exp.Expression) -> Set[str]:
+        aliases: Set[str] = set()
+        for with_expr in expression.find_all(exp.With):
+            for cte in with_expr.expressions:
+                if isinstance(cte, exp.CTE) and cte.alias:
+                    aliases.add(str(cte.alias).strip('"`[]').lower())
+        return aliases
+
+    @staticmethod
+    def _table_name_from_node(node: exp.Table) -> str:
+        if isinstance(node.this, exp.Identifier):
+            table_name = node.this.this
+        else:
+            table_name = str(node.this)
+        return str(table_name or "").strip('"`[]').lower()
+
+    @staticmethod
+    def _table_alias_from_node(node: exp.Table) -> str:
+        alias = node.alias_or_name
+        return str(alias or "").strip('"`[]')
+
+    def _extract_select_table_aliases(self, select_expr: exp.Select, *, cte_aliases: Optional[Set[str]] = None) -> Dict[str, str]:
+        """提取当前 SELECT 直接 FROM/JOIN 作用域内的物理表与别名映射。"""
+        aliases: Dict[str, str] = {}
+        cte_aliases = cte_aliases or set()
+
+        def add_table(node: Any) -> None:
+            if not isinstance(node, exp.Table):
+                return
+            table_name = self._table_name_from_node(node)
+            if table_name in cte_aliases:
+                return
+            alias_name = self._table_alias_from_node(node) or table_name
+            if table_name:
+                aliases[table_name] = alias_name
+
+        from_expr = select_expr.args.get("from_")
+        if isinstance(from_expr, exp.From):
+            add_table(from_expr.this)
+
+        for join_expr in select_expr.args.get("joins") or []:
+            if isinstance(join_expr, exp.Join):
+                add_table(join_expr.this)
+
+        return aliases
 
     def _filter_relevant_conditions(self, filters: List[Dict[str, Any]], query_tables: Set[str]) -> List[Dict[str, Any]]:
         """智能过滤：只返回与查询表相关的条件"""
@@ -125,6 +202,82 @@ class SQLRewriter:
             else:
                 logger.info(f"[SQLRewriter] Skipping unrelated filter: '{condition}' (Tables: {condition_tables_lower})")
         
+        return relevant_filters
+
+    def _extract_unqualified_columns(self, condition: str) -> Set[str]:
+        """从条件字符串中提取未带表前缀的字段名。"""
+        clean_condition = re.sub(r"\{user\.\w+\}", "", condition)
+        without_qualified = re.sub(
+            r'(?:["`\[])?[a-zA-Z_][a-zA-Z0-9_]*(?:["`\]])?\.[a-zA-Z_][a-zA-Z0-9_]*',
+            "",
+            clean_condition,
+        )
+        reserved = {
+            "and", "or", "not", "in", "is", "like", "null", "true", "false",
+            "between", "exists", "case", "when", "then", "else", "end",
+        }
+        columns: Set[str] = set()
+        for match in re.finditer(
+            r"\b([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:=|<>|!=|<|>|<=|>=|IN\b|LIKE\b|IS\b|BETWEEN\b)",
+            without_qualified,
+            flags=re.IGNORECASE,
+        ):
+            name = str(match.group(1) or "").lower()
+            if name and name not in reserved:
+                columns.add(name)
+        return columns
+
+    def _local_tables_for_unqualified_condition(
+        self,
+        condition: str,
+        local_tables: Set[str],
+    ) -> Set[str]:
+        """判定无表前缀条件在当前 SELECT 作用域内可安全应用的物理表。"""
+        if not local_tables:
+            return set()
+        unqualified_columns = self._extract_unqualified_columns(condition)
+        if not unqualified_columns:
+            return local_tables if len(local_tables) == 1 else set()
+        if not self.table_metadata:
+            return local_tables if len(local_tables) == 1 else set()
+
+        matching_tables = {
+            table_name
+            for table_name in local_tables
+            if unqualified_columns.issubset(self.table_metadata.get(table_name, set()))
+        }
+        return matching_tables if len(matching_tables) == 1 else set()
+
+    def _filter_relevant_conditions_for_scope(
+        self,
+        filters: List[Dict[str, Any]],
+        table_aliases: Dict[str, str],
+    ) -> List[Dict[str, Any]]:
+        """只返回适用于当前 SELECT 直接表作用域的条件。"""
+        local_tables = set(table_aliases.keys())
+        if not local_tables:
+            return []
+        relevant_filters = []
+
+        for f in filters:
+            condition = f.get("condition", "")
+            target_table = str(f.get("target_table", "all")).strip('"`[]').lower()
+            condition_tables = self._extract_tables_from_condition(condition)
+
+            if target_table != "all" and target_table not in local_tables:
+                continue
+            if condition_tables and not condition_tables.issubset(local_tables):
+                continue
+            if not condition_tables:
+                if target_table != "all":
+                    if target_table in local_tables:
+                        relevant_filters.append(f)
+                    continue
+                if self._local_tables_for_unqualified_condition(condition, local_tables):
+                    relevant_filters.append(f)
+                continue
+            relevant_filters.append(f)
+
         return relevant_filters
 
     def _extract_tables_from_condition(self, condition: str) -> Set[str]:
@@ -179,6 +332,44 @@ class SQLRewriter:
         
         return prepared
 
+    def _prepare_conditions_for_scope(
+        self,
+        filters: List[Dict[str, Any]],
+        context: Dict[str, Any],
+        table_aliases: Dict[str, str],
+    ) -> List[exp.Expression]:
+        prepared = []
+        query_tables = set(table_aliases.keys())
+
+        for f in filters:
+            cond_str = f.get("condition")
+            if not cond_str:
+                raise SQLRewriteError("Permission filter condition is empty")
+
+            temp_cond = self._replace_user_variables(cond_str, context)
+            if not query_tables or not self._validate_condition_fields(temp_cond, query_tables):
+                logger.error(f"[SQLRewriter] Invalid permission condition due to field validation: {temp_cond}")
+                raise SQLRewriteError(f"Permission filter condition references unavailable fields: {temp_cond}")
+
+            try:
+                cond_expr = sqlglot.parse_one(temp_cond, read=self.dialect)
+                self._rewrite_condition_table_aliases(cond_expr, table_aliases)
+                prepared.append(cond_expr)
+                logger.debug(f"[SQLRewriter] Applied condition: {temp_cond}")
+            except Exception as e:
+                logger.error(f"[SQLRewriter] Failed to parse permission condition '{temp_cond}': {e}")
+                raise SQLRewriteError(f"Permission filter condition parse failed: {e}") from e
+
+        return prepared
+
+    @staticmethod
+    def _rewrite_condition_table_aliases(condition: exp.Expression, table_aliases: Dict[str, str]) -> None:
+        for column in condition.find_all(exp.Column):
+            table_name = str(column.table or "").strip('"`[]').lower()
+            alias = table_aliases.get(table_name)
+            if alias and alias != table_name:
+                column.set("table", exp.to_identifier(alias))
+
     def _replace_user_variables(self, condition: str, context: Dict[str, Any]) -> str:
         """替换用户变量占位符"""
         placeholders = re.findall(r"\{user\.(\w+)\}", condition)
@@ -219,14 +410,16 @@ class SQLRewriter:
             return True
         
         for table_name, field_name in matches:
+            table_key = str(table_name).lower()
+            field_key = str(field_name)
             # 检查表是否在查询中
-            if table_name not in query_tables:
+            if table_key not in query_tables:
                 logger.debug(f"[SQLRewriter] Field {table_name}.{field_name} references table not in query: {query_tables}")
                 return False
-            
+
             # 检查字段是否在表中存在
-            if table_name in self.table_metadata:
-                if field_name not in self.table_metadata[table_name]:
+            if table_key in self.table_metadata:
+                if field_key not in self.table_metadata[table_key]:
                     logger.debug(f"[SQLRewriter] Field {field_name} not found in table {table_name}")
                     return False
         

--- a/app/services/ai/runners/chatbi/react_stream.py
+++ b/app/services/ai/runners/chatbi/react_stream.py
@@ -286,7 +286,13 @@ async def stream_agentscope_events(
                 timestamp=datetime.fromtimestamp(state.tool_started_at.get(tool_id, time.time())),
             )
         )
-        yield {
+        notice = None
+        if tool_name == "execute_sql_query" and not state.sql_error:
+            final_parsed = runner._try_parse_json_output(output)
+            notice = final_parsed.get("permission_notice") if isinstance(final_parsed, dict) else None
+            if isinstance(notice, dict) and notice.get("row_filter_applied") is True:
+                yield {"type": "meta", "permission_notice": notice}
+        log_payload: Dict[str, Any] = {
             "type": "log",
             "id": tool_id,
             "title": f"工具完成: {tool_name}",
@@ -294,6 +300,13 @@ async def stream_agentscope_events(
             "status": "success",
             "execution_time_ms": duration_ms,
         }
+        if (
+            tool_name == "execute_sql_query"
+            and isinstance(notice, dict)
+            and notice.get("row_filter_applied") is True
+        ):
+            log_payload["row_filter_applied"] = True
+        yield log_payload
 
     def track_sql_plan_delta(delta: str) -> None:
         state.text_window = (state.text_window + delta)[-4000:]

--- a/app/services/ai/runners/chatbi/tool_result_handlers.py
+++ b/app/services/ai/runners/chatbi/tool_result_handlers.py
@@ -20,6 +20,13 @@ def format_sql_result_for_display(runner: Any, output: Any, *, max_rows: int = _
     parsed = runner._try_parse_json_output(output)
     if isinstance(parsed, dict) and runner._is_structured_sql_result(parsed):
         display: dict[str, Any] = dict(parsed)
+        notice = display.get("permission_notice")
+        if isinstance(notice, dict) and "executed_sql" in notice:
+            display["permission_notice"] = {
+                key: value for key, value in notice.items() if key != "executed_sql"
+            }
+            if not display["permission_notice"]:
+                display.pop("permission_notice", None)
         for key in _SQL_RESULT_ROW_KEYS:
             rows = display.get(key)
             if isinstance(rows, list) and len(rows) > max_rows:
@@ -43,6 +50,25 @@ def format_sql_result_for_display(runner: Any, output: Any, *, max_rows: int = _
         except Exception:
             return str(output or "")
     return str(output or "")
+
+
+def resolve_executed_sql_for_tool_log(
+    parsed: Any,
+    tool_args: dict[str, Any] | None,
+) -> str | None:
+    if isinstance(parsed, dict):
+        notice = parsed.get("permission_notice")
+        if isinstance(notice, dict):
+            executed_sql = notice.get("executed_sql")
+            if isinstance(executed_sql, str) and executed_sql.strip():
+                return executed_sql.strip()
+    if not tool_args:
+        return None
+    raw_sql = tool_args.get("sql") or tool_args.get("query")
+    if isinstance(raw_sql, str) and raw_sql.strip():
+        return raw_sql.strip()
+    return None
+
 
 def build_sql_error_tool_details(runner: Any, output: Any, tool_args: dict[str, Any] | None) -> str:
     text = str(output or "")
@@ -78,10 +104,10 @@ def format_tool_details(
             details = result_details
             output_text = str(output or "")
             if "[Executed SQL]:" not in output_text and tool_args:
-                raw_sql = tool_args.get("sql") or tool_args.get("query")
-                if isinstance(raw_sql, str) and raw_sql.strip():
+                executed_sql = resolve_executed_sql_for_tool_log(parsed, tool_args)
+                if executed_sql:
                     details = (
-                        f"[Executed SQL]:\n{raw_sql.strip()}\n\n"
+                        f"[Executed SQL]:\n{executed_sql}\n\n"
                         f"{_SQL_TOOL_RESULT_DELIMITER}\n{result_details}"
                     )
         elif runner._is_failed_sql_repeat_gate_block(output):
@@ -95,10 +121,10 @@ def format_tool_details(
             details = truncate_for_context(result_text, max_len=1000)
             output_text = str(output or "")
             if "[Executed SQL]:" not in output_text and tool_args:
-                raw_sql = tool_args.get("sql") or tool_args.get("query")
-                if isinstance(raw_sql, str) and raw_sql.strip():
+                executed_sql = resolve_executed_sql_for_tool_log(parsed, tool_args)
+                if executed_sql:
                     details = (
-                        f"[Executed SQL]:\n{raw_sql.strip()}\n\n"
+                        f"[Executed SQL]:\n{executed_sql}\n\n"
                         f"{_SQL_TOOL_RESULT_DELIMITER}\n{details}"
                     )
     else:

--- a/app/services/ai/tools/data_api.py
+++ b/app/services/ai/tools/data_api.py
@@ -1,7 +1,7 @@
 import logging
 import httpx
 import json
-from typing import Optional
+from typing import Any, Optional
 from app.services.ai.tools.tool_compat import tool
 from app.core.config import settings
 import re
@@ -381,11 +381,32 @@ async def execute_sql_query(sql: str, data_source: str, dataset_name: str) -> st
     """
     from app.core.context import get_current_agent_context
     from app.core.orm import AsyncSessionLocal
-    from app.services.sql_query_execution_service import execute_sql_query_core
+    from app.services.sql_query_execution_service import (
+        attach_permission_notice_to_json_result,
+        execute_sql_query_core,
+    )
 
     ctx = get_current_agent_context()
     user_id = ctx.user_id if ctx else None
     is_admin = bool(ctx and getattr(ctx, "is_admin", False))
+    permission_notice: dict[str, Any] = {}
+
+    async def _run_query(session):
+        res = await execute_sql_query_core(
+            session,
+            sql=sql,
+            data_source=data_source,
+            dataset_name=dataset_name,
+            user_id=user_id,
+            user_dimensions=(ctx.user_dimensions if ctx else None) or None,
+            trace_logs=None,
+            api_key=ctx.api_key if ctx else None,
+            agent_context=ctx,
+            dry_run=None,
+            is_admin=is_admin,
+            permission_notice=permission_notice,
+        )
+        return attach_permission_notice_to_json_result(res, permission_notice)
 
     trace_buffer = ctx.trace_buffer if ctx else None
     if trace_buffer is not None:
@@ -398,33 +419,9 @@ async def execute_sql_query(sql: str, data_source: str, dataset_name: str) -> st
             tool_input={"sql": sql, "data_source": data_source, "dataset_name": dataset_name}
         ) as span:
             async with AsyncSessionLocal() as session:
-                res = await execute_sql_query_core(
-                    session,
-                    sql=sql,
-                    data_source=data_source,
-                    dataset_name=dataset_name,
-                    user_id=user_id,
-                    user_dimensions=(ctx.user_dimensions if ctx else None) or None,
-                    trace_logs=None,
-                    api_key=ctx.api_key if ctx else None,
-                    agent_context=ctx,
-                    dry_run=None,
-                    is_admin=is_admin,
-                )
+                res = await _run_query(session)
                 span.set_output(res)
                 return res
     else:
         async with AsyncSessionLocal() as session:
-            return await execute_sql_query_core(
-                session,
-                sql=sql,
-                data_source=data_source,
-                dataset_name=dataset_name,
-                user_id=user_id,
-                user_dimensions=(ctx.user_dimensions if ctx else None) or None,
-                trace_logs=None,
-                api_key=ctx.api_key if ctx else None,
-                agent_context=ctx,
-                dry_run=None,
-                is_admin=is_admin,
-            )
+            return await _run_query(session)

--- a/app/services/branding_settings_service.py
+++ b/app/services/branding_settings_service.py
@@ -1,0 +1,138 @@
+from typing import Any, Dict, Optional
+
+from app.services.config_service import ConfigService
+
+DEFAULT_PRODUCT_NAME = "云枢 · 智能体平台"
+DEFAULT_LOGIN_SUBTITLE = "Yunshu Intelligent Agent Platform"
+DEFAULT_ICON_URL = "/favicon.png"
+
+
+class BrandingSettingsService:
+    CONFIG_ENABLED = "branding.enabled"
+    CONFIG_PRODUCT_NAME = "branding.product_name"
+    CONFIG_LOGIN_SUBTITLE = "branding.login_subtitle"
+    CONFIG_ICON_URL = "branding.icon_url"
+    CONFIG_HIDE_LOGIN_SSO = "branding.hide_login_sso"
+    CONFIG_HIDE_VERSION_LINK = "branding.hide_version_link"
+    CONFIG_CONTACT_MARKDOWN = "branding.contact_markdown"
+    CONFIG_COPYRIGHT_TEXT = "branding.copyright_text"
+
+    @staticmethod
+    async def _get_bool(key: str, default: bool = False) -> bool:
+        val = await ConfigService.get(key)
+        if val is None:
+            return default
+        return str(val).strip().lower() == "true"
+
+    @classmethod
+    async def get_raw_settings(cls) -> Dict[str, Any]:
+        return {
+            "enabled": await cls._get_bool(cls.CONFIG_ENABLED, False),
+            "product_name": (await ConfigService.get(cls.CONFIG_PRODUCT_NAME, DEFAULT_PRODUCT_NAME) or "").strip()
+            or DEFAULT_PRODUCT_NAME,
+            "login_subtitle": (await ConfigService.get(cls.CONFIG_LOGIN_SUBTITLE, DEFAULT_LOGIN_SUBTITLE) or "").strip()
+            or DEFAULT_LOGIN_SUBTITLE,
+            "icon_url": (await ConfigService.get(cls.CONFIG_ICON_URL, DEFAULT_ICON_URL) or "").strip()
+            or DEFAULT_ICON_URL,
+            "hide_login_sso": await cls._get_bool(cls.CONFIG_HIDE_LOGIN_SSO, False),
+            "hide_version_link": await cls._get_bool(cls.CONFIG_HIDE_VERSION_LINK, False),
+            "contact_markdown": (await ConfigService.get(cls.CONFIG_CONTACT_MARKDOWN, "")) or "",
+            "copyright_text": (await ConfigService.get(cls.CONFIG_COPYRIGHT_TEXT, "")) or "",
+        }
+
+    @classmethod
+    async def get_public_branding(cls) -> Dict[str, Any]:
+        """前端展示用：未启用个性化时返回默认品牌，开关项均为默认展示行为。"""
+        raw = await cls.get_raw_settings()
+        if not raw["enabled"]:
+            return {
+                "enabled": False,
+                "product_name": DEFAULT_PRODUCT_NAME,
+                "login_subtitle": DEFAULT_LOGIN_SUBTITLE,
+                "icon_url": DEFAULT_ICON_URL,
+                "hide_login_sso": False,
+                "hide_version_link": False,
+                "contact_markdown": "",
+                "copyright_text": "",
+            }
+        return {
+            "enabled": True,
+            "product_name": raw["product_name"],
+            "login_subtitle": raw["login_subtitle"],
+            "icon_url": raw["icon_url"],
+            "hide_login_sso": raw["hide_login_sso"],
+            "hide_version_link": raw["hide_version_link"],
+            "contact_markdown": raw["contact_markdown"],
+            "copyright_text": raw["copyright_text"],
+        }
+
+    @classmethod
+    async def update_settings(
+        cls,
+        *,
+        enabled: bool,
+        product_name: str,
+        login_subtitle: str,
+        icon_url: str,
+        hide_login_sso: bool,
+        hide_version_link: bool,
+        contact_markdown: str,
+        copyright_text: str,
+        changed_by: str = "system",
+    ) -> None:
+        await ConfigService.set_config(
+            cls.CONFIG_ENABLED,
+            "true" if enabled else "false",
+            description="是否启用品牌个性化",
+            category="branding",
+            changed_by=changed_by,
+        )
+        await ConfigService.set_config(
+            cls.CONFIG_PRODUCT_NAME,
+            (product_name or DEFAULT_PRODUCT_NAME).strip(),
+            description="产品名称（浏览器标题、侧栏、登录页）",
+            category="branding",
+            changed_by=changed_by,
+        )
+        await ConfigService.set_config(
+            cls.CONFIG_LOGIN_SUBTITLE,
+            (login_subtitle or DEFAULT_LOGIN_SUBTITLE).strip(),
+            description="登录页副标题",
+            category="branding",
+            changed_by=changed_by,
+        )
+        await ConfigService.set_config(
+            cls.CONFIG_ICON_URL,
+            (icon_url or DEFAULT_ICON_URL).strip(),
+            description="Logo / Favicon 地址",
+            category="branding",
+            changed_by=changed_by,
+        )
+        await ConfigService.set_config(
+            cls.CONFIG_HIDE_LOGIN_SSO,
+            "true" if hide_login_sso else "false",
+            description="登录页隐藏 SSO 登录",
+            category="branding",
+            changed_by=changed_by,
+        )
+        await ConfigService.set_config(
+            cls.CONFIG_HIDE_VERSION_LINK,
+            "true" if hide_version_link else "false",
+            description="侧栏版本号取消 GitHub 外链",
+            category="branding",
+            changed_by=changed_by,
+        )
+        await ConfigService.set_config(
+            cls.CONFIG_CONTACT_MARKDOWN,
+            contact_markdown or "",
+            description="联系信息 Markdown（个人中心 → 关于）",
+            category="branding",
+            changed_by=changed_by,
+        )
+        await ConfigService.set_config(
+            cls.CONFIG_COPYRIGHT_TEXT,
+            copyright_text or "",
+            description="登录页底部版权文案",
+            category="branding",
+            changed_by=changed_by,
+        )

--- a/app/services/config_service.py
+++ b/app/services/config_service.py
@@ -182,6 +182,8 @@ class ConfigService:
         
         for key, data in configs.items():
             cat = data['category']
+            if cat == 'branding':
+                continue
             if cat not in grouped:
                 grouped[cat] = []
             

--- a/app/services/data_adapter/factory.py
+++ b/app/services/data_adapter/factory.py
@@ -2,6 +2,7 @@ from .base import DataSourceAdapter
 from .clickhouse import ClickHouseAdapter
 from .mysql import MySQLAdapter
 from .oracle import OracleAdapter
+from .sqlserver import SQLServerAdapter, normalize_sqlserver_type
 import logging
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,8 @@ async def get_adapter(data_source_name: str) -> DataSourceAdapter:
         return MySQLAdapter(db_config.id)
     elif db_type_lower == "oracle":
         return OracleAdapter(db_config.id)
+    elif normalize_sqlserver_type(db_config.db_type):
+        return SQLServerAdapter(db_config.id)
     else:
         logger.error(f"[Adapter Factory] 不支持的数据库类型: {db_config.db_type}")
         raise NotImplementedError(f"适配器暂未实现对 '{db_config.db_type}' 类型的支持。")

--- a/app/services/data_adapter/sqlserver.py
+++ b/app/services/data_adapter/sqlserver.py
@@ -1,0 +1,202 @@
+import logging
+import os
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+from jinja2 import BaseLoader, Environment, Undefined
+
+from .base import DataSourceAdapter, SQLSafetyError, standardize_items
+from .models import LogicalQuery, ResultSet
+
+logger = logging.getLogger(__name__)
+
+
+class SqlLabUndefined(Undefined):
+    def __str__(self):
+        return "NULL"
+
+    def __html__(self):
+        return "NULL"
+
+    def __iter__(self):
+        return iter([])
+
+    def __bool__(self):
+        return False
+
+
+SQL_LAB_ENV = Environment(loader=BaseLoader(), undefined=SqlLabUndefined)
+
+
+def build_sqlserver_odbc_dsn(config: Dict[str, Any]) -> str:
+    """构建 SQL Server ODBC 连接串（供连接池与导入服务共用）。"""
+    driver = os.environ.get("MSSQL_ODBC_DRIVER", "ODBC Driver 18 for SQL Server")
+    port = int(config.get("port", 1433))
+    server = f"{config.get('host')},{port}"
+    database = config.get("database") or config.get("database_name") or ""
+    user = config.get("user") or config.get("db_user") or ""
+    password = config.get("password") or ""
+    return (
+        f"DRIVER={{{driver}}};"
+        f"SERVER={server};"
+        f"DATABASE={database};"
+        f"UID={user};"
+        f"PWD={password};"
+        f"TrustServerCertificate=yes;"
+    )
+
+
+def normalize_sqlserver_type(db_type: str) -> bool:
+    return db_type.strip().lower() in ("sqlserver", "mssql", "tsql")
+
+
+class SQLServerAdapter(DataSourceAdapter):
+    """SQL Server 数据库适配器：封装基于 aioodbc 连接池的物理查询、结构探测和安全限制"""
+
+    def __init__(self, source_id: int):
+        self.source_id = source_id
+
+    async def execute(self, query: LogicalQuery) -> ResultSet:
+        raise NotImplementedError("本地适配器在智能体平台中仅供执行只读物理 SQL，暂不支持逻辑查询 execute 方法。")
+
+    async def execute_summary(self, query: LogicalQuery, agg_fields: List[str] = None) -> Dict[str, Any]:
+        raise NotImplementedError("本地适配器在智能体平台中仅供执行只读物理 SQL，暂不支持逻辑查询 execute_summary 方法。")
+
+    async def get_tables(self) -> List[Dict[str, str]]:
+        """获取当前库下的所有表和视图名称"""
+        from app.services.pool_manager import DataSourcePoolManager
+
+        pool = await DataSourcePoolManager.get_pool(self.source_id)
+        sql = """
+            SELECT TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_TYPE IN ('BASE TABLE', 'VIEW')
+              AND TABLE_CATALOG = DB_NAME()
+            ORDER BY TABLE_NAME
+        """
+
+        async with pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(sql)
+                rows = await cursor.fetchall()
+
+        return [
+            {"name": row[0], "type": "VIEW" if row[1] == "VIEW" else "TABLE"}
+            for row in rows
+        ]
+
+    async def get_columns(
+        self,
+        table_name: Optional[str] = None,
+        custom_sql: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, str]]:
+        """获取表或自定义查询 SQL 的字段列定义"""
+        from app.services.pool_manager import DataSourcePoolManager
+
+        pool = await DataSourcePoolManager.get_pool(self.source_id)
+
+        if custom_sql:
+            raw_sql = custom_sql.strip().rstrip(";")
+            try:
+                sql = SQL_LAB_ENV.from_string(raw_sql).render(**(params or {}))
+            except Exception as e:
+                logger.warning(f"Jinja2 模板渲染异常，回退使用原始 SQL: {e}")
+                sql = raw_sql
+            final_sql = f"SELECT TOP 0 * FROM ({sql}) AS t"
+        elif table_name:
+            final_sql = f"SELECT TOP 0 * FROM [{table_name}]"
+        else:
+            return []
+
+        async with pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                try:
+                    await cursor.execute(final_sql)
+                    columns = [desc[0] for desc in cursor.description]
+                except Exception as e:
+                    logger.error(f"SQL Server 获取字段信息失败: {e}. SQL: {final_sql}")
+                    raise ValueError(f"不合法的 SQL 语句或数据表: {e}")
+
+        return [{"name": col, "type": "String", "comment": ""} for col in columns]
+
+    async def execute_sql(self, sql: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """执行物理只读 SQL 并返回统一的结果格式。"""
+        from app.services.pool_manager import DataSourcePoolManager
+
+        if params is not None and not params:
+            params = None
+
+        pool = await DataSourcePoolManager.get_pool(self.source_id)
+
+        async with pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(sql, params or ())
+                rows = await cursor.fetchall()
+
+                columns = []
+                if cursor.description:
+                    for desc in cursor.description:
+                        columns.append({"name": desc[0], "type": str(desc[1])})
+
+                items = [list(row) for row in rows]
+                return {"columns": columns, "items": standardize_items(items)}
+
+    async def preview(self, sql: str, limit: int = 100, params: Dict[str, Any] = None) -> Dict[str, Any]:
+        """供数据源管理或 SQL Lab 调试的 Preview 接口，强制最大行数和只读拦截"""
+        params = params or {}
+        limit = min(max(int(limit or 100), 1), 1000)
+
+        try:
+            self._validate_sql_safety(sql)
+        except SQLSafetyError as e:
+            raise ValueError(str(e))
+
+        rendered_sql = sql
+        if "{{" in sql or "{%" in sql:
+            try:
+                rendered_sql = SQL_LAB_ENV.from_string(sql).render(**params)
+                self._validate_sql_safety(rendered_sql)
+            except SQLSafetyError as e:
+                raise ValueError(str(e))
+            except Exception as e:
+                raise ValueError(f"Jinja2 模板渲染失败: {str(e)}")
+
+        clean_sql = rendered_sql.strip().rstrip(";")
+        top_match = re.search(r"\bTOP\s+(\d+)", clean_sql, re.IGNORECASE)
+        if top_match:
+            limit_val = int(top_match.group(1))
+            final_sql = (
+                clean_sql[: top_match.start(1)] + str(min(limit_val, limit)) + clean_sql[top_match.end(1) :]
+            )
+        else:
+            final_sql = re.sub(r"(?is)^\s*select\s+", f"SELECT TOP {limit} ", clean_sql, count=1)
+
+        start_time = time.perf_counter()
+
+        from app.services.pool_manager import DataSourcePoolManager
+
+        pool = await DataSourcePoolManager.get_pool(self.source_id)
+
+        async with pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                logger.info(f"[SQL Server Executor] 执行预览 SQL: {final_sql}")
+                await cursor.execute(final_sql)
+                rows = await cursor.fetchall()
+
+                columns = []
+                if cursor.description:
+                    for desc in cursor.description:
+                        columns.append({"name": desc[0], "type": str(desc[1])})
+
+                items = [list(row) for row in rows]
+
+        execution_time = (time.perf_counter() - start_time) * 1000
+
+        return {
+            "columns": columns,
+            "rows": standardize_items(items),
+            "execution_time_ms": execution_time,
+            "scanned_rows": 0,
+        }

--- a/app/services/dataset_navigation_service.py
+++ b/app/services/dataset_navigation_service.py
@@ -20,12 +20,11 @@ from app.services.ai.runtime.agentscope.stream_reconcile import finalize_visible
 
 logger = logging.getLogger(__name__)
 
-_NAV_CACHE_TTL_SECONDS = 604800  # 7 days
-_NAV_PROMPT_VERSION = "v5"
-_NAV_CACHE_GEN_KEY = "agent:dataset_navigation:cache_generation"
+_NAV_CACHE_TTL_SECONDS = 90 * 24 * 60 * 60  # 90 days
 _CLICK_STATS_TTL_SECONDS = 90 * 24 * 60 * 60
 _RECENT_REFRESH_QUESTIONS_TTL_SECONDS = 5 * 60
 _RECENT_REFRESH_QUESTIONS_LIMIT = 80
+_LEGACY_NAV_CACHE_GEN_KEY = "agent:dataset_navigation:cache_generation"
 
 
 def _user_cache_key(*, user_id: Optional[int], is_admin: bool) -> str:
@@ -95,26 +94,75 @@ class DatasetNavigationService:
         return await AgentConfigProvider.get_dataset_menu(user_id=user_id, is_admin=is_admin, force_refresh=force_refresh)
 
     @staticmethod
-    async def _get_navigation_cache_generation() -> str:
+    def _navigation_cache_key(user_key: str) -> str:
+        return f"agent:dataset_navigation:{user_key}"
+
+    @staticmethod
+    def _click_rank_key(user_key: str) -> str:
+        return f"agent:dataset_navigation_click_rank:{user_key}"
+
+    @staticmethod
+    def _click_meta_key(user_key: str) -> str:
+        return f"agent:dataset_navigation_click_meta:{user_key}"
+
+    @staticmethod
+    def _recent_refresh_questions_key(
+        *,
+        user_key: str,
+        purpose: str,
+        group_identity: str,
+    ) -> str:
+        clean_purpose = re.sub(r"[^0-9A-Za-z_-]+", "_", str(purpose or "questions").strip()) or "questions"
+        group_hash = _question_hash(group_identity or "unknown")
+        return f"agent:dataset_navigation_recent_questions:{user_key}:{clean_purpose}:{group_hash}"
+
+    @staticmethod
+    async def invalidate_navigation_cache_for_user(
+        *,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> None:
+        """权限或目录变更后，清理指定用户的数据门户 Redis 缓存。"""
+        user_key = _user_cache_key(user_id=user_id, is_admin=is_admin)
         try:
-            redis = await get_redis()
-            if redis:
-                cached = await redis.get(_NAV_CACHE_GEN_KEY)
-                if cached is not None:
-                    return str(cached)
+            redis_client = await get_redis()
+            if not redis_client:
+                return
+            await redis_client.delete(
+                DatasetNavigationService._navigation_cache_key(user_key),
+                DatasetNavigationService._click_rank_key(user_key),
+                DatasetNavigationService._click_meta_key(user_key),
+            )
+            pattern = f"agent:dataset_navigation_recent_questions:{user_key}:*"
+            async for key in redis_client.scan_iter(match=pattern, count=200):
+                await redis_client.delete(key)
         except Exception as e:
-            logger.warning("Dataset navigation cache generation read failed: %s", e)
-        return "0"
+            logger.warning("Dataset navigation cache invalidate failed for %s: %s", user_key, e)
+
+    @staticmethod
+    async def invalidate_all_navigation_caches() -> None:
+        """元数据变更后清理全部用户的数据门户 Redis 缓存（含历史 menu_hash 旧 Key）。"""
+        patterns = (
+            "agent:dataset_navigation:*",
+            "agent:dataset_navigation_click_rank:*",
+            "agent:dataset_navigation_click_meta:*",
+            "agent:dataset_navigation_recent_questions:*",
+        )
+        try:
+            redis_client = await get_redis()
+            if not redis_client:
+                return
+            for pattern in patterns:
+                async for key in redis_client.scan_iter(match=pattern, count=200):
+                    await redis_client.delete(key)
+            await redis_client.delete(_LEGACY_NAV_CACHE_GEN_KEY)
+        except Exception as e:
+            logger.warning("Dataset navigation global cache invalidate failed: %s", e)
 
     @staticmethod
     async def bump_navigation_cache_generation() -> None:
-        """元数据变更后递增，使门户 Markdown 缓存失效。"""
-        try:
-            redis = await get_redis()
-            if redis:
-                await redis.incr(_NAV_CACHE_GEN_KEY)
-        except Exception as e:
-            logger.warning("Dataset navigation cache generation bump failed: %s", e)
+        """兼容旧调用：改为直接删除门户相关 Redis 缓存。"""
+        await DatasetNavigationService.invalidate_all_navigation_caches()
 
     @staticmethod
     async def _load_cached_navigation(cache_key: str) -> Optional[str]:
@@ -173,27 +221,6 @@ class DatasetNavigationService:
             return fallback_md, err[:240]
 
     @staticmethod
-    def _click_rank_key(*, user_key: str, dataset_menu_hash: str) -> str:
-        return f"agent:dataset_navigation_click_rank:{user_key}:{dataset_menu_hash}"
-
-    @staticmethod
-    def _click_meta_key(*, user_key: str, dataset_menu_hash: str) -> str:
-        return f"agent:dataset_navigation_click_meta:{user_key}:{dataset_menu_hash}"
-
-    @staticmethod
-    def _recent_refresh_questions_key(
-        *,
-        user_key: str,
-        dataset_menu_hash: str,
-        purpose: str,
-        group_identity: str,
-    ) -> str:
-        clean_hash = str(dataset_menu_hash or "").strip() or "unknown"
-        clean_purpose = re.sub(r"[^0-9A-Za-z_-]+", "_", str(purpose or "questions").strip()) or "questions"
-        group_hash = _question_hash(group_identity or "unknown")
-        return f"agent:dataset_navigation_recent_questions:{user_key}:{clean_hash}:{clean_purpose}:{group_hash}"
-
-    @staticmethod
     def _extract_question_queries(questions: Optional[list[Any]]) -> list[str]:
         extracted: list[str] = []
         for item in questions or []:
@@ -209,19 +236,15 @@ class DatasetNavigationService:
     async def _load_recent_refresh_questions(
         *,
         user_key: str,
-        dataset_menu_hash: str,
         purpose: str,
         group_identity: str,
     ) -> list[str]:
-        if not dataset_menu_hash:
-            return []
         try:
             redis = await get_redis()
             if not redis:
                 return []
             key = DatasetNavigationService._recent_refresh_questions_key(
                 user_key=user_key,
-                dataset_menu_hash=dataset_menu_hash,
                 purpose=purpose,
                 group_identity=group_identity,
             )
@@ -241,13 +264,12 @@ class DatasetNavigationService:
     async def _remember_recent_refresh_questions(
         *,
         user_key: str,
-        dataset_menu_hash: str,
         purpose: str,
         group_identity: str,
         questions: list[dict[str, Any]],
     ) -> None:
         new_queries = DatasetNavigationService._extract_question_queries(questions)
-        if not dataset_menu_hash or not new_queries:
+        if not new_queries:
             return
         try:
             redis = await get_redis()
@@ -255,7 +277,6 @@ class DatasetNavigationService:
                 return
             key = DatasetNavigationService._recent_refresh_questions_key(
                 user_key=user_key,
-                dataset_menu_hash=dataset_menu_hash,
                 purpose=purpose,
                 group_identity=group_identity,
             )
@@ -331,20 +352,13 @@ class DatasetNavigationService:
     async def _load_question_click_stats(
         *,
         user_key: str,
-        dataset_menu_hash: str,
     ) -> Dict[str, Dict[str, Any]]:
         try:
             redis = await get_redis()
             if not redis:
                 return {}
-            rank_key = DatasetNavigationService._click_rank_key(
-                user_key=user_key,
-                dataset_menu_hash=dataset_menu_hash,
-            )
-            meta_key = DatasetNavigationService._click_meta_key(
-                user_key=user_key,
-                dataset_menu_hash=dataset_menu_hash,
-            )
+            rank_key = DatasetNavigationService._click_rank_key(user_key)
+            meta_key = DatasetNavigationService._click_meta_key(user_key)
             ranked = await redis.zrevrange(rank_key, 0, -1, withscores=True)
             raw_meta = await redis.hgetall(meta_key)
             meta_map: Dict[str, Any] = {}
@@ -423,14 +437,14 @@ class DatasetNavigationService:
         *,
         user_id: Optional[int],
         is_admin: bool,
-        dataset_menu_hash: str,
         query: str,
         label: Optional[str] = None,
         group_id: Optional[str] = None,
+        dataset_menu_hash: Optional[str] = None,
     ) -> None:
-        clean_hash = str(dataset_menu_hash or "").strip()
+        del dataset_menu_hash
         clean_query = str(query or "").strip()
-        if not clean_hash or not clean_query:
+        if not clean_query:
             return
         try:
             redis = await get_redis()
@@ -438,14 +452,8 @@ class DatasetNavigationService:
                 return
             user_key = _user_cache_key(user_id=user_id, is_admin=is_admin)
             question_id = _question_hash(clean_query)
-            rank_key = DatasetNavigationService._click_rank_key(
-                user_key=user_key,
-                dataset_menu_hash=clean_hash,
-            )
-            meta_key = DatasetNavigationService._click_meta_key(
-                user_key=user_key,
-                dataset_menu_hash=clean_hash,
-            )
+            rank_key = DatasetNavigationService._click_rank_key(user_key)
+            meta_key = DatasetNavigationService._click_meta_key(user_key)
             now = datetime.now(timezone.utc).isoformat()
             metadata = {
                 "query": clean_query,
@@ -465,12 +473,12 @@ class DatasetNavigationService:
         *,
         user_id: Optional[int],
         is_admin: bool,
-        dataset_menu_hash: str,
         query: str,
+        dataset_menu_hash: Optional[str] = None,
     ) -> bool:
-        clean_hash = str(dataset_menu_hash or "").strip()
+        del dataset_menu_hash
         clean_query = str(query or "").strip()
-        if not clean_hash or not clean_query:
+        if not clean_query:
             return False
         try:
             redis = await get_redis()
@@ -478,14 +486,8 @@ class DatasetNavigationService:
                 return False
             user_key = _user_cache_key(user_id=user_id, is_admin=is_admin)
             question_id = _question_hash(clean_query)
-            rank_key = DatasetNavigationService._click_rank_key(
-                user_key=user_key,
-                dataset_menu_hash=clean_hash,
-            )
-            meta_key = DatasetNavigationService._click_meta_key(
-                user_key=user_key,
-                dataset_menu_hash=clean_hash,
-            )
+            rank_key = DatasetNavigationService._click_rank_key(user_key)
+            meta_key = DatasetNavigationService._click_meta_key(user_key)
             removed_rank = int(await redis.zrem(rank_key, question_id) or 0)
             removed_meta = int(await redis.hdel(meta_key, question_id) or 0)
             return removed_rank > 0 or removed_meta > 0
@@ -658,11 +660,8 @@ class DatasetNavigationService:
 
         menu_hash = hashlib.md5(dataset_menu.encode("utf-8")).hexdigest()[:12]
         user_key = _user_cache_key(user_id=user_id, is_admin=is_admin)
-        cache_gen = await DatasetNavigationService._get_navigation_cache_generation()
+        cache_key = DatasetNavigationService._navigation_cache_key(user_key)
         groups = DataQueryPrompts.build_dataset_navigation_groups(dataset_menu)
-        cache_key = (
-            f"agent:dataset_navigation:{user_key}:{menu_hash}:{_NAV_PROMPT_VERSION}:{cache_gen}"
-        )
         has_datasets = menu_has_authorized_datasets(dataset_menu)
 
         if not has_datasets:
@@ -700,7 +699,7 @@ class DatasetNavigationService:
             fallback_md = finalize_visible_reply(fallback_raw, collapse_duplicates=False)
             is_fallback = (markdown == fallback_md)
             
-            # 如果是异常兜底（有授权数据集但生成了兜底文本），只缓存 15 秒，避免长期卡在兜底状态；如果是正常情况则缓存 10 分钟
+            # 如果是异常兜底（有授权数据集但生成了兜底文本），只缓存 15 秒，避免长期卡在兜底状态；正常 LLM 结果缓存 90 天
             ttl = 15 if (is_fallback and has_datasets) else _NAV_CACHE_TTL_SECONDS
             await DatasetNavigationService._save_cached_navigation(cache_key, markdown, ttl=ttl)
 
@@ -751,7 +750,6 @@ class DatasetNavigationService:
         # 应用用户点击的偏好排序
         click_stats = await DatasetNavigationService._load_question_click_stats(
             user_key=user_key,
-            dataset_menu_hash=menu_hash,
         )
         groups = DatasetNavigationService._apply_question_click_stats(groups, click_stats)
 
@@ -792,7 +790,6 @@ class DatasetNavigationService:
         tables: list[str],
         user_id: Optional[int] = None,
         is_admin: bool = False,
-        dataset_menu_hash: str = "",
         group_id: str = "",
         exclude_questions: Optional[list[Any]] = None,
     ) -> list[dict[str, Any]]:
@@ -810,7 +807,6 @@ class DatasetNavigationService:
 
         recent_questions = await DatasetNavigationService._load_recent_refresh_questions(
             user_key=user_key,
-            dataset_menu_hash=dataset_menu_hash,
             purpose=purpose,
             group_identity=group_identity,
         )
@@ -858,7 +854,6 @@ class DatasetNavigationService:
             ]
         await DatasetNavigationService._remember_recent_refresh_questions(
             user_key=user_key,
-            dataset_menu_hash=dataset_menu_hash,
             purpose=purpose,
             group_identity=group_identity,
             questions=questions,
@@ -873,7 +868,6 @@ class DatasetNavigationService:
         tables: list[str],
         user_id: Optional[int] = None,
         is_admin: bool = False,
-        dataset_menu_hash: str = "",
         group_id: str = "",
         exclude_questions: Optional[list[Any]] = None,
     ) -> list[dict[str, Any]]:
@@ -890,7 +884,6 @@ class DatasetNavigationService:
             return []
         recent_questions = await DatasetNavigationService._load_recent_refresh_questions(
             user_key=user_key,
-            dataset_menu_hash=dataset_menu_hash,
             purpose=purpose,
             group_identity=group_identity,
         )
@@ -937,7 +930,6 @@ class DatasetNavigationService:
             ]
         await DatasetNavigationService._remember_recent_refresh_questions(
             user_key=user_key,
-            dataset_menu_hash=dataset_menu_hash,
             purpose=purpose,
             group_identity=group_identity,
             questions=questions,

--- a/app/services/db_import_service.py
+++ b/app/services/db_import_service.py
@@ -326,3 +326,145 @@ class DBImportService:
         except Exception as e:
             logger.error(f"Failed to get Oracle DDL: {e}")
             raise Exception(f"获取 Oracle DDL 失败: {str(e)}")
+
+    @staticmethod
+    def _sqlserver_type_aliases() -> tuple:
+        return ("sqlserver", "mssql", "tsql")
+
+    @staticmethod
+    async def test_sqlserver_connection(config: Dict[str, Any]) -> bool:
+        """测试 SQL Server 连接"""
+        try:
+            import aioodbc
+            from app.services.data_adapter.sqlserver import build_sqlserver_odbc_dsn
+
+            dsn = build_sqlserver_odbc_dsn(config)
+            conn = await aioodbc.connect(dsn=dsn, timeout=10)
+            try:
+                async with conn.cursor() as cur:
+                    await cur.execute("SELECT 1")
+                    await cur.fetchone()
+            finally:
+                await conn.close()
+            return True
+        except Exception as e:
+            logger.error(f"SQL Server connection test failed: {e}")
+            raise Exception(f"SQL Server 连接失败: {str(e)}")
+
+    @staticmethod
+    async def get_sqlserver_tables(config: Dict[str, Any]) -> List[Dict[str, str]]:
+        """获取 SQL Server 表列表及其备注 (包含视图类型)"""
+        try:
+            import aioodbc
+            from app.services.data_adapter.sqlserver import build_sqlserver_odbc_dsn
+
+            dsn = build_sqlserver_odbc_dsn(config)
+            conn = await aioodbc.connect(dsn=dsn, timeout=10)
+            try:
+                query = """
+                    SELECT
+                        t.TABLE_NAME,
+                        ISNULL(CAST(ep.value AS NVARCHAR(MAX)), '') AS TABLE_COMMENT,
+                        CASE WHEN t.TABLE_TYPE = 'VIEW' THEN 'view' ELSE 'table' END AS obj_type
+                    FROM INFORMATION_SCHEMA.TABLES t
+                    LEFT JOIN sys.tables st ON st.name = t.TABLE_NAME
+                    LEFT JOIN sys.extended_properties ep
+                        ON ep.major_id = st.object_id AND ep.minor_id = 0 AND ep.name = 'MS_Description'
+                    WHERE t.TABLE_TYPE IN ('BASE TABLE', 'VIEW')
+                      AND t.TABLE_CATALOG = DB_NAME()
+                    ORDER BY t.TABLE_NAME
+                """
+                async with conn.cursor() as cur:
+                    await cur.execute(query)
+                    res = await cur.fetchall()
+                    return [
+                        {"name": row[0], "comment": row[1] or "", "type": row[2]}
+                        for row in res
+                    ]
+            finally:
+                await conn.close()
+        except Exception as e:
+            logger.error(f"Failed to get SQL Server tables: {e}")
+            raise Exception(f"获取 SQL Server 表列表失败: {str(e)}")
+
+    @staticmethod
+    def _format_sqlserver_column_type(row: tuple) -> str:
+        data_type, char_len, num_precision, num_scale = row[1], row[2], row[3], row[4]
+        data_type = (data_type or "").lower()
+        if data_type in ("varchar", "nvarchar", "char", "nchar") and char_len:
+            if int(char_len) == -1:
+                return f"{data_type}(max)"
+            return f"{data_type}({int(char_len)})"
+        if data_type in ("decimal", "numeric") and num_precision is not None:
+            scale = int(num_scale or 0)
+            return f"{data_type}({int(num_precision)},{scale})"
+        return data_type
+
+    @staticmethod
+    async def get_sqlserver_ddl(config: Dict[str, Any], table_names: List[str]) -> str:
+        """获取 SQL Server DDL (支持 TABLE 和 VIEW)"""
+        try:
+            import aioodbc
+            from app.services.data_adapter.sqlserver import build_sqlserver_odbc_dsn
+
+            dsn = build_sqlserver_odbc_dsn(config)
+            conn = await aioodbc.connect(dsn=dsn, timeout=10)
+            ddls: List[str] = []
+            try:
+                async with conn.cursor() as cur:
+                    for table in table_names:
+                        await cur.execute(
+                            """
+                            SELECT TABLE_TYPE
+                            FROM INFORMATION_SCHEMA.TABLES
+                            WHERE TABLE_NAME = ? AND TABLE_CATALOG = DB_NAME()
+                            """,
+                            (table,),
+                        )
+                        type_row = await cur.fetchone()
+                        if not type_row:
+                            continue
+
+                        if type_row[0] == "VIEW":
+                            await cur.execute(
+                                """
+                                SELECT m.definition
+                                FROM sys.sql_modules m
+                                INNER JOIN sys.objects o ON m.object_id = o.object_id
+                                WHERE o.name = ? AND o.type = 'V'
+                                """,
+                                (table,),
+                            )
+                            view_row = await cur.fetchone()
+                            if view_row and view_row[0]:
+                                ddls.append(str(view_row[0]).strip())
+                            continue
+
+                        await cur.execute(
+                            """
+                            SELECT
+                                COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH,
+                                NUMERIC_PRECISION, NUMERIC_SCALE, IS_NULLABLE, COLUMN_DEFAULT
+                            FROM INFORMATION_SCHEMA.COLUMNS
+                            WHERE TABLE_NAME = ? AND TABLE_CATALOG = DB_NAME()
+                            ORDER BY ORDINAL_POSITION
+                            """,
+                            (table,),
+                        )
+                        columns = await cur.fetchall()
+                        if not columns:
+                            continue
+
+                        col_defs = []
+                        for col in columns:
+                            col_type = DBImportService._format_sqlserver_column_type(col)
+                            nullable = "" if col[5] == "NO" else " NULL"
+                            default = f" DEFAULT {col[6]}" if col[6] else ""
+                            col_defs.append(f"    [{col[0]}] {col_type}{nullable}{default}")
+                        ddls.append(f"CREATE TABLE [{table}] (\n" + ",\n".join(col_defs) + "\n);")
+            finally:
+                await conn.close()
+            return "\n\n".join(ddls)
+        except Exception as e:
+            logger.error(f"Failed to get SQL Server DDL: {e}")
+            raise Exception(f"获取 SQL Server DDL 失败: {str(e)}")

--- a/app/services/pool_manager.py
+++ b/app/services/pool_manager.py
@@ -131,6 +131,8 @@ class DataSourcePoolManager:
                 pool = await cls._create_mysql_pool(db_config)
             elif db_type == "oracle":
                 pool = await cls._create_oracle_pool(db_config)
+            elif db_type in ("sqlserver", "mssql", "tsql"):
+                pool = await cls._create_sqlserver_pool(db_config)
             else:
                 raise NotImplementedError(f"不支持的连接池数据库类型: '{db_config.db_type}'")
 
@@ -167,6 +169,29 @@ class DataSourcePoolManager:
             minsize=1,
             maxsize=50,
             encoding_errors="replace"
+        )
+        return pool
+
+    @classmethod
+    async def _create_sqlserver_pool(cls, db_config: Any) -> Any:
+        """创建 SQL Server 连接池"""
+        import aioodbc
+        from app.services.data_adapter.sqlserver import build_sqlserver_odbc_dsn
+
+        dsn = build_sqlserver_odbc_dsn(
+            {
+                "host": db_config.host,
+                "port": db_config.port,
+                "database": db_config.database_name,
+                "user": db_config.db_user,
+                "password": db_config.password,
+            }
+        )
+        pool = await aioodbc.create_pool(
+            dsn=dsn,
+            minsize=1,
+            maxsize=50,
+            autocommit=True,
         )
         return pool
 

--- a/app/services/sql_query_execution_service.py
+++ b/app/services/sql_query_execution_service.py
@@ -59,6 +59,60 @@ def _append_trace(agent_context: Optional[AgentContext], trace_logs: Optional[Li
         trace_logs.append(message)
 
 
+def _mark_row_filter_notice(
+    permission_notice: Optional[Dict[str, Any]],
+    *,
+    dataset_name: Optional[str],
+    rule_count: int,
+    executed_sql: Optional[str] = None,
+) -> None:
+    if permission_notice is None:
+        return
+    payload: Dict[str, Any] = {
+        "row_filter_applied": True,
+        "dataset_name": dataset_name,
+        "rule_count": rule_count,
+        "message": "已按你的数据权限自动过滤结果",
+    }
+    rewritten_sql = str(executed_sql or "").strip()
+    if rewritten_sql:
+        payload["executed_sql"] = rewritten_sql
+    permission_notice.update(payload)
+
+
+def attach_permission_notice_to_payload(
+    payload: Dict[str, Any],
+    permission_notice: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    if permission_notice and permission_notice.get("row_filter_applied") is True:
+        payload["permission_notice"] = dict(permission_notice)
+    return payload
+
+
+def attach_permission_notice_to_json_result(
+    result_str: str,
+    permission_notice: Optional[Dict[str, Any]],
+) -> str:
+    if not permission_notice or permission_notice.get("row_filter_applied") is not True:
+        return result_str
+    raw = result_str.strip()
+    if not raw or raw.startswith("["):
+        return result_str
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return result_str
+    if isinstance(parsed, dict):
+        return json.dumps(
+            attach_permission_notice_to_payload(parsed, permission_notice),
+            ensure_ascii=False,
+        )
+    return json.dumps(
+        attach_permission_notice_to_payload({"rows": parsed}, permission_notice),
+        ensure_ascii=False,
+    )
+
+
 def _user_dims_for_rewrite(agent_context: Optional[AgentContext], user_dimensions: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     if agent_context is not None and agent_context.user_dimensions:
         return dict(agent_context.user_dimensions)
@@ -289,6 +343,7 @@ async def execute_sql_query_core(
     auth_check_only: bool = False,
     bypass_table_auth: bool = False,
     sql_query_binding: Any | None = None,
+    permission_notice: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     在给定 DB 会话下完成权限重写与执行；调用方负责会话生命周期。
@@ -302,6 +357,9 @@ async def execute_sql_query_core(
                  `auth_check_only=True` 且 `dry_run=False`）。
         sql_query_binding: 可选的 ChatBI 表/数据集/字段绑定；未传时尝试读取 ContextVar，
                  Agent 路径在 execute 前由 tool gate 注入。
+        permission_notice: 可选可变字典；当行级权限 SQL 重写实际生效时写入给 HTTP/前端使用的
+                 非敏感提示元信息；可含 `executed_sql` 供工具日志展示实际执行的 SQL，
+                 不包含具体过滤条件表达式。
     """
     from app.services.ai.chatbi_sql_query_binding import (
         build_data_perm_table_metadata,
@@ -451,8 +509,24 @@ async def execute_sql_query_core(
 
             if filters:
                 user_dims = _user_dims_for_rewrite(agent_context, user_dimensions)
-                sql = rewriter.rewrite(sql, filters, user_dims)
-                logger.info("[DataPerm] SQL Rewritten for user %s. Applied %s filters.", user_id_eff, len(filters))
+                original_sql = sql
+                rewrite_stats: Dict[str, int] = {}
+                sql = rewriter.rewrite(sql, filters, user_dims, rewrite_stats=rewrite_stats)
+                rewrite_applied = sql != original_sql
+                applied_rule_count = int(rewrite_stats.get("applied_rule_count") or 0)
+                logger.info(
+                    "[DataPerm] SQL Rewritten for user %s. Applied %s/%s filter conditions.",
+                    user_id_eff,
+                    applied_rule_count,
+                    len(filters),
+                )
+                if rewrite_applied:
+                    _mark_row_filter_notice(
+                        permission_notice,
+                        dataset_name=dataset_name,
+                        rule_count=applied_rule_count,
+                        executed_sql=sql,
+                    )
                 _append_trace(
                     agent_context,
                     trace_logs,

--- a/app/services/sql_query_execution_service.py
+++ b/app/services/sql_query_execution_service.py
@@ -126,6 +126,8 @@ def dialect_from_data_source(data_source: Optional[str]) -> str:
         dialect = "mysql"
     elif "oracle" in ds_lower:
         dialect = "oracle"
+    elif any(token in ds_lower for token in ("sqlserver", "mssql", "tsql")):
+        dialect = "sqlserver"
     return dialect
 
 

--- a/db-prod/V84-branding-config.sql
+++ b/db-prod/V84-branding-config.sql
@@ -1,0 +1,12 @@
+-- V84: 品牌个性化配置
+-- Date: 2026-07-01
+
+INSERT IGNORE INTO `system_configs` (`key`, `value`, `description`, `category`, `is_secret`) VALUES
+('branding.enabled', 'false', '是否启用品牌个性化', 'branding', 0),
+('branding.product_name', '云枢 · 智能体平台', '产品名称（浏览器标题、侧栏、登录页）', 'branding', 0),
+('branding.login_subtitle', 'Yunshu Intelligent Agent Platform', '登录页副标题', 'branding', 0),
+('branding.icon_url', '/favicon.png', 'Logo / Favicon 地址（相对或绝对 URL）', 'branding', 0),
+('branding.hide_login_sso', 'false', '登录页隐藏 SSO 登录', 'branding', 0),
+('branding.hide_version_link', 'false', '侧栏版本号取消 GitHub 外链', 'branding', 0),
+('branding.contact_markdown', '', '联系信息 Markdown（个人中心 → 关于）', 'branding', 0),
+('branding.copyright_text', '', '登录页底部版权文案（启用品牌个性化后展示）', 'branding', 0);

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
 import ToastContainer from './components/ToastContainer.vue'
+import { onMounted } from 'vue'
+import { loadBranding } from './composables/useBranding'
+
+onMounted(() => {
+  loadBranding()
+})
 </script>
 
 <template>

--- a/frontend/src/api/agent.ts
+++ b/frontend/src/api/agent.ts
@@ -58,6 +58,10 @@ export const agentApi = {
   
   // Update agent
   updateAgent: (id: string, data: Partial<AIAgent>) => axios.put<AIAgent>(`/api/portal/agents/${id}`, data),
+
+  // Batch reorder agents (sort_order)
+  reorderAgents: (items: { id: string; sort_order: number }[]) =>
+    axios.post<{ status: string }>('/api/portal/agents/reorder', { items }),
   
   // Delete agent
   deleteAgent: (id: string) => axios.delete<void>(`/api/portal/agents/${id}`),

--- a/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
+++ b/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
@@ -348,7 +348,7 @@
             <pre class="max-h-72 overflow-auto rounded-lg bg-gray-950 text-green-100 p-3 text-[11px] leading-relaxed whitespace-pre-wrap">{{ selectedSavedReportDetail.sql_template || selectedSavedReportDetail.sql_content }}</pre>
           </section>
           <div class="flex flex-wrap gap-2 pt-2">
-            <button type="button" class="px-3 py-2 rounded-lg text-xs font-bold bg-blue-600 text-white disabled:opacity-50" :disabled="isSavedReportActionDisabled(selectedSavedReportDetail)" @click="handleExecuteSavedReportClick(selectedSavedReportDetail)">运行</button>
+            <button type="button" class="px-3 py-2 rounded-lg text-xs font-bold bg-blue-600 text-white disabled:opacity-50" :title="getSavedReportButtonTitle(selectedSavedReportDetail)" :disabled="isSavedReportActionDisabled(selectedSavedReportDetail)" @click="handleExecuteSavedReportClick(selectedSavedReportDetail)">运行</button>
             <button v-if="selectedSavedReportDetail.is_owner" type="button" class="px-3 py-2 rounded-lg text-xs font-bold border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300" @click="handleEditReport(selectedSavedReportDetail)">编辑</button>
             <button v-if="selectedSavedReportDetail.is_owner" type="button" class="px-3 py-2 rounded-lg text-xs font-bold border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300" @click="openShareReportModal(selectedSavedReportDetail)">共享</button>
           </div>
@@ -1896,6 +1896,10 @@ const extractSavedReportActionErrorMessage = (error: any, fallback: string) => {
 };
 
 const handleCopyReport = async (report: any) => {
+  if (isSavedReportActionDisabled(report)) {
+    showToast(getSavedReportCopyTitle(report), "error");
+    return;
+  }
   try {
     await axios.post(`/api/portal/saved-reports/${report.id}/copy`);
     showToast("已复制为我的报表", "success");

--- a/frontend/src/components/metadata/DatabaseImportModal.vue
+++ b/frontend/src/components/metadata/DatabaseImportModal.vue
@@ -68,7 +68,8 @@ const fetchSavedConfigs = async () => {
 const dbTypes = [
   { id: 'mysql', name: 'MySQL', icon: '🐬', defaultPort: 3306, disabled: false },
   { id: 'clickhouse', name: 'ClickHouse', icon: '🧊', defaultPort: 9000, disabled: false },
-  { id: 'oracle', name: 'Oracle', icon: '🔴', defaultPort: 1521, disabled: false }
+  { id: 'oracle', name: 'Oracle', icon: '🔴', defaultPort: 1521, disabled: false },
+  { id: 'sqlserver', name: 'SQL Server', icon: '🟦', defaultPort: 1433, disabled: false },
 ]
 
 const dbTypeIcon = (type: string) => dbTypes.find((item) => item.id === type)?.icon || '🗄️'
@@ -222,6 +223,7 @@ const dbTypeColor = (type: string) => {
   if (type === 'mysql') return 'bg-blue-100 text-blue-700'
   if (type === 'clickhouse') return 'bg-cyan-100 text-cyan-700'
   if (type === 'oracle') return 'bg-red-100 text-red-700'
+  if (type === 'sqlserver' || type === 'mssql') return 'bg-indigo-100 text-indigo-700'
   return 'bg-gray-100 text-gray-600'
 }
 </script>

--- a/frontend/src/components/metadata/RowFilterOptionSelect.vue
+++ b/frontend/src/components/metadata/RowFilterOptionSelect.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+export type RowFilterSelectOption = {
+  value: string
+  label: string
+  remark?: string
+}
+
+const props = withDefaults(defineProps<{
+  modelValue: string
+  options: RowFilterSelectOption[]
+  placeholder?: string
+  disabled?: boolean
+  buttonClass?: string
+  menuClass?: string
+}>(), {
+  placeholder: '请选择...',
+  disabled: false,
+  buttonClass: 'border-gray-300 focus:ring-slate-500',
+  menuClass: 'hover:bg-slate-50',
+})
+
+const emit = defineEmits<{ 'update:modelValue': [string] }>()
+
+const open = ref(false)
+const rootRef = ref<HTMLElement | null>(null)
+
+const selectedOption = computed(
+  () => props.options.find((option) => option.value === props.modelValue) || null,
+)
+
+const toggle = () => {
+  if (props.disabled) return
+  open.value = !open.value
+}
+
+const selectOption = (value: string) => {
+  emit('update:modelValue', value)
+  open.value = false
+}
+
+const onClickOutside = (event: MouseEvent) => {
+  if (!rootRef.value?.contains(event.target as Node)) {
+    open.value = false
+  }
+}
+
+onMounted(() => document.addEventListener('click', onClickOutside))
+onBeforeUnmount(() => document.removeEventListener('click', onClickOutside))
+</script>
+
+<template>
+  <div ref="rootRef" class="relative w-40 min-w-[9rem]">
+    <button
+      type="button"
+      :disabled="disabled"
+      class="w-full h-[2.625rem] bg-white border rounded-lg px-2 text-left shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50 focus:ring-1 outline-none"
+      :class="buttonClass"
+      @click.stop="toggle"
+    >
+      <div class="flex items-center gap-1">
+        <div class="min-w-0 flex-1">
+          <template v-if="selectedOption">
+            <div class="truncate text-xs font-medium text-gray-800">{{ selectedOption.label }}</div>
+            <div
+              v-if="selectedOption.remark"
+              class="truncate text-[10px] leading-tight text-gray-400"
+            >
+              {{ selectedOption.remark }}
+            </div>
+          </template>
+          <div v-else class="truncate text-xs text-gray-400">{{ placeholder }}</div>
+        </div>
+        <svg
+          class="h-3.5 w-3.5 shrink-0 text-gray-400 transition-transform"
+          :class="{ 'rotate-180': open }"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </div>
+    </button>
+
+    <div
+      v-if="open"
+      class="absolute left-0 top-full z-[10000] mt-1 max-h-56 w-full min-w-[11rem] overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-xl custom-scrollbar"
+    >
+      <button
+        v-for="option in options"
+        :key="option.value"
+        type="button"
+        class="w-full px-2.5 py-1.5 text-left transition-colors"
+        :class="[
+          menuClass,
+          modelValue === option.value ? 'bg-blue-50 text-blue-700' : 'text-gray-800',
+        ]"
+        @click.stop="selectOption(option.value)"
+      >
+        <div class="truncate text-xs font-medium">{{ option.label }}</div>
+        <div v-if="option.remark" class="truncate text-[10px] leading-tight text-gray-400">
+          {{ option.remark }}
+        </div>
+      </button>
+      <div v-if="options.length === 0" class="px-2.5 py-2 text-[10px] text-gray-400">
+        暂无可选项
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/system/RedisKeyCleanupModal.vue
+++ b/frontend/src/components/system/RedisKeyCleanupModal.vue
@@ -1,0 +1,402 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import axios from '@/utils/axios'
+import Modal from '../Modal.vue'
+import {
+  groupRedisKeys,
+  getRedisKeyCategoryLabel,
+  type RedisKeyGroupMode,
+  type RedisKeyListItem,
+} from '../../utils/redisKeyGroups'
+
+const props = defineProps<{
+  show: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+  deleted: [payload: { deletedCount: number; message: string }]
+}>()
+
+const loading = ref(false)
+const deleting = ref(false)
+const keys = ref<RedisKeyListItem[]>([])
+const groupMode = ref<RedisKeyGroupMode>('redis_type')
+const searchKeyword = ref('')
+const selectedKeys = ref<Set<string>>(new Set())
+const expandedGroups = ref<Set<string>>(new Set())
+const loadError = ref('')
+const detailKey = ref<string | null>(null)
+const keyDetail = ref<{ name: string; type: string; ttl: number; value: any } | null>(null)
+const detailLoading = ref(false)
+
+const formatRedisValue = (value: any): string => {
+  if (value === null || value === undefined) return '(null)'
+  if (typeof value === 'string') {
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2)
+    } catch {
+      return value
+    }
+  }
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+const formatTtl = (ttl: number) => {
+  if (ttl === -1) return '永不过期'
+  if (ttl === -2) return '已过期'
+  return `${ttl} 秒`
+}
+
+const fetchKeyDetail = async (key: string) => {
+  if (detailKey.value === key && keyDetail.value) {
+    detailKey.value = null
+    keyDetail.value = null
+    return
+  }
+
+  detailKey.value = key
+  keyDetail.value = null
+  detailLoading.value = true
+  try {
+    const res = await axios.get('/api/portal/system/redis/key-detail', { params: { key } })
+    keyDetail.value = res.data
+  } catch (e: any) {
+    loadError.value = e.response?.data?.detail || e.message || '获取 Key 详情失败'
+    detailKey.value = null
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+const filteredKeys = computed(() => {
+  const keyword = searchKeyword.value.trim().toLowerCase()
+  if (!keyword) return keys.value
+  return keys.value.filter((item) => item.name.toLowerCase().includes(keyword))
+})
+
+const groupedKeys = computed(() => groupRedisKeys(filteredKeys.value, groupMode.value))
+
+const selectedCount = computed(() => selectedKeys.value.size)
+
+const isGroupFullySelected = (groupId: string) => {
+  const group = groupedKeys.value.find((item) => item.id === groupId)
+  if (!group || group.keys.length === 0) return false
+  return group.keys.every((item) => selectedKeys.value.has(item.name))
+}
+
+const isGroupPartiallySelected = (groupId: string) => {
+  const group = groupedKeys.value.find((item) => item.id === groupId)
+  if (!group || group.keys.length === 0) return false
+  const selectedInGroup = group.keys.filter((item) => selectedKeys.value.has(item.name)).length
+  return selectedInGroup > 0 && selectedInGroup < group.keys.length
+}
+
+const toggleGroup = (groupId: string, checked: boolean) => {
+  const group = groupedKeys.value.find((item) => item.id === groupId)
+  if (!group) return
+  const next = new Set(selectedKeys.value)
+  for (const item of group.keys) {
+    if (checked) next.add(item.name)
+    else next.delete(item.name)
+  }
+  selectedKeys.value = next
+}
+
+const toggleKey = (key: string, checked: boolean) => {
+  const next = new Set(selectedKeys.value)
+  if (checked) next.add(key)
+  else next.delete(key)
+  selectedKeys.value = next
+}
+
+const toggleExpanded = (groupId: string) => {
+  const next = new Set(expandedGroups.value)
+  if (next.has(groupId)) next.delete(groupId)
+  else next.add(groupId)
+  expandedGroups.value = next
+}
+
+const selectAllVisible = () => {
+  selectedKeys.value = new Set(filteredKeys.value.map((item) => item.name))
+}
+
+const clearSelection = () => {
+  selectedKeys.value = new Set()
+}
+
+const fetchKeys = async () => {
+  loading.value = true
+  loadError.value = ''
+  keys.value = []
+  selectedKeys.value = new Set()
+  expandedGroups.value = new Set()
+  detailKey.value = null
+  keyDetail.value = null
+  try {
+    const res = await axios.get('/api/portal/system/redis/keys-list', {
+      params: { pattern: '*' },
+    })
+    keys.value = res.data.keys || []
+    expandedGroups.value = new Set(groupRedisKeys(keys.value, groupMode.value).map((g) => g.id))
+  } catch (e: any) {
+    loadError.value = e.response?.data?.detail || e.message || '加载 Redis Keys 失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+const executeDelete = async () => {
+  if (selectedCount.value === 0) return
+  deleting.value = true
+  try {
+    const res = await axios.post('/api/portal/system/redis/delete-keys', {
+      keys: Array.from(selectedKeys.value),
+    })
+    emit('deleted', {
+      deletedCount: res.data.deleted_count ?? 0,
+      message: res.data.message || '删除完成',
+    })
+    emit('close')
+  } catch (e: any) {
+    loadError.value = e.response?.data?.detail || e.message || '删除失败'
+  } finally {
+    deleting.value = false
+  }
+}
+
+watch(
+  () => props.show,
+  (visible) => {
+    if (visible) {
+      searchKeyword.value = ''
+      groupMode.value = 'redis_type'
+      detailKey.value = null
+      keyDetail.value = null
+      fetchKeys()
+    }
+  },
+)
+
+watch(groupMode, () => {
+  expandedGroups.value = new Set(groupedKeys.value.map((g) => g.id))
+})
+</script>
+
+<template>
+  <Modal
+    :show="show"
+    title="选择性清理 Redis Keys"
+    size="max-w-4xl"
+    :z-index="80"
+    @close="emit('close')"
+  >
+    <div class="-m-6 flex flex-col max-h-[78vh]">
+      <div class="px-6 py-4 space-y-4 flex-1 min-h-0 flex flex-col">
+      <p class="text-sm text-gray-500">
+        按类型分组展示当前 Redis 库中的 Key，可勾选整组或单个 Key 进行清理。最多加载 5000 条。
+      </p>
+
+      <div class="flex flex-wrap items-center gap-3">
+        <div class="flex items-center bg-gray-100 p-1 rounded-lg border border-gray-200">
+          <button
+            type="button"
+            class="px-3 py-1.5 rounded-md text-xs font-semibold transition-all"
+            :class="groupMode === 'redis_type' ? 'bg-white shadow text-primary' : 'text-gray-500'"
+            @click="groupMode = 'redis_type'"
+          >
+            按 Redis 类型
+          </button>
+          <button
+            type="button"
+            class="px-3 py-1.5 rounded-md text-xs font-semibold transition-all"
+            :class="groupMode === 'business' ? 'bg-white shadow text-primary' : 'text-gray-500'"
+            @click="groupMode = 'business'"
+          >
+            按业务分类
+          </button>
+        </div>
+
+        <input
+          v-model="searchKeyword"
+          type="text"
+          placeholder="搜索 Key 名称..."
+          class="flex-1 min-w-[12rem] shadow-sm focus:ring-primary focus:border-primary block sm:text-sm border-gray-300 rounded-md bg-gray-50 p-2 border"
+        />
+
+        <button
+          type="button"
+          class="text-xs text-primary hover:underline"
+          @click="selectAllVisible"
+        >
+          全选当前
+        </button>
+        <button
+          type="button"
+          class="text-xs text-gray-500 hover:underline"
+          @click="clearSelection"
+        >
+          清空选择
+        </button>
+      </div>
+
+      <div
+        v-if="loadError"
+        class="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+      >
+        {{ loadError }}
+      </div>
+
+      <div class="flex-1 min-h-[20rem] overflow-y-auto border border-gray-200 rounded-lg custom-scrollbar">
+        <div v-if="loading" class="p-12 text-center text-gray-400">
+          <span class="inline-block animate-spin h-8 w-8 border-2 border-primary border-t-transparent rounded-full mb-3" />
+          <p class="text-sm">正在加载 Redis Keys...</p>
+        </div>
+
+        <div v-else-if="groupedKeys.length === 0" class="p-12 text-center text-gray-400 text-sm italic">
+          暂无匹配的 Key
+        </div>
+
+        <div v-else class="divide-y divide-gray-100">
+          <div v-for="group in groupedKeys" :key="group.id" class="bg-white">
+            <div class="flex items-center gap-3 px-4 py-3 bg-gray-50/80">
+              <input
+                type="checkbox"
+                class="rounded border-gray-300 text-primary focus:ring-primary"
+                :checked="isGroupFullySelected(group.id)"
+                :indeterminate="isGroupPartiallySelected(group.id)"
+                @change="toggleGroup(group.id, ($event.target as HTMLInputElement).checked)"
+              />
+              <button
+                type="button"
+                class="flex-1 min-w-0 text-left"
+                @click="toggleExpanded(group.id)"
+              >
+                <div class="flex items-center gap-2">
+                  <span class="text-sm font-bold text-gray-900">{{ group.label }}</span>
+                  <span class="text-[10px] px-2 py-0.5 rounded-full bg-gray-200 text-gray-600 font-bold">
+                    {{ group.keys.length }}
+                  </span>
+                </div>
+                <p class="text-[11px] text-gray-500 mt-0.5">{{ group.description }}</p>
+              </button>
+              <button
+                type="button"
+                class="text-gray-400 hover:text-gray-600"
+                @click="toggleExpanded(group.id)"
+              >
+                <svg
+                  class="w-4 h-4 transition-transform"
+                  :class="{ 'rotate-180': expandedGroups.has(group.id) }"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+            </div>
+
+            <div v-if="expandedGroups.has(group.id)" class="divide-y divide-gray-50">
+              <div
+                v-for="item in group.keys"
+                :key="item.name"
+              >
+                <div class="flex items-start gap-3 px-4 py-2.5 hover:bg-gray-50">
+                  <input
+                    type="checkbox"
+                    class="mt-0.5 rounded border-gray-300 text-primary focus:ring-primary"
+                    :checked="selectedKeys.has(item.name)"
+                    @change="toggleKey(item.name, ($event.target as HTMLInputElement).checked)"
+                  />
+                  <div class="min-w-0 flex-1">
+                    <div class="text-xs font-mono text-gray-800 break-all">{{ item.name }}</div>
+                    <div class="mt-1 flex items-center gap-2">
+                      <span
+                        class="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase border"
+                        :class="
+                          item.type === 'string' ? 'bg-green-50 text-green-700 border-green-100' :
+                          item.type === 'hash' ? 'bg-blue-50 text-blue-700 border-blue-100' :
+                          item.type === 'list' ? 'bg-yellow-50 text-yellow-700 border-yellow-100' :
+                          'bg-gray-50 text-gray-600 border-gray-100'
+                        "
+                      >
+                        {{ item.type }}
+                      </span>
+                      <span
+                        v-if="groupMode === 'redis_type'"
+                        class="text-[10px] text-gray-400"
+                      >
+                        {{ getRedisKeyCategoryLabel(item.name) }}
+                      </span>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    class="shrink-0 text-[11px] font-medium px-2 py-1 rounded-md border transition-colors"
+                    :class="detailKey === item.name
+                      ? 'text-primary border-primary/30 bg-primary/5'
+                      : 'text-gray-500 border-gray-200 hover:text-primary hover:border-primary/30 hover:bg-primary/5'"
+                    @click="fetchKeyDetail(item.name)"
+                  >
+                    {{ detailKey === item.name ? '收起' : '查看详情' }}
+                  </button>
+                </div>
+
+                <div
+                  v-if="detailKey === item.name"
+                  class="mx-4 mb-3 rounded-lg border border-gray-200 bg-gray-50 overflow-hidden"
+                >
+                  <div v-if="detailLoading" class="px-4 py-6 text-center text-gray-400 text-sm">
+                    <span class="inline-block animate-spin h-5 w-5 border-2 border-primary border-t-transparent rounded-full mb-2" />
+                    <p>正在加载 Key 内容...</p>
+                  </div>
+                  <div v-else-if="keyDetail" class="p-3 space-y-2">
+                    <div class="flex flex-wrap items-center gap-2 text-[10px]">
+                      <span class="px-1.5 py-0.5 rounded-full font-bold uppercase bg-indigo-50 text-indigo-700 border border-indigo-100">
+                        {{ keyDetail.type }}
+                      </span>
+                      <span class="font-mono text-gray-500">TTL: {{ formatTtl(keyDetail.ttl) }}</span>
+                    </div>
+                    <div class="max-h-48 overflow-y-auto bg-gray-950 rounded-lg p-3 font-mono text-[11px] text-green-400 custom-scrollbar border border-gray-900">
+                      <pre class="whitespace-pre-wrap break-all select-text">{{ formatRedisValue(keyDetail.value) }}</pre>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      </div>
+
+      <div class="px-6 py-4 border-t border-gray-100 bg-gray-50/50 flex items-center justify-between flex-shrink-0">
+        <span class="text-sm text-gray-500">
+          已选择 <strong class="text-gray-900">{{ selectedCount }}</strong> 个 Key
+        </span>
+        <div class="flex items-center gap-3">
+          <button
+            type="button"
+            class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+            :disabled="deleting"
+            @click="emit('close')"
+          >
+            取消
+          </button>
+          <button
+            type="button"
+            class="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50"
+            :disabled="deleting || selectedCount === 0"
+            @click="executeDelete"
+          >
+            {{ deleting ? '删除中...' : `删除所选 (${selectedCount})` }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Modal>
+</template>

--- a/frontend/src/composables/useBranding.ts
+++ b/frontend/src/composables/useBranding.ts
@@ -1,0 +1,60 @@
+import api from '@/utils/axios'
+import { ref } from 'vue'
+import {
+  DEFAULT_BRANDING,
+  DEFAULT_REPO_URL,
+  type PublicBranding,
+} from '@/constants/branding'
+
+const branding = ref<PublicBranding>({ ...DEFAULT_BRANDING })
+let loadPromise: Promise<PublicBranding> | null = null
+
+function applyFavicon(iconUrl: string) {
+  const href = iconUrl || DEFAULT_BRANDING.icon_url
+  let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]')
+  if (!link) {
+    link = document.createElement('link')
+    link.rel = 'icon'
+    document.head.appendChild(link)
+  }
+  link.href = href
+}
+
+export function applyDocumentTitle(pageTitle?: string) {
+  const name = branding.value.product_name || DEFAULT_BRANDING.product_name
+  document.title = pageTitle ? `${pageTitle} - ${name}` : name
+}
+
+export function resolveRepoUrl(): string {
+  if (branding.value.hide_version_link) return ''
+  return DEFAULT_REPO_URL
+}
+
+export async function loadBranding(force = false): Promise<PublicBranding> {
+  if (!force && loadPromise) return loadPromise
+
+  loadPromise = (async () => {
+    try {
+      const res = await api.get('/api/portal/auth/branding')
+      const data = res.data?.data ?? res.data
+      branding.value = { ...DEFAULT_BRANDING, ...data }
+    } catch {
+      branding.value = { ...DEFAULT_BRANDING }
+    }
+    applyFavicon(branding.value.icon_url)
+    applyDocumentTitle()
+    return branding.value
+  })()
+
+  return loadPromise
+}
+
+export function useBranding() {
+  return {
+    branding,
+    loadBranding,
+    applyDocumentTitle,
+    applyFavicon,
+    resolveRepoUrl,
+  }
+}

--- a/frontend/src/constants/branding.ts
+++ b/frontend/src/constants/branding.ts
@@ -1,0 +1,26 @@
+export const DEFAULT_PRODUCT_NAME = '云枢 · 智能体平台'
+export const DEFAULT_LOGIN_SUBTITLE = 'Yunshu Intelligent Agent Platform'
+export const DEFAULT_ICON_URL = '/favicon.png'
+export const DEFAULT_REPO_URL = 'https://github.com/RandyChen1985/yunshu-ai-agent-platform'
+
+export interface PublicBranding {
+  enabled: boolean
+  product_name: string
+  login_subtitle: string
+  icon_url: string
+  hide_login_sso: boolean
+  hide_version_link: boolean
+  contact_markdown: string
+  copyright_text: string
+}
+
+export const DEFAULT_BRANDING: PublicBranding = {
+  enabled: false,
+  product_name: DEFAULT_PRODUCT_NAME,
+  login_subtitle: DEFAULT_LOGIN_SUBTITLE,
+  icon_url: DEFAULT_ICON_URL,
+  hide_login_sso: false,
+  hide_version_link: false,
+  contact_markdown: '',
+  copyright_text: '',
+}

--- a/frontend/src/utils/redisKeyGroups.ts
+++ b/frontend/src/utils/redisKeyGroups.ts
@@ -1,0 +1,167 @@
+export type RedisKeyListItem = {
+  name: string
+  type: string
+}
+
+export type RedisKeyCategory = {
+  id: string
+  label: string
+  description: string
+  match: (key: string) => boolean
+}
+
+/** 业务前缀分类，用于 key 旁展示标签 */
+export const REDIS_KEY_CATEGORIES: RedisKeyCategory[] = [
+  {
+    id: 'conversation',
+    label: '对话',
+    description: '多轮对话上下文与查数结果',
+    match: (key) => key.startsWith('conversation:'),
+  },
+  {
+    id: 'auth',
+    label: '认证',
+    description: 'API Key 与登录态缓存',
+    match: (key) => key.startsWith('auth:'),
+  },
+  {
+    id: 'permissions',
+    label: '权限',
+    description: '用户权限集缓存',
+    match: (key) => key.startsWith('sys:auth:permissions:'),
+  },
+  {
+    id: 'sys_config',
+    label: '系统配置',
+    description: '系统参数缓存',
+    match: (key) => key.startsWith('sys_config:'),
+  },
+  {
+    id: 'dataset_menu',
+    label: '数据集菜单',
+    description: 'Agent 数据集 Schema 菜单',
+    match: (key) => key.startsWith('agent:dataset_menu'),
+  },
+  {
+    id: 'dataset_navigation',
+    label: '数据门户',
+    description: '数据门户导航与点击偏好',
+    match: (key) => key.startsWith('agent:dataset_navigation'),
+  },
+  {
+    id: 'memory',
+    label: '记忆',
+    description: '会话摘要、长期记忆与防抖状态',
+    match: (key) =>
+      key.startsWith('memory:') ||
+      key.startsWith('yunshu:agent:ltm:') ||
+      key.startsWith('memory_config:'),
+  },
+  {
+    id: 'vector',
+    label: '向量索引',
+    description: '元数据/案例/记忆向量文档',
+    match: (key) =>
+      key.startsWith('yunshu:idx:') ||
+      key.startsWith('idx:') ||
+      key.startsWith('metadata:dataset:') ||
+      key.startsWith('yunshu:example:'),
+  },
+  {
+    id: 'sql_cache',
+    label: 'SQL 缓存',
+    description: '查数结果临时缓存',
+    match: (key) => key.startsWith('sql_result:'),
+  },
+  {
+    id: 'session_lock',
+    label: '会话锁',
+    description: '并发会话与运行锁',
+    match: (key) =>
+      key.startsWith('yunshu:conv_run:') ||
+      key.startsWith('lock:') ||
+      key.includes(':session_lock:'),
+  },
+  {
+    id: 'portal_prefs',
+    label: '门户偏好',
+    description: '用户数据门户偏好设置',
+    match: (key) => key.startsWith('portal:prefs:'),
+  },
+  {
+    id: 'rate_limit',
+    label: '限流',
+    description: '接口限流计数',
+    match: (key) => key.startsWith('rate_limit:'),
+  },
+]
+
+export const REDIS_TYPE_LABELS: Record<string, string> = {
+  string: 'String',
+  hash: 'Hash',
+  list: 'List',
+  set: 'Set',
+  zset: 'Sorted Set',
+  stream: 'Stream',
+  none: 'Unknown',
+}
+
+export function getRedisKeyCategoryLabel(key: string): string {
+  const category = REDIS_KEY_CATEGORIES.find((item) => item.match(key))
+  return category?.label ?? '其他'
+}
+
+export type RedisKeyGroupMode = 'redis_type' | 'business'
+
+export type RedisKeyGroup = {
+  id: string
+  label: string
+  description: string
+  keys: RedisKeyListItem[]
+}
+
+export function groupRedisKeys(
+  keys: RedisKeyListItem[],
+  mode: RedisKeyGroupMode,
+): RedisKeyGroup[] {
+  const buckets = new Map<string, RedisKeyGroup>()
+
+  for (const item of keys) {
+    let groupId = 'other'
+    let label = '其他'
+    let description = '未匹配到已知业务前缀的键'
+
+    if (mode === 'redis_type') {
+      groupId = item.type || 'none'
+      label = REDIS_TYPE_LABELS[groupId] || groupId.toUpperCase()
+      description = `Redis 数据类型：${label}`
+    } else {
+      const category = REDIS_KEY_CATEGORIES.find((entry) => entry.match(item.name))
+      if (category) {
+        groupId = category.id
+        label = category.label
+        description = category.description
+      }
+    }
+
+    if (!buckets.has(groupId)) {
+      buckets.set(groupId, { id: groupId, label, description, keys: [] })
+    }
+    buckets.get(groupId)!.keys.push(item)
+  }
+
+  const groups = Array.from(buckets.values())
+  groups.sort((a, b) => {
+    if (mode === 'redis_type') {
+      const order = ['string', 'hash', 'list', 'set', 'zset', 'stream', 'none', 'other']
+      return order.indexOf(a.id) - order.indexOf(b.id)
+    }
+    return b.keys.length - a.keys.length || a.label.localeCompare(b.label, 'zh-CN')
+  })
+
+  for (const group of groups) {
+    group.keys.sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  return groups
+}

--- a/frontend/src/utils/redisKeyGroups.ts
+++ b/frontend/src/utils/redisKeyGroups.ts
@@ -45,7 +45,7 @@ export const REDIS_KEY_CATEGORIES: RedisKeyCategory[] = [
   {
     id: 'dataset_navigation',
     label: '数据门户',
-    description: '数据门户导航与点击偏好',
+    description: '数据门户导航 Markdown 缓存、点击统计与换一批去重（按 user_id 单 Key）',
     match: (key) => key.startsWith('agent:dataset_navigation'),
   },
   {

--- a/frontend/src/utils/toolLogDisplay.ts
+++ b/frontend/src/utils/toolLogDisplay.ts
@@ -62,6 +62,7 @@ export type ToolLogLike = {
   title?: string;
   details?: string;
   status?: string;
+  rowFilterApplied?: boolean;
 };
 
 export type MessageWithToolLogs = {
@@ -103,6 +104,19 @@ export function sqlToolLogResultHasDataRows(bodyPart: string): boolean {
 export function isExecuteSqlQueryLog(log: ToolLogLike): boolean {
   const label = `${log.name || ""} ${log.title || ""}`;
   return /execute_sql_query/i.test(label);
+}
+
+export function logHasRowFilterApplied(log: ToolLogLike): boolean {
+  if (log.rowFilterApplied) return true;
+  if (!isExecuteSqlQueryLog(log) || !log.details) return false;
+  const sections = splitSqlToolLogDetails(log.details);
+  if (!sections || sections.bodyKind !== "result") return false;
+  try {
+    const parsed = JSON.parse(sections.bodyPart) as { permission_notice?: { row_filter_applied?: boolean } };
+    return parsed.permission_notice?.row_filter_applied === true;
+  } catch {
+    return false;
+  }
 }
 
 function normalizeSavableSql(sqlPart: string): string {

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -45,6 +45,7 @@ import {
   resolveSavableSqlFromLog,
   canSaveGoldenReportFromMessage,
   resolveSavableSqlFromMessage,
+  logHasRowFilterApplied,
 } from "@/utils/toolLogDisplay";
 import {
   deriveSavedReportDescription,
@@ -1090,6 +1091,7 @@ const executeSavedReportWithOptions = async (reportArg?: SavedReportPayload | nu
       execResult = res.data.data;
       resultMarkdown = renderSavedReportDataToMarkdown(execResult);
       detailsText = `${report.sql_content}\n--- 结果 ---\n${typeof execResult === 'object' ? JSON.stringify(execResult, null, 2) : String(execResult)}`;
+      agentMsg.value.permissionNotice = execResult?.permission_notice;
     } else {
       resultMarkdown = "执行结果为空。";
       detailsText = `${report.sql_content}\n--- 结果 ---\n无`;
@@ -1202,6 +1204,7 @@ interface LogEntry {
   category?: 'router' | 'sql' | 'knowledge' | 'tool' | 'intent' | 'permission' | 'external' | 'model' | 'agent' | 'context' | 'default';
   model?: string;
   temperature?: number;
+  rowFilterApplied?: boolean;
 }
 
 interface SavedReportPayload {
@@ -1215,6 +1218,13 @@ interface SavedReportPayload {
   analysis_mode?: string;
   description?: string;
   tags?: string[];
+}
+
+interface PermissionNotice {
+  row_filter_applied?: boolean;
+  dataset_name?: string;
+  rule_count?: number;
+  message?: string;
 }
 
 // ... inside script ...
@@ -1298,6 +1308,7 @@ interface Message {
   pendingExternalExecution?: PendingExternalExecution;
   toolResultData?: Record<string, Array<{ block_id?: string; media_type?: string; data?: unknown; url?: string | null }>>;
   datasetNavigation?: DatasetNavigationPayload;
+  permissionNotice?: PermissionNotice;
   prompt_tokens?: number;
   completion_tokens?: number;
 }
@@ -2808,6 +2819,9 @@ const sendMessage = async () => {
               if (data.rag_retrieval) {
                 ragRetrievalMeta.value = data.rag_retrieval;
               }
+              if (data.permission_notice) {
+                agentMsg.value.permissionNotice = data.permission_notice;
+              }
             }
 
             // Handle Status
@@ -2895,6 +2909,7 @@ const addRealLog = (msg: Message, data: any) => {
     if (data.isDebug !== undefined) existingLog.isDebug = data.isDebug;
     if (data.isRouter !== undefined) existingLog.isRouter = data.isRouter;
     if (data.category !== undefined) existingLog.category = data.category as any;
+    if (data.row_filter_applied === true) existingLog.rowFilterApplied = true;
   } else {
     // Categorization Logic for new logs
     let inferredCategory = (data.category as any) || 'default';
@@ -2918,7 +2933,8 @@ const addRealLog = (msg: Message, data: any) => {
       isRouter: data.isRouter,
       category: inferredCategory,
       model: data.model,
-      temperature: data.temperature
+      temperature: data.temperature,
+      rowFilterApplied: data.row_filter_applied === true,
     };
     msg.logs.push(log);
   }
@@ -3042,6 +3058,7 @@ const applyPermissionStreamEvent = (msg: Message, data: any) => {
     if (data.agent_name) msg.agentName = data.agent_name;
     if (data.agent_display_name) msg.agentDisplayName = data.agent_display_name;
     if (data.rag_retrieval) ragRetrievalMeta.value = data.rag_retrieval;
+    if (data.permission_notice) msg.permissionNotice = data.permission_notice;
   } else if (data.type === "error") {
     if (msg.pendingPermission) msg.pendingPermission.status = "error";
     msg.isThinking = false;
@@ -3940,6 +3957,11 @@ onUnmounted(() => {
                                         }">
                                             <span>{{ log.title }}</span>
                                             <span
+                                              v-if="logHasRowFilterApplied(log)"
+                                              class="flex-shrink-0 text-[12px]"
+                                              title="已按行级数据权限改写 SQL"
+                                            >🔒</span>
+                                            <span
                                               v-if="log.status === 'success' && (log.category === 'sql' || (log.title && log.title.toLowerCase().includes('sql')))"
                                               class="text-emerald-500 font-bold ml-1 flex-shrink-0 select-none"
                                             >
@@ -4229,6 +4251,15 @@ onUnmounted(() => {
                     />
                   </svg>
                 </button>
+                <div
+                  v-if="msg.permissionNotice?.row_filter_applied"
+                  class="mb-2 inline-flex max-w-full items-start gap-1.5 rounded-lg border border-emerald-100 bg-emerald-50/70 px-2.5 py-1.5 text-[11px] font-medium leading-relaxed text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/30 dark:text-emerald-300"
+                >
+                  <svg class="mt-0.5 h-3.5 w-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                  </svg>
+                  <span>{{ msg.permissionNotice.message || '已按你的数据权限自动过滤结果' }}</span>
+                </div>
                 <MessageRenderer
                   v-if="!msg.datasetNavigation?.groups?.length"
                   :content="msg.content"

--- a/frontend/src/views/AgentManagement.vue
+++ b/frontend/src/views/AgentManagement.vue
@@ -210,6 +210,7 @@ const openSafetyModal = (type: 'input' | 'output') => {
 const searchKeyword = ref("");
 const statusFilter = ref<"all" | "enabled" | "disabled">("all"); // New
 const typeFilter = ref<"all" | "system" | "custom">("all"); // New
+const userInfo = ref<any>({});
 
 const filteredAgents = computed(() => {
   let result = [...agents.value];
@@ -254,7 +255,99 @@ const filteredAgents = computed(() => {
   });
 });
 
-const userInfo = ref<any>({});
+const hasActiveAgentFilters = computed(
+  () =>
+    !!searchKeyword.value ||
+    statusFilter.value !== "all" ||
+    typeFilter.value !== "all",
+);
+
+const canDragAgents = computed(
+  () => !hasActiveAgentFilters.value && userInfo.value?.role === "admin" && !loading.value,
+);
+
+const dragSourceId = ref<string | null>(null);
+const dragOverId = ref<string | null>(null);
+const savingAgentOrder = ref(false);
+
+const buildAgentSortUpdates = (orderedIds: string[]) =>
+  orderedIds.map((id, index) => ({
+    id,
+    sort_order: (orderedIds.length - index) * 10,
+  }));
+
+const applyAgentSortUpdates = (updates: { id: string; sort_order: number }[]) => {
+  const sortMap = new Map(updates.map((item) => [item.id, item.sort_order]));
+  agents.value = agents.value.map((agent) =>
+    sortMap.has(agent.id)
+      ? { ...agent, sort_order: sortMap.get(agent.id)! }
+      : agent,
+  );
+};
+
+const persistAgentOrder = async (updates: { id: string; sort_order: number }[]) => {
+  if (!updates.length) return;
+  savingAgentOrder.value = true;
+  const previous = agents.value.map((agent) => ({
+    id: agent.id,
+    sort_order: agent.sort_order ?? 0,
+  }));
+  applyAgentSortUpdates(updates);
+  try {
+    await agentApi.reorderAgents(updates);
+    showToast("排序已更新", "success");
+  } catch (error: any) {
+    applyAgentSortUpdates(previous);
+    showToast(error.response?.data?.detail || "更新排序失败", "error");
+  } finally {
+    savingAgentOrder.value = false;
+  }
+};
+
+const handleAgentDragStart = (event: DragEvent, agentId: string) => {
+  if (!canDragAgents.value) return;
+  dragSourceId.value = agentId;
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", agentId);
+  }
+};
+
+const handleAgentDragOver = (event: DragEvent, agentId: string) => {
+  if (!canDragAgents.value) return;
+  event.preventDefault();
+  if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+  if (agentId !== dragSourceId.value) dragOverId.value = agentId;
+};
+
+const handleAgentDragLeave = (event: DragEvent) => {
+  const related = event.relatedTarget as HTMLElement | null;
+  const row = event.currentTarget as HTMLElement;
+  if (!related || !row.contains(related)) dragOverId.value = null;
+};
+
+const handleAgentDrop = (event: DragEvent, targetId: string) => {
+  event.preventDefault();
+  dragOverId.value = null;
+  const sourceId = dragSourceId.value;
+  dragSourceId.value = null;
+  if (!canDragAgents.value || !sourceId || sourceId === targetId) return;
+
+  const currentOrder = filteredAgents.value.map((agent) => agent.id);
+  const sourceIdx = currentOrder.indexOf(sourceId);
+  const targetIdx = currentOrder.indexOf(targetId);
+  if (sourceIdx === -1 || targetIdx === -1) return;
+
+  const newOrder = [...currentOrder];
+  newOrder.splice(sourceIdx, 1);
+  newOrder.splice(targetIdx, 0, sourceId);
+  persistAgentOrder(buildAgentSortUpdates(newOrder));
+};
+
+const handleAgentDragEnd = () => {
+  dragSourceId.value = null;
+  dragOverId.value = null;
+};
 
 // 视图模式切换 (Grid / List)
 const viewMode = ref<'grid' | 'list'>((localStorage.getItem('agent_view_mode') as 'grid' | 'list') || 'grid');
@@ -1226,6 +1319,12 @@ const formatDate = (dateStr: string) => {
             </svg>
           </button>
         </div>
+        <p
+          v-if="canDragAgents"
+          class="text-[11px] text-gray-400 hidden sm:block"
+        >
+          拖动卡片或列表行可调整排序
+        </p>
       </div>
     </div>
 
@@ -1273,12 +1372,31 @@ const formatDate = (dateStr: string) => {
         <div
           v-for="agent in filteredAgents"
           :key="agent.id"
-          class="bg-white rounded-xl shadow-sm border hover:shadow-md transition-all duration-200 flex flex-col overflow-hidden group"
+          class="bg-white rounded-xl shadow-sm border hover:shadow-md transition-all duration-200 flex flex-col overflow-hidden group relative"
           :class="[
             !agent.is_enabled ? 'bg-gray-50/50 grayscale-[0.8] opacity-80' : '',
-            getAgentColorTheme(agent).border
+            getAgentColorTheme(agent).border,
+            canDragAgents ? 'cursor-grab active:cursor-grabbing' : '',
+            dragOverId === agent.id ? 'ring-2 ring-primary/40 scale-[1.01]' : '',
+            dragSourceId === agent.id ? 'opacity-50' : '',
+            savingAgentOrder ? 'pointer-events-none' : '',
           ]"
+          :draggable="canDragAgents"
+          @dragstart="handleAgentDragStart($event, agent.id)"
+          @dragover="handleAgentDragOver($event, agent.id)"
+          @dragleave="handleAgentDragLeave($event)"
+          @drop="handleAgentDrop($event, agent.id)"
+          @dragend="handleAgentDragEnd()"
         >
+        <div
+          v-if="canDragAgents"
+          class="absolute top-2 left-1/2 -translate-x-1/2 z-10 opacity-0 group-hover:opacity-40 transition-opacity pointer-events-none select-none"
+        >
+          <svg class="w-4 h-3 text-gray-500" viewBox="0 0 16 10" fill="currentColor">
+            <circle cx="4" cy="2" r="1.2"/><circle cx="8" cy="2" r="1.2"/><circle cx="12" cy="2" r="1.2"/>
+            <circle cx="4" cy="8" r="1.2"/><circle cx="8" cy="8" r="1.2"/><circle cx="12" cy="8" r="1.2"/>
+          </svg>
+        </div>
         <!-- Card Header Accent -->
         <div class="h-1.5 w-full" :class="getAgentColorTheme(agent).accent"></div>
         <!-- Card Header & Status -->
@@ -1530,6 +1648,7 @@ const formatDate = (dateStr: string) => {
           <table class="w-full text-left border-collapse">
             <thead>
               <tr class="bg-gray-50/50 border-b border-gray-200">
+                <th v-if="canDragAgents" class="px-3 py-3 text-[11px] font-bold text-gray-400 uppercase tracking-wider w-8"></th>
                 <th class="px-6 py-3 text-[11px] font-bold text-gray-400 uppercase tracking-wider w-12 text-center">Icon</th>
                 <th class="px-6 py-3 text-[11px] font-bold text-gray-400 uppercase tracking-wider">智能体名称</th>
                 <th class="px-6 py-3 text-[11px] font-bold text-gray-400 uppercase tracking-wider hidden md:table-cell">引擎 / 类型</th>
@@ -1542,8 +1661,26 @@ const formatDate = (dateStr: string) => {
                 v-for="agent in filteredAgents"
                 :key="agent.id"
                 class="hover:bg-blue-50/30 transition-colors group"
-                :class="!agent.is_enabled ? 'opacity-70 grayscale-[0.6] bg-gray-50/30' : ''"
+                :class="[
+                  !agent.is_enabled ? 'opacity-70 grayscale-[0.6] bg-gray-50/30' : '',
+                  canDragAgents ? 'cursor-grab active:cursor-grabbing' : '',
+                  dragOverId === agent.id ? 'bg-blue-50/60 ring-1 ring-inset ring-primary/30' : '',
+                  dragSourceId === agent.id ? 'opacity-50' : '',
+                  savingAgentOrder ? 'pointer-events-none' : '',
+                ]"
+                :draggable="canDragAgents"
+                @dragstart="handleAgentDragStart($event, agent.id)"
+                @dragover="handleAgentDragOver($event, agent.id)"
+                @dragleave="handleAgentDragLeave($event)"
+                @drop="handleAgentDrop($event, agent.id)"
+                @dragend="handleAgentDragEnd()"
               >
+                <td v-if="canDragAgents" class="px-3 py-4 text-gray-300 group-hover:text-gray-400">
+                  <svg class="w-4 h-4 mx-auto" viewBox="0 0 16 10" fill="currentColor">
+                    <circle cx="4" cy="2" r="1.2"/><circle cx="8" cy="2" r="1.2"/><circle cx="12" cy="2" r="1.2"/>
+                    <circle cx="4" cy="8" r="1.2"/><circle cx="8" cy="8" r="1.2"/><circle cx="12" cy="8" r="1.2"/>
+                  </svg>
+                </td>
                 <td class="px-6 py-4">
                   <div
                     class="w-8 h-8 rounded-lg flex items-center justify-center text-lg shadow-inner border mx-auto"

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { useRouter, useRoute } from "vue-router";
-import { computed, ref, onMounted } from "vue";
+import { computed, ref, onMounted, onUnmounted, watch } from "vue";
 import axios from "../utils/axios";
 import Toast from "../components/Toast.vue";
+import { useBranding } from "../composables/useBranding";
 
 const router = useRouter();
 const route = useRoute();
+const { branding, loadBranding, applyDocumentTitle, resolveRepoUrl } = useBranding();
+const repoUrl = computed(() => resolveRepoUrl());
 const isCollapsed = ref(false);
 const showMobileSidebar = ref(false);
 const windowWidth = ref(window.innerWidth);
@@ -84,6 +87,7 @@ const fetchUserInfo = async () => {
 };
 
 onMounted(() => {
+  loadBranding();
   fetchUserInfo();
   fetchOnlineUsers();
 });
@@ -182,8 +186,6 @@ onMounted(() => {
   document.addEventListener("keydown", handleEscape);
 });
 
-// Cleanup on unmount
-import { onUnmounted, watch } from "vue";
 onUnmounted(() => {
   document.removeEventListener("keydown", handleEscape);
 });
@@ -199,6 +201,14 @@ const breadcrumbs = computed(() => {
   const matched = route.matched;
   return matched.map((m) => m.meta?.title || m.name).filter(Boolean);
 });
+
+watch(
+  () => [route.path, breadcrumbs.value[breadcrumbs.value.length - 1], branding.value.product_name],
+  () => {
+    applyDocumentTitle(breadcrumbs.value[breadcrumbs.value.length - 1] || undefined);
+  },
+  { immediate: true },
+);
 
 const toggleSidebar = () => {
   if (isMobile.value) {
@@ -367,24 +377,33 @@ const filteredMenuGroups = computed(() => {
         :class="isCollapsed ? 'justify-center px-0' : 'px-4'"
       >
         <img
-          src="/logo.png"
-          class="w-8 h-8 flex-shrink-0 rounded-lg"
+          :src="branding.icon_url"
+          class="w-8 h-8 flex-shrink-0 rounded-lg object-cover"
           alt="Logo"
         />
         <transition name="fade">
           <div v-if="!isCollapsed" class="ml-2.5 flex flex-col justify-center -translate-y-0.5">
-            <span class="text-[15px] font-bold tracking-wide leading-tight">云枢 · 智能体平台</span>
-            <a 
-              href="https://github.com/RandyChen1985/yunshu-ai-agent-platform" 
-              target="_blank" 
-              class="group flex items-center text-[10px] text-gray-500 font-medium tracking-wider leading-none mt-0.5 hover:text-white transition-colors"
-              title="View on GitHub"
+            <span class="text-[15px] font-bold tracking-wide leading-tight">{{ branding.product_name }}</span>
+            <component
+              :is="repoUrl ? 'a' : 'span'"
+              :href="repoUrl || undefined"
+              :target="repoUrl ? '_blank' : undefined"
+              :rel="repoUrl ? 'noopener noreferrer' : undefined"
+              class="group flex items-center text-[10px] text-gray-500 font-medium tracking-wider leading-none mt-0.5 transition-colors"
+              :class="repoUrl ? 'hover:text-white' : ''"
+              :title="repoUrl ? 'View on GitHub' : undefined"
             >
-              <svg class="w-3 h-3 mr-1 opacity-80 group-hover:opacity-100 transition-opacity" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <svg
+                v-if="repoUrl"
+                class="w-3 h-3 mr-1 opacity-80 group-hover:opacity-100 transition-opacity"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
                 <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd" />
               </svg>
               <span>v{{ appVersion }}</span>
-            </a>
+            </component>
           </div>
         </transition>
       </div>
@@ -592,7 +611,7 @@ const filteredMenuGroups = computed(() => {
                 </svg>
              </router-link>
              <h1 class="text-sm font-bold text-gray-900 truncate">
-                {{ breadcrumbs[breadcrumbs.length - 1] || '云枢智能体' }}
+                {{ breadcrumbs[breadcrumbs.length - 1] || branding.product_name }}
              </h1>
           </div>
         </div>

--- a/frontend/src/views/DataSourceManagement.vue
+++ b/frontend/src/views/DataSourceManagement.vue
@@ -10,6 +10,7 @@ const dbTypes = [
   { id: 'mysql', name: 'MySQL', icon: '🐬', defaultPort: 3306 },
   { id: 'clickhouse', name: 'ClickHouse', icon: '🧊', defaultPort: 9000 },
   { id: 'oracle', name: 'Oracle', icon: '🔴', defaultPort: 1521 },
+  { id: 'sqlserver', name: 'SQL Server', icon: '🟦', defaultPort: 1433 },
 ]
 
 const configs = ref<DbConnectionConfig[]>([])
@@ -66,6 +67,7 @@ const dbTypeColor = (type: string) => {
   if (type === 'mysql') return 'bg-blue-100 text-blue-700 border-blue-200'
   if (type === 'clickhouse') return 'bg-cyan-100 text-cyan-700 border-cyan-200'
   if (type === 'oracle') return 'bg-red-100 text-red-700 border-red-200'
+  if (type === 'sqlserver' || type === 'mssql') return 'bg-indigo-100 text-indigo-700 border-indigo-200'
   return 'bg-gray-100 text-gray-600 border-gray-200'
 }
 
@@ -269,7 +271,7 @@ const confirmDeleteConfig = async () => {
 
 const openSqlDebug = (item: DbConnectionConfig) => {
   debugTarget.value = item
-  debugSql.value = item.db_type === 'oracle' ? 'SELECT 1 FROM DUAL' : 'SELECT 1'
+  debugSql.value = item.db_type === 'oracle' ? 'SELECT 1 FROM DUAL' : item.db_type === 'sqlserver' || item.db_type === 'mssql' ? 'SELECT 1' : 'SELECT 1'
   debugLimit.value = 100
   debugError.value = ''
   debugResult.value = null
@@ -336,7 +338,7 @@ onMounted(() => {
         </div>
 
         <div class="p-5 space-y-4">
-          <div class="grid grid-cols-3 gap-3">
+          <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
             <button
               v-for="db in dbTypes"
               :key="db.id"
@@ -351,9 +353,9 @@ onMounted(() => {
 
           <div>
             <label class="block text-xs font-bold text-gray-400 uppercase tracking-wider mb-1.5">数据源名称</label>
-            <input v-model="form.name" class="w-full border border-gray-200 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary/50" placeholder="如：default_clickhouse、clickhouse_ods、mysql_crm、oracle_erp">
+            <input v-model="form.name" class="w-full border border-gray-200 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary/50" placeholder="如：default_clickhouse、clickhouse_ods、mysql_crm、oracle_erp、sqlserver_erp">
             <p class="mt-1.5 text-xs leading-5 text-amber-700 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2">
-              建议使用外部 SQL 执行兼容标识命名，例如 default_clickhouse、clickhouse_xxx、mysql_xxx、oracle_xxx，ChatBI 本地执行会按数据源名称匹配历史配置。
+              建议使用外部 SQL 执行兼容标识命名，例如 default_clickhouse、clickhouse_xxx、mysql_xxx、oracle_xxx、sqlserver_xxx，ChatBI 本地执行会按数据源名称匹配历史配置。
             </p>
           </div>
 

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -699,6 +699,11 @@
                                <!-- Main Text -->
                                <span class="truncate">{{ log.title }}</span>
                                <span
+                                 v-if="logHasRowFilterApplied(log)"
+                                 class="flex-shrink-0 text-[12px]"
+                                 title="已按行级数据权限改写 SQL"
+                               >🔒</span>
+                               <span
                                  v-if="isActiveThoughtStep(log, msg.isThinking)"
                                  class="inline-flex items-center px-1 sm:px-1.5 py-px sm:py-0.5 rounded text-[8px] sm:text-[9px] font-bold uppercase tracking-wide text-primary bg-primary/10 border border-primary/20 scale-90 sm:scale-100 origin-center"
                                >
@@ -907,6 +912,15 @@
                 >
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>
                 </button>
+                                                                <div
+                                                                  v-if="msg.permissionNotice?.row_filter_applied"
+                                                                  class="mb-2 inline-flex max-w-full items-start gap-1.5 rounded-lg border border-emerald-100 bg-emerald-50/70 px-2.5 py-1.5 text-[11px] font-medium leading-relaxed text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/30 dark:text-emerald-300"
+                                                                >
+                                                                  <svg class="mt-0.5 h-3.5 w-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                                                                  </svg>
+                                                                  <span>{{ msg.permissionNotice.message || '已按你的数据权限自动过滤结果' }}</span>
+                                                                </div>
                                                                 <MessageRenderer
                                                                   v-if="!msg.datasetNavigation?.groups?.length"
                                                                   :content="msg.content"
@@ -1049,34 +1063,6 @@
                 </svg>
                 <span>导出</span>
               </button>
-              <!-- ChatBI 可视化分析 -->
-              <button
-                v-if="msg.hasDataOutput && checkRole(msg, 'agent') && !msg.isThinking"
-                type="button"
-                @click="handleVisualAnalysis()"
-                class="flex shrink-0 items-center space-x-1 text-[10px] font-medium text-primary border border-primary/25 bg-primary/5 hover:bg-primary/10 transition-colors rounded"
-                :class="windowWidth < 640 ? 'p-2.5' : 'px-1.5 py-0.5'"
-                title="基于本轮查询结果进行可视化深度分析"
-              >
-                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                </svg>
-                <span class="hidden sm:inline">可视化分析</span>
-              </button>
-              <!-- 添加黄金报表 -->
-              <button
-                v-if="canSaveGoldenReportFromMessage(msg) && checkRole(msg, 'agent') && !msg.isThinking"
-                type="button"
-                @click="handleSaveReportFromMessage(msg)"
-                class="flex shrink-0 items-center space-x-1 text-[10px] font-medium text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-700/50 bg-amber-50 dark:bg-amber-900/20 hover:bg-amber-100 dark:hover:bg-amber-900/35 transition-colors rounded"
-                :class="windowWidth < 640 ? 'p-2.5' : 'px-1.5 py-0.5'"
-                title="将本轮成功查数的 SQL 沉淀为黄金报表"
-              >
-                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-                </svg>
-                <span class="hidden sm:inline">添加黄金报表</span>
-              </button>
               <!-- Time -->
               <span v-if="msg.timestamp" class="text-[10px] text-gray-400 dark:text-gray-500 select-none mr-1">{{ formatBubbleTime(msg.timestamp) }}</span>
               <button
@@ -1113,7 +1099,17 @@
                 </svg>
                 <span>链路</span>
               </button>
-              <!-- Token 消耗显示（移动端隐藏以节省空间） -->
+              <!-- Token 消耗：移动端仅 icon，桌面端展示 in/out 明细 -->
+              <button
+                v-if="msg.prompt_tokens !== undefined || msg.completion_tokens !== undefined"
+                @click="openModelCallStats(msg)"
+                class="flex sm:hidden shrink-0 items-center justify-center text-gray-400 hover:text-primary transition-colors rounded hover:bg-gray-100 dark:hover:bg-gray-800 p-2.5"
+                title="查看 Token 消耗详情"
+              >
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h10M7 16h6M5 6a2 2 0 012-2h10a2 2 0 012 2v12a2 2 0 01-2 2H7a2 2 0 01-2-2V6z" />
+                </svg>
+              </button>
               <button
                 v-if="msg.prompt_tokens !== undefined || msg.completion_tokens !== undefined"
                 @click="openModelCallStats(msg)"
@@ -1130,8 +1126,9 @@
                   <span class="font-medium text-gray-500 dark:text-gray-400">{{ msg.completion_tokens || 0 }}</span>
                 </span>
               </button>
-              <!-- Feedback Buttons（托管引擎不展示点赞踩） -->
-              <div v-if="!hideEmbedLikeDislike" class="flex items-center space-x-1 ml-auto">
+              <!-- 反馈与 ChatBI 扩展操作（靠右对齐） -->
+              <div class="flex items-center space-x-1 ml-auto">
+                <template v-if="!hideEmbedLikeDislike">
                 <button
                   @click="handleFeedback(msg, 'up')"
                   class="rounded transition-colors hover:bg-green-50 dark:hover:bg-green-900/20 text-gray-400 hover:text-green-500"
@@ -1176,9 +1173,36 @@
                       stroke-width="2"
                       d="M10 14H5.292C4.288 14 3.5 13.257 3.5 12.342c0-.354.05-.7.145-1.03l1.921-6.641C5.768 3.859 6.486 3 7.5 3h8c1.105 0 2 .895 2 2v8c0 .55-.224 1.05-.586 1.414l-5 5c-.381.381-1 .381-1.381 0L10 19v-5z"
                     />
-                                    </svg>
-                                  </button>
-                                </div>
+                  </svg>
+                </button>
+                </template>
+                <button
+                  v-if="msg.hasDataOutput && checkRole(msg, 'agent') && !msg.isThinking"
+                  type="button"
+                  @click="handleVisualAnalysis()"
+                  class="flex shrink-0 items-center space-x-1 text-[10px] font-medium text-primary border border-primary/25 bg-primary/5 hover:bg-primary/10 transition-colors rounded"
+                  :class="windowWidth < 640 ? 'p-2.5' : 'px-1.5 py-0.5'"
+                  title="基于本轮查询结果进行可视化深度分析"
+                >
+                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                  </svg>
+                  <span class="hidden sm:inline">可视化分析</span>
+                </button>
+                <button
+                  v-if="canSaveGoldenReportFromMessage(msg) && checkRole(msg, 'agent') && !msg.isThinking"
+                  type="button"
+                  @click="handleSaveReportFromMessage(msg)"
+                  class="flex shrink-0 items-center space-x-1 text-[10px] font-medium text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-700/50 bg-amber-50 dark:bg-amber-900/20 hover:bg-amber-100 dark:hover:bg-amber-900/35 transition-colors rounded"
+                  :class="windowWidth < 640 ? 'p-2.5' : 'px-1.5 py-0.5'"
+                  title="将本轮成功查数的 SQL 沉淀为黄金报表"
+                >
+                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                  </svg>
+                  <span class="hidden sm:inline">添加黄金报表</span>
+                </button>
+              </div>
                               </div>
                             </div>
                           </div>
@@ -2579,6 +2603,7 @@ import {
   resolveSavableSqlFromLog,
   canSaveGoldenReportFromMessage,
   resolveSavableSqlFromMessage,
+  logHasRowFilterApplied,
 } from "@/utils/toolLogDisplay";
 import {
   deriveSavedReportDescription,
@@ -2613,6 +2638,7 @@ interface LogEntry {
   execution_time_ms?: number | null;
   elapsed_time_ms?: number | null;
   started_at?: number | null;
+  rowFilterApplied?: boolean;
 }
 
 interface SavedReportPayload {
@@ -2626,6 +2652,13 @@ interface SavedReportPayload {
   analysis_mode?: string;
   description?: string;
   tags?: string[];
+}
+
+interface PermissionNotice {
+  row_filter_applied?: boolean;
+  dataset_name?: string;
+  rule_count?: number;
+  message?: string;
 }
 
 interface SkillMeta {
@@ -2705,6 +2738,7 @@ interface Message {
   pendingExternalExecution?: PendingExternalExecution;
   toolResultData?: Record<string, Array<{ block_id?: string; media_type?: string; data?: unknown; url?: string | null }>>;
   datasetNavigation?: DatasetNavigationPayload;
+  permissionNotice?: PermissionNotice;
   _hasSilentlyRefreshed?: boolean;
 }
 // Helper: Check Role
@@ -4535,6 +4569,7 @@ const executeSavedReportWithOptions = async (reportArg?: SavedReportPayload | nu
       const execResult = res.data.data;
       resultMarkdown = renderSavedReportDataToMarkdown(execResult);
       detailsText = `${report.sql_content}\n--- 结果 ---\n${typeof execResult === 'object' ? JSON.stringify(execResult, null, 2) : String(execResult)}`;
+      agentMsg.value.permissionNotice = execResult?.permission_notice;
     } else {
       resultMarkdown = "执行结果为空。";
       detailsText = `${report.sql_content}\n--- 结果 ---\n无`;
@@ -5675,6 +5710,7 @@ const addEmbedLogFromStream = (msg: Message, data: any) => {
       execution_time_ms: execution_time_ms ?? currentLog.execution_time_ms,
       elapsed_time_ms: data.elapsed_time_ms ?? currentLog.elapsed_time_ms,
       started_at: currentLog.started_at ?? (data.status === "pending" ? Date.now() : data.started_at),
+      rowFilterApplied: data.row_filter_applied === true || currentLog.rowFilterApplied,
     };
     return;
   }
@@ -5688,6 +5724,7 @@ const addEmbedLogFromStream = (msg: Message, data: any) => {
     execution_time_ms: data.execution_time_ms ?? null,
     elapsed_time_ms: data.elapsed_time_ms ?? null,
     started_at: data.status === "pending" ? Date.now() : (data.started_at ?? null),
+    rowFilterApplied: data.row_filter_applied === true,
   });
 };
 
@@ -5742,6 +5779,7 @@ const applyPermissionStreamEvent = (msg: Message, data: any) => {
     if (data.prompt_tokens !== undefined) msg.prompt_tokens = data.prompt_tokens;
     if (data.completion_tokens !== undefined) msg.completion_tokens = data.completion_tokens;
     if (data.has_data_output) msg.hasDataOutput = true;
+    if (data.permission_notice) msg.permissionNotice = data.permission_notice;
   } else if (data.type === "error") {
     if (msg.pendingPermission) msg.pendingPermission.status = "error";
     msg.isThinking = false;
@@ -6151,6 +6189,9 @@ const sendMessage = async () => {
             }
             if (data.has_data_output) {
               agentMsg.value.hasDataOutput = true;
+            }
+            if (data.permission_notice) {
+              agentMsg.value.permissionNotice = data.permission_notice;
             }
             if (data.ltm_applied && data.ltm_data) {
               if (!ltmAlertedInSession.value) {

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -1180,7 +1180,7 @@
                   v-if="msg.hasDataOutput && checkRole(msg, 'agent') && !msg.isThinking"
                   type="button"
                   @click="handleVisualAnalysis()"
-                  class="flex shrink-0 items-center space-x-1 text-[10px] font-medium text-primary border border-primary/25 bg-primary/5 hover:bg-primary/10 transition-colors rounded"
+                  class="flex shrink-0 items-center space-x-1 text-[10px] text-gray-400 hover:text-primary transition-colors rounded hover:bg-gray-100 dark:hover:bg-gray-800"
                   :class="windowWidth < 640 ? 'p-2.5' : 'px-1.5 py-0.5'"
                   title="基于本轮查询结果进行可视化深度分析"
                 >
@@ -1193,7 +1193,7 @@
                   v-if="canSaveGoldenReportFromMessage(msg) && checkRole(msg, 'agent') && !msg.isThinking"
                   type="button"
                   @click="handleSaveReportFromMessage(msg)"
-                  class="flex shrink-0 items-center space-x-1 text-[10px] font-medium text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-700/50 bg-amber-50 dark:bg-amber-900/20 hover:bg-amber-100 dark:hover:bg-amber-900/35 transition-colors rounded"
+                  class="flex shrink-0 items-center space-x-1 text-[10px] text-gray-400 hover:text-primary transition-colors rounded hover:bg-gray-100 dark:hover:bg-gray-800"
                   :class="windowWidth < 640 ? 'p-2.5' : 'px-1.5 py-0.5'"
                   title="将本轮成功查数的 SQL 沉淀为黄金报表"
                 >

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch } from 'vue'
+import { ref, onMounted, onUnmounted, watch, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import axios from 'axios'
+import { useBranding } from '../composables/useBranding'
 
 const router = useRouter()
+const { branding, loadBranding } = useBranding()
 const activeTab = ref<'sso' | 'password' | 'apikey'>('password')
 const ssoEnabled = ref(false)
 const apiKey = ref('')
@@ -11,6 +13,22 @@ const username = ref('')
 const password = ref('')
 const error = ref('')
 const loading = ref(false)
+
+const productName = computed(() => branding.value.product_name)
+const loginSubtitle = computed(() => branding.value.login_subtitle)
+const iconUrl = computed(() => branding.value.icon_url)
+const showCopyright = computed(() => branding.value.enabled && !!(branding.value.copyright_text || '').trim())
+const copyrightText = computed(() => (branding.value.copyright_text || '').trim())
+const showSsoFromBranding = computed(() => !branding.value.hide_login_sso)
+
+const displaySlides = computed(() => {
+    const list = slides.map((slide) => ({ ...slide }))
+    if (list[0]) {
+        list[0].title = productName.value
+        list[0].subtitle = loginSubtitle.value
+    }
+    return list
+})
 
 // Carousel Logic
 const currentSlide = ref(0)
@@ -104,10 +122,20 @@ const fetchPublicConfig = async () => {
     }
 }
 
-onMounted(() => { 
+onMounted(async () => { 
     window.addEventListener('mousemove', handleMouseMove)
     startSlide()
+    await loadBranding()
+    if (branding.value.hide_login_sso && activeTab.value === 'sso') {
+        activeTab.value = 'password'
+    }
     fetchPublicConfig()
+})
+
+watch(() => branding.value.hide_login_sso, (hide) => {
+    if (hide && activeTab.value === 'sso') {
+        activeTab.value = 'password'
+    }
 })
 onUnmounted(() => { 
     window.removeEventListener('mousemove', handleMouseMove)
@@ -189,7 +217,7 @@ const handleLogin = async () => {
         <!-- Carousel Container -->
         <div class="relative w-full h-full flex items-center justify-center">
             <div 
-                v-for="(slide, index) in slides" 
+                v-for="(slide, index) in displaySlides" 
                 :key="index"
                 class="absolute inset-0 flex flex-col items-center justify-center text-center px-20 transition-all duration-1000 ease-in-out"
                 :class="[
@@ -250,10 +278,10 @@ const handleLogin = async () => {
         <!-- Mobile Header (Visible only on small screens) -->
         <div class="lg:hidden pt-8 px-10 pb-0 animate-fade-in">
             <div class="flex items-center gap-3 mb-2">
-                <img src="/logo.png" class="w-8 h-8 rounded-lg drop-shadow-md" alt="Logo" />
-                <h1 class="text-xl font-bold text-slate-900 tracking-tight">云枢 · 智能体平台</h1>
+                <img :src="iconUrl" class="w-8 h-8 rounded-lg drop-shadow-md object-cover" alt="Logo" />
+                <h1 class="text-xl font-bold text-slate-900 tracking-tight">{{ productName }}</h1>
             </div>
-            <p class="text-xs text-slate-500 tracking-wide uppercase">Yunshu Intelligent Agent Platform</p>
+            <p class="text-xs text-slate-500 tracking-wide uppercase">{{ loginSubtitle }}</p>
         </div>
 
         <div class="flex-1 flex flex-col justify-center px-10">
@@ -265,7 +293,7 @@ const handleLogin = async () => {
             <!-- Tabs -->
             <div class="flex space-x-8 border-b border-slate-100 mb-8">
                 <button 
-                    v-for="tab in [{id:'sso', name:'SSO 登录'}, {id:'apikey', name:'API Key'}, {id:'password', name:'本地账号'}].filter(t => t.id !== 'sso' || ssoEnabled)" 
+                    v-for="tab in [{id:'sso', name:'SSO 登录'}, {id:'password', name:'本地账号'}, {id:'apikey', name:'API Key'}].filter(t => t.id !== 'sso' || (ssoEnabled && showSsoFromBranding))" 
                     :key="tab.id"
                     @click="activeTab = tab.id as any"
                     class="pb-3 text-sm font-semibold transition-all relative"
@@ -340,7 +368,13 @@ const handleLogin = async () => {
             </div>
         </div>
         
-        <div class="p-6 text-center text-[10px] text-slate-400 font-mono opacity-40">
+        <div v-if="showCopyright" class="p-6 text-center">
+            <p class="login-copyright text-[10px] text-slate-400/80 font-extralight tracking-[0.22em] leading-[1.8] whitespace-pre-line">
+                {{ copyrightText }}
+            </p>
+            <div class="mt-3 mx-auto h-px w-14 bg-gradient-to-r from-transparent via-slate-300/40 to-transparent" aria-hidden="true" />
+        </div>
+        <div v-else class="p-6 text-center text-[10px] text-slate-400 font-mono opacity-40">
             © 2026 Yunshu Network // CLOUD_PIVOT_AGENT
         </div>
     </div>

--- a/frontend/src/views/MetadataDatasets.vue
+++ b/frontend/src/views/MetadataDatasets.vue
@@ -6,6 +6,7 @@ import type { Dataset } from '../api/metadata'
 import { portalApi, type User, type Role } from '../api/portal'
 import axios from '@/utils/axios'
 import SmartImportWizard from '../components/metadata/SmartImportWizard.vue'
+import RowFilterOptionSelect from '../components/metadata/RowFilterOptionSelect.vue'
 import { useUser } from '../composables/useUser'
 import { useToast } from '../composables/useToast'
 
@@ -204,6 +205,23 @@ const syncFromVisual = (silent = false) => {
 // 获取表的字段
 const getTableFields = (tableName: string) => {
   return tableFields.value[tableName] || []
+}
+
+const tableSelectOptions = computed(() =>
+  datasetTables.value.map((table: any) => ({
+    value: table.physical_name,
+    label: table.physical_name,
+    remark: table.term || table.description || '',
+  })),
+)
+
+const getColumnSelectOptions = (tableName: string) => {
+  const table = datasetTables.value.find((item: any) => item.physical_name === tableName)
+  return (table?.columns || []).map((column: any) => ({
+    value: column.physical_name,
+    label: column.physical_name,
+    remark: column.term || column.description || '',
+  }))
 }
 
 // 规则校验功能
@@ -2084,21 +2102,28 @@ relationships:
                           <div class="flex items-end gap-3 p-3 bg-amber-50/80 rounded-xl border border-amber-200">
                             <div class="flex-1 space-y-1">
                               <label class="block text-[10px] text-amber-600 font-bold ml-1">目标表</label>
-                              <select v-model="rule._builder_table" class="bg-white border border-amber-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-amber-500 outline-none w-32 shadow-sm">
-                                <option value="" disabled selected>选择表...</option>
-                                <option v-for="table in availableTables" :key="table" :value="table">{{ table }}</option>
-                              </select>
+                              <RowFilterOptionSelect
+                                v-model="rule._builder_table"
+                                :options="tableSelectOptions"
+                                placeholder="选择表..."
+                                button-class="border-amber-300 focus:ring-amber-500"
+                                menu-class="hover:bg-amber-50"
+                              />
                             </div>
                             <div class="flex-1 space-y-1">
                               <label class="block text-[10px] text-amber-600 font-bold ml-1">字段</label>
-                              <select v-model="rule._builder_field" class="bg-white border border-amber-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-amber-500 outline-none w-32 shadow-sm">
-                                <option value="" disabled selected>选择字段...</option>
-                                <option v-for="field in getTableFields(rule._builder_table)" :key="field" :value="field">{{ field }}</option>
-                              </select>
+                              <RowFilterOptionSelect
+                                v-model="rule._builder_field"
+                                :options="getColumnSelectOptions(rule._builder_table)"
+                                placeholder="选择字段..."
+                                :disabled="!rule._builder_table"
+                                button-class="border-amber-300 focus:ring-amber-500"
+                                menu-class="hover:bg-amber-50"
+                              />
                             </div>
                             <div class="flex-1 space-y-1">
                               <label class="block text-[10px] text-amber-600 font-bold ml-1">操作符</label>
-                              <select v-model="rule._builder_op" class="bg-white border border-amber-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-amber-500 outline-none w-24 shadow-sm">
+                              <select v-model="rule._builder_op" class="h-[2.625rem] bg-white border border-amber-300 rounded-lg px-2 text-xs focus:ring-1 focus:ring-amber-500 outline-none w-28 shadow-sm">
                                 <option value="" disabled selected>操作符...</option>
                                 <option v-for="op in OPERATORS" :key="op.value" :value="op.value">{{ op.label }}</option>
                               </select>
@@ -2106,8 +2131,8 @@ relationships:
                             <div class="flex-1 space-y-1">
                               <label class="block text-[10px] text-amber-600 font-bold ml-1">过滤值/变量</label>
                               <div class="relative flex items-center gap-1">
-                                <input v-model="rule._builder_val" class="flex-1 w-full bg-white border border-amber-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-amber-500 outline-none min-w-[120px] shadow-sm" placeholder="e.g. {user.id}">
-                                <button @click.stop="toggleMenu(`visual-user-${userId}-${idx}-vars`)" class="flex-shrink-0 w-8 h-8 rounded-lg text-amber-600 hover:bg-amber-50 transition-colors border border-amber-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
+                                <input v-model="rule._builder_val" class="flex-1 w-full h-[2.625rem] bg-white border border-amber-300 rounded-lg px-2 text-xs focus:ring-1 focus:ring-amber-500 outline-none min-w-[120px] shadow-sm" placeholder="e.g. {user.id}">
+                                <button @click.stop="toggleMenu(`visual-user-${userId}-${idx}-vars`)" class="flex-shrink-0 h-[2.625rem] w-9 rounded-lg text-amber-600 hover:bg-amber-50 transition-colors border border-amber-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
                                   { }
                                 </button>
                                 <div v-if="activeMenuPath === `visual-user-${userId}-${idx}-vars`" class="absolute right-0 top-full mt-1 w-36 bg-white rounded-lg shadow-xl border border-gray-100 z-[9999] max-h-48 overflow-y-auto custom-scrollbar">
@@ -2117,7 +2142,7 @@ relationships:
                                 </div>
                               </div>
                             </div>
-                            <button @click="appendBuilderCondition(rule)" class="bg-amber-700 hover:bg-amber-800 text-white w-10 h-8 rounded-lg flex items-center justify-center transition-all shadow-md disabled:opacity-30 disabled:scale-100 active:scale-95" :disabled="!rule._builder_table || !rule._builder_field || !rule._builder_op || !rule._builder_val" title="追加条件">
+                            <button @click="appendBuilderCondition(rule)" class="bg-amber-700 hover:bg-amber-800 text-white w-10 h-[2.625rem] rounded-lg flex items-center justify-center transition-all shadow-md disabled:opacity-30 disabled:scale-100 active:scale-95" :disabled="!rule._builder_table || !rule._builder_field || !rule._builder_op || !rule._builder_val" title="追加条件">
                               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 6v6m0 0v6m0-6h6m-6 0h6"/></svg>
                             </button>
                             <button @click="rules.splice(idx, 1)" class="text-red-500 hover:text-red-700">
@@ -2203,23 +2228,30 @@ relationships:
                             <div class="flex items-end gap-3 p-3 bg-emerald-50/80 rounded-xl border border-emerald-200">
                               <div class="space-y-1">
                                 <label class="block text-[10px] text-emerald-600 font-bold ml-1">目标表</label>
-                                <select v-model="rule._builder_table" class="bg-white border border-emerald-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-emerald-500 outline-none w-32 shadow-sm">
-                                  <option value="" disabled selected>选择数据表...</option>
-                                  <option v-for="t in datasetTables" :key="t.physical_name" :value="t.physical_name">{{ t.physical_name }}</option>
-                                </select>
+                                <RowFilterOptionSelect
+                                  v-model="rule._builder_table"
+                                  :options="tableSelectOptions"
+                                  placeholder="选择数据表..."
+                                  button-class="border-emerald-300 focus:ring-emerald-500"
+                                  menu-class="hover:bg-emerald-50"
+                                />
                               </div>
                               
                               <div class="space-y-1">
                                 <label class="block text-[10px] text-emerald-600 font-bold ml-1">选择字段</label>
-                                <select v-model="rule._builder_field" class="bg-white border border-emerald-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-emerald-500 outline-none w-32 shadow-sm" :disabled="!rule._builder_table">
-                                  <option value="" disabled selected>选择字段...</option>
-                                  <option v-for="col in (datasetTables.find((t: any) => t.physical_name === rule._builder_table)?.columns || [])" :key="col.physical_name" :value="col.physical_name">{{ col.physical_name }}</option>
-                                </select>
+                                <RowFilterOptionSelect
+                                  v-model="rule._builder_field"
+                                  :options="getColumnSelectOptions(rule._builder_table)"
+                                  placeholder="选择字段..."
+                                  :disabled="!rule._builder_table"
+                                  button-class="border-emerald-300 focus:ring-emerald-500"
+                                  menu-class="hover:bg-emerald-50"
+                                />
                               </div>
 
                               <div class="space-y-1">
                                 <label class="block text-[10px] text-emerald-600 font-bold ml-1">操作符</label>
-                                <select v-model="rule._builder_op" class="bg-white border border-emerald-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-emerald-500 outline-none w-24 shadow-sm">
+                                <select v-model="rule._builder_op" class="h-[2.625rem] bg-white border border-emerald-300 rounded-lg px-2 text-xs focus:ring-1 focus:ring-emerald-500 outline-none w-28 shadow-sm">
                                   <option value="" disabled selected>操作符...</option>
                                   <option v-for="op in OPERATORS" :key="op.value" :value="op.value">{{ op.label }}</option>
                                 </select>
@@ -2228,9 +2260,9 @@ relationships:
                               <div class="flex-1 space-y-1">
                                 <label class="block text-[10px] text-emerald-600 font-bold ml-1">过滤值/变量</label>
                                 <div class="relative flex items-center gap-1">
-                                  <input v-model="rule._builder_val" class="flex-1 w-full bg-white border border-emerald-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-emerald-500 outline-none min-w-[120px] shadow-sm" placeholder="e.g. {user.id}">
+                                  <input v-model="rule._builder_val" class="flex-1 w-full h-[2.625rem] bg-white border border-emerald-300 rounded-lg px-2 text-xs focus:ring-1 focus:ring-emerald-500 outline-none min-w-[120px] shadow-sm" placeholder="e.g. {user.id}">
                                   <!-- System variable dropdown trigger -->
-                                  <button @click.stop="toggleMenu(`role-${roleName}-${idx}-vars`)" class="flex-shrink-0 w-8 h-8 rounded-lg text-emerald-600 hover:bg-emerald-50 transition-colors border border-emerald-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
+                                  <button @click.stop="toggleMenu(`role-${roleName}-${idx}-vars`)" class="flex-shrink-0 h-[2.625rem] w-9 rounded-lg text-emerald-600 hover:bg-emerald-50 transition-colors border border-emerald-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
                                     { }
                                   </button>
                                   <div v-if="activeMenuPath === `role-${roleName}-${idx}-vars`" class="absolute right-0 top-full mt-1 w-36 bg-white rounded-lg shadow-xl border border-gray-100 z-[9999] max-h-48 overflow-y-auto custom-scrollbar">
@@ -2241,7 +2273,7 @@ relationships:
                                 </div>
                               </div>
                               
-                              <button @click="appendBuilderCondition(rule)" class="bg-emerald-700 hover:bg-emerald-800 text-white w-10 h-8 rounded-lg flex items-center justify-center transition-all shadow-md disabled:opacity-30 disabled:scale-100 active:scale-95" :disabled="!rule._builder_table || !rule._builder_field || !rule._builder_op || !rule._builder_val" title="追加条件">
+                              <button @click="appendBuilderCondition(rule)" class="bg-emerald-700 hover:bg-emerald-800 text-white w-10 h-[2.625rem] rounded-lg flex items-center justify-center transition-all shadow-md disabled:opacity-30 disabled:scale-100 active:scale-95" :disabled="!rule._builder_table || !rule._builder_field || !rule._builder_op || !rule._builder_val" title="追加条件">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/></svg>
                               </button>
                             </div>
@@ -2295,23 +2327,30 @@ relationships:
                               <div class="flex items-end gap-3 p-3 bg-amber-50/80 rounded-xl border border-amber-200">
                                 <div class="space-y-1">
                                   <label class="block text-[10px] text-amber-600 font-bold ml-1">目标表</label>
-                                  <select v-model="rule._builder_table" class="bg-white border border-amber-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-amber-500 outline-none w-32 shadow-sm">
-                                    <option value="" disabled selected>选择数据表...</option>
-                                    <option v-for="t in datasetTables" :key="t.physical_name" :value="t.physical_name">{{ t.physical_name }}</option>
-                                  </select>
+                                  <RowFilterOptionSelect
+                                    v-model="rule._builder_table"
+                                    :options="tableSelectOptions"
+                                    placeholder="选择数据表..."
+                                    button-class="border-amber-300 focus:ring-amber-500"
+                                    menu-class="hover:bg-amber-50"
+                                  />
                                 </div>
                                 
                                 <div class="space-y-1">
                                   <label class="block text-[10px] text-amber-600 font-bold ml-1">选择字段</label>
-                                  <select v-model="rule._builder_field" class="bg-white border border-amber-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-amber-500 outline-none w-32 shadow-sm" :disabled="!rule._builder_table">
-                                    <option value="" disabled selected>选择字段...</option>
-                                    <option v-for="col in (datasetTables.find((t: any) => t.physical_name === rule._builder_table)?.columns || [])" :key="col.physical_name" :value="col.physical_name">{{ col.physical_name }}</option>
-                                  </select>
+                                  <RowFilterOptionSelect
+                                    v-model="rule._builder_field"
+                                    :options="getColumnSelectOptions(rule._builder_table)"
+                                    placeholder="选择字段..."
+                                    :disabled="!rule._builder_table"
+                                    button-class="border-amber-300 focus:ring-amber-500"
+                                    menu-class="hover:bg-amber-50"
+                                  />
                                 </div>
 
                                 <div class="space-y-1">
                                   <label class="block text-[10px] text-amber-600 font-bold ml-1">操作符</label>
-                                  <select v-model="rule._builder_op" class="bg-white border border-amber-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-amber-500 outline-none w-24 shadow-sm">
+                                  <select v-model="rule._builder_op" class="h-[2.625rem] bg-white border border-amber-300 rounded-lg px-2 text-xs focus:ring-1 focus:ring-amber-500 outline-none w-28 shadow-sm">
                                     <option value="" disabled selected>操作符...</option>
                                     <option v-for="op in OPERATORS" :key="op.value" :value="op.value">{{ op.label }}</option>
                                   </select>
@@ -2320,9 +2359,9 @@ relationships:
                                 <div class="flex-1 space-y-1">
                                   <label class="block text-[10px] text-amber-600 font-bold ml-1">过滤值/变量</label>
                                   <div class="relative flex items-center gap-1">
-                                    <input v-model="rule._builder_val" class="flex-1 w-full bg-white border border-amber-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-amber-500 outline-none min-w-[120px] shadow-sm" placeholder="e.g. {user.id}">
+                                    <input v-model="rule._builder_val" class="flex-1 w-full h-[2.625rem] bg-white border border-amber-300 rounded-lg px-2 text-xs focus:ring-1 focus:ring-amber-500 outline-none min-w-[120px] shadow-sm" placeholder="e.g. {user.id}">
                                     <!-- System variable dropdown trigger -->
-                                    <button @click.stop="toggleMenu(`user-${uid}-${idx}-vars`)" class="flex-shrink-0 w-8 h-8 rounded-lg text-amber-600 hover:bg-amber-50 transition-colors border border-amber-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
+                                    <button @click.stop="toggleMenu(`user-${uid}-${idx}-vars`)" class="flex-shrink-0 h-[2.625rem] w-9 rounded-lg text-amber-600 hover:bg-amber-50 transition-colors border border-amber-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
                                       { }
                                     </button>
                                     <div v-if="activeMenuPath === `user-${uid}-${idx}-vars`" class="absolute right-0 top-full mt-1 w-36 bg-white rounded-lg shadow-xl border border-gray-100 z-[9999] max-h-48 overflow-y-auto custom-scrollbar">
@@ -2333,7 +2372,7 @@ relationships:
                                   </div>
                                 </div>
                                 
-                                <button @click="appendBuilderCondition(rule)" class="bg-amber-700 hover:bg-amber-800 text-white w-10 h-8 rounded-lg flex items-center justify-center transition-all shadow-md disabled:opacity-30 disabled:scale-100 active:scale-95" :disabled="!rule._builder_table || !rule._builder_field || !rule._builder_op || !rule._builder_val" title="追加条件">
+                                <button @click="appendBuilderCondition(rule)" class="bg-amber-700 hover:bg-amber-800 text-white w-10 h-[2.625rem] rounded-lg flex items-center justify-center transition-all shadow-md disabled:opacity-30 disabled:scale-100 active:scale-95" :disabled="!rule._builder_table || !rule._builder_field || !rule._builder_op || !rule._builder_val" title="追加条件">
                                   <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/></svg>
                                 </button>
                               </div>
@@ -2377,23 +2416,30 @@ relationships:
                          <div class="flex items-end gap-3 p-3 bg-slate-50/80 rounded-xl border border-slate-200">
                            <div class="space-y-1">
                              <label class="block text-[10px] text-slate-400 font-bold ml-1">目标表</label>
-                             <select v-model="rule._builder_table" class="bg-white border border-slate-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-slate-500 outline-none w-32 shadow-sm">
-                                <option value="" disabled selected>选择数据表...</option>
-                                <option v-for="t in datasetTables" :key="t.physical_name" :value="t.physical_name">{{ t.physical_name }}</option>
-                             </select>
+                             <RowFilterOptionSelect
+                               v-model="rule._builder_table"
+                               :options="tableSelectOptions"
+                               placeholder="选择数据表..."
+                               button-class="border-slate-300 focus:ring-slate-500"
+                               menu-class="hover:bg-slate-50"
+                             />
                            </div>
                            
                            <div class="space-y-1">
                              <label class="block text-[10px] text-slate-400 font-bold ml-1">选择字段</label>
-                             <select v-model="rule._builder_field" class="bg-white border border-slate-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-slate-500 outline-none w-32 shadow-sm" :disabled="!rule._builder_table">
-                                <option value="" disabled selected>选择字段...</option>
-                                <option v-for="col in (datasetTables.find((t: any) => t.physical_name === rule._builder_table)?.columns || [])" :key="col.physical_name" :value="col.physical_name">{{ col.physical_name }}</option>
-                             </select>
+                             <RowFilterOptionSelect
+                               v-model="rule._builder_field"
+                               :options="getColumnSelectOptions(rule._builder_table)"
+                               placeholder="选择字段..."
+                               :disabled="!rule._builder_table"
+                               button-class="border-slate-300 focus:ring-slate-500"
+                               menu-class="hover:bg-slate-50"
+                             />
                            </div>
 
                            <div class="space-y-1">
                              <label class="block text-[10px] text-slate-400 font-bold ml-1">操作符</label>
-                             <select v-model="rule._builder_op" class="bg-white border border-slate-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-slate-500 outline-none w-24 shadow-sm">
+                             <select v-model="rule._builder_op" class="h-[2.625rem] bg-white border border-slate-300 rounded-lg px-2 text-xs focus:ring-1 focus:ring-slate-500 outline-none w-28 shadow-sm">
                                 <option value="" disabled selected>操作符...</option>
                                 <option v-for="op in OPERATORS" :key="op.value" :value="op.value">{{ op.label }}</option>
                              </select>
@@ -2402,9 +2448,9 @@ relationships:
                            <div class="flex-1 space-y-1">
                              <label class="block text-[10px] text-slate-400 font-bold ml-1">过滤值/变量</label>
                              <div class="relative flex items-center gap-1">
-                               <input v-model="rule._builder_val" class="flex-1 w-full bg-white border border-slate-300 rounded-lg px-2 py-1.5 text-xs focus:ring-1 focus:ring-slate-500 outline-none min-w-[120px] shadow-sm" placeholder="e.g. {user.id}">
+                               <input v-model="rule._builder_val" class="flex-1 w-full h-[2.625rem] bg-white border border-slate-300 rounded-lg px-2 text-xs focus:ring-1 focus:ring-slate-500 outline-none min-w-[120px] shadow-sm" placeholder="e.g. {user.id}">
                                <!-- System variable dropdown trigger -->
-                               <button @click.stop="toggleMenu(`default-${idx}-vars`)" class="flex-shrink-0 w-8 h-8 rounded-lg text-emerald-600 hover:bg-emerald-50 transition-colors border border-emerald-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
+                               <button @click.stop="toggleMenu(`default-${idx}-vars`)" class="flex-shrink-0 h-[2.625rem] w-9 rounded-lg text-emerald-600 hover:bg-emerald-50 transition-colors border border-emerald-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
                                  { }
                                </button>
                                <div v-if="activeMenuPath === `default-${idx}-vars`" class="absolute right-0 top-full mt-1 w-36 bg-white rounded-lg shadow-xl border border-gray-100 z-[9999] max-h-48 overflow-y-auto custom-scrollbar">
@@ -2415,7 +2461,7 @@ relationships:
                              </div>
                            </div>
                            
-                           <button @click="appendBuilderCondition(rule)" class="bg-slate-700 hover:bg-slate-800 text-white w-10 h-8 rounded-lg flex items-center justify-center transition-all shadow-md disabled:opacity-30 disabled:scale-100 active:scale-95" :disabled="!rule._builder_table || !rule._builder_field || !rule._builder_op || !rule._builder_val" title="追加条件">
+                           <button @click="appendBuilderCondition(rule)" class="bg-slate-700 hover:bg-slate-800 text-white w-10 h-[2.625rem] rounded-lg flex items-center justify-center transition-all shadow-md disabled:opacity-30 disabled:scale-100 active:scale-95" :disabled="!rule._builder_table || !rule._builder_field || !rule._builder_op || !rule._builder_val" title="追加条件">
                              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/></svg>
                            </button>
                          </div>

--- a/frontend/src/views/PersonalCenter.vue
+++ b/frontend/src/views/PersonalCenter.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import axios from '../utils/axios'
 import Toast from '../components/Toast.vue'
+import { useBranding } from '../composables/useBranding'
+import { renderMarkdown } from '../utils/markdown'
+
+const { branding, loadBranding } = useBranding()
 
 const userInfo = ref<any>({})
 const userApiKey = ref('')
@@ -99,6 +103,9 @@ import Modal from '../components/Modal.vue'
 import ConfirmModal from '../components/ConfirmModal.vue'
 
 const activeTab = ref<'info' | 'permissions' | 'memory'>('info')
+const permissionsSubTab = ref<'list' | 'about'>('list')
+const showAboutTab = computed(() => !!branding.value.contact_markdown?.trim())
+const contactHtml = computed(() => renderMarkdown(branding.value.contact_markdown || ''))
 const loadingPermissions = ref(false)
 const permissions = ref<{
     roles?: string[],
@@ -506,6 +513,7 @@ watch(activeTab, (val) => {
 
 onMounted(() => {
     fetchUserInfo()
+    loadBranding()
 })
 </script>
 
@@ -681,6 +689,30 @@ onMounted(() => {
             </div>
             
             <div v-else class="space-y-4 sm:space-y-6">
+                <div v-if="showAboutTab" class="border-b border-gray-200">
+                    <nav class="-mb-px flex space-x-6">
+                        <button
+                            @click="permissionsSubTab = 'list'"
+                            class="whitespace-nowrap py-3 px-1 border-b-2 font-medium text-xs sm:text-sm transition-colors"
+                            :class="permissionsSubTab === 'list' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'"
+                        >
+                            权限清单
+                        </button>
+                        <button
+                            @click="permissionsSubTab = 'about'"
+                            class="whitespace-nowrap py-3 px-1 border-b-2 font-medium text-xs sm:text-sm transition-colors"
+                            :class="permissionsSubTab === 'about' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'"
+                        >
+                            关于
+                        </button>
+                    </nav>
+                </div>
+
+                <div v-if="permissionsSubTab === 'about' && showAboutTab" class="bg-gray-50 border border-gray-100 rounded-xl p-4 sm:p-6">
+                    <div class="markdown-body prose prose-sm max-w-none text-gray-700 break-words" v-html="contactHtml"></div>
+                </div>
+
+                <template v-else>
                 <!-- Helper Text -->
                 <div class="bg-gray-50 p-3 sm:p-4 rounded-lg text-xs sm:text-sm text-gray-600 flex items-start gap-3 border border-gray-100">
                     <svg class="w-5 h-5 text-gray-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -799,6 +831,7 @@ onMounted(() => {
                         </div>
                     </div>
                 </div>
+                </template>
             </div>
         </div>
 

--- a/frontend/src/views/SystemConfig.vue
+++ b/frontend/src/views/SystemConfig.vue
@@ -1036,19 +1036,19 @@ onMounted(() => {
                 <XCircleIcon v-else class="h-6 w-6 text-red-500" />
               </div>
             </div>
-            <div class="border-t border-gray-100 pt-4 mt-2 grid grid-cols-3 gap-3">
-              <button @click="testConnection('redis')" :disabled="loading.redis || !canSave" class="flex justify-center items-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none disabled:opacity-50">
-                <PlayIcon v-if="!loading.redis" class="h-4 w-4 mr-2" />
-                <span v-else class="animate-spin h-4 w-4 mr-2 border-2 border-white border-t-transparent rounded-full"></span>
+            <div class="border-t border-gray-100 pt-4 mt-2 flex flex-col gap-2">
+              <button @click="testConnection('redis')" :disabled="loading.redis || !canSave" class="w-full inline-flex justify-center items-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none disabled:opacity-50 whitespace-nowrap">
+                <PlayIcon v-if="!loading.redis" class="h-4 w-4 mr-2 shrink-0" />
+                <span v-else class="animate-spin h-4 w-4 mr-2 border-2 border-white border-t-transparent rounded-full shrink-0"></span>
                 {{ loading.redis ? '测试中...' : '测试连接' }}
               </button>
-               <button @click="scanRedisKeys" :disabled="loading.redis_scan || !canSave" class="flex justify-center items-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50">
-                <MagnifyingGlassIcon v-if="!loading.redis_scan" class="h-4 w-4 mr-2" />
-                <span v-else class="animate-spin h-4 w-4 mr-2 border-2 border-gray-400 border-t-transparent rounded-full"></span>
+               <button @click="scanRedisKeys" :disabled="loading.redis_scan || !canSave" class="w-full inline-flex justify-center items-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 whitespace-nowrap">
+                <MagnifyingGlassIcon v-if="!loading.redis_scan" class="h-4 w-4 mr-2 shrink-0" />
+                <span v-else class="animate-spin h-4 w-4 mr-2 border-2 border-gray-400 border-t-transparent rounded-full shrink-0"></span>
                 {{ loading.redis_scan ? '扫描中...' : '扫描 Keys' }}
               </button>
-              <button @click="openClearConfirm" :disabled="!canSave" class="flex justify-center items-center py-2 px-4 border border-red-300 rounded-md shadow-sm text-sm font-medium text-red-700 bg-red-50 hover:bg-red-100 disabled:opacity-50">
-                <TrashIcon class="h-4 w-4 mr-2" />
+              <button @click="openClearConfirm" :disabled="!canSave" class="w-full inline-flex justify-center items-center py-2 px-4 border border-red-300 rounded-md shadow-sm text-sm font-medium text-red-700 bg-red-50 hover:bg-red-100 disabled:opacity-50 whitespace-nowrap">
+                <TrashIcon class="h-4 w-4 mr-2 shrink-0" />
                 清理 Keys
               </button>
             </div>

--- a/frontend/src/views/SystemConfig.vue
+++ b/frontend/src/views/SystemConfig.vue
@@ -9,6 +9,7 @@ import ToolRegistry from '../components/system/ToolRegistry.vue'
 import McpServerRegistry from '../components/system/McpServerRegistry.vue'
 import RagFlowResourceSelector from '../components/RagFlowResourceSelector.vue'
 import ConfirmModal from '../components/ConfirmModal.vue'
+import RedisKeyCleanupModal from '../components/system/RedisKeyCleanupModal.vue'
 import {
   CircleStackIcon,
   CheckCircleIcon,
@@ -39,7 +40,6 @@ const logs = ref<string[]>([])
 const loading = ref<{ [key: string]: boolean }> ({
   redis: false,
   redis_scan: false,
-  redis_flush: false,
   redis_vector: false,
   rebuild_vector: false
 })
@@ -67,7 +67,7 @@ type VectorHealth = {
 const redisVectorHealth = ref<VectorHealth | null>(null)
 
 const { showToast } = useToast()
-const showClearConfirm = ref(false)
+const showRedisCleanupModal = ref(false)
 const showRebuildConfirm = ref(false)
 
 const appendLog = (msg: string) => {
@@ -187,28 +187,14 @@ const testRedisVectorSearch = async (force = true) => {
 }
 
 const openClearConfirm = () => {
-  showClearConfirm.value = true
+  showRedisCleanupModal.value = true
 }
 
-const executeClearKeys = async () => {
-  loading.value['redis_flush'] = true
-  showClearConfirm.value = false
-  appendLog('>>> 正在清空 Redis Keys...')
-
-  try {
-     const response = await axios.post('/api/portal/system/redis/flush')
-     const { message } = response.data
-     appendLog(`>>> ✅ ${message}`)
-     showToast('Redis 已清空', 'success')
-
-     // 自动重新扫描
-     scanRedisKeys()
-  } catch (e: any) {
-    const msg = e.response?.data?.detail || e.message
-    appendLog(`>>> ❌ 清空失败: ${msg}`)
-    showToast('清空失败', 'error')
-  } finally {
-    loading.value['redis_flush'] = false
+const handleRedisKeysDeleted = async (payload: { deletedCount: number; message: string }) => {
+  appendLog(`>>> ✅ ${payload.message}`)
+  showToast(`已删除 ${payload.deletedCount} 个 Key`, 'success')
+  if (diagSubTab.value === 'redis') {
+    await fetchRedisKeys()
   }
 }
 
@@ -1031,9 +1017,9 @@ onMounted(() => {
        </div>
 
        <!-- DIAGNOSTICS TAB -->
-       <div v-else-if="activeTab === 'diagnostics'" class="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full overflow-y-auto pb-6">
+       <div v-else-if="activeTab === 'diagnostics'" class="grid grid-cols-1 lg:grid-cols-3 gap-6 h-full overflow-y-auto pb-6">
         <!-- Left Column: Connection Checks -->
-        <div class="space-y-6">
+        <div class="space-y-6 lg:col-span-1">
           <div class="bg-white shadow rounded-lg p-6">
             <div class="flex items-center justify-between mb-4">
               <div class="flex items-center space-x-3">
@@ -1061,10 +1047,9 @@ onMounted(() => {
                 <span v-else class="animate-spin h-4 w-4 mr-2 border-2 border-gray-400 border-t-transparent rounded-full"></span>
                 {{ loading.redis_scan ? '扫描中...' : '扫描 Keys' }}
               </button>
-              <button @click="openClearConfirm" :disabled="loading.redis_flush || !canSave" class="flex justify-center items-center py-2 px-4 border border-red-300 rounded-md shadow-sm text-sm font-medium text-red-700 bg-red-50 hover:bg-red-100 disabled:opacity-50">
-                <TrashIcon v-if="!loading.redis_flush" class="h-4 w-4 mr-2" />
-                <span v-else class="animate-spin h-4 w-4 mr-2 border-2 border-red-400 border-t-transparent rounded-full"></span>
-                {{ loading.redis_flush ? '清空中...' : '清空 Keys' }}
+              <button @click="openClearConfirm" :disabled="!canSave" class="flex justify-center items-center py-2 px-4 border border-red-300 rounded-md shadow-sm text-sm font-medium text-red-700 bg-red-50 hover:bg-red-100 disabled:opacity-50">
+                <TrashIcon class="h-4 w-4 mr-2" />
+                清理 Keys
               </button>
             </div>
           </div>
@@ -1140,7 +1125,7 @@ onMounted(() => {
           </div>
         </div>
         <!-- Right Column: Console Output / Redis Browser -->
-        <div class="bg-white rounded-lg shadow flex flex-col h-[600px] border border-gray-100 overflow-hidden">
+        <div class="lg:col-span-2 bg-white rounded-lg shadow flex flex-col h-[600px] border border-gray-100 overflow-hidden">
           <div class="bg-gray-50 px-4 py-2.5 flex justify-between items-center border-b border-gray-200 flex-shrink-0">
             <div class="flex space-x-2">
               <button 
@@ -1505,15 +1490,10 @@ onMounted(() => {
         @select="handleDatasetSelect"
     />
 
-    <ConfirmModal
-      v-if="showClearConfirm"
-      title="清理系统缓存？"
-      message="此操作将清理系统缓存（如权限、临时数据），但会**保留**所有用户的对话历史。确定执行吗？"
-      confirm-text="确认清理"
-      cancel-text="取消"
-      type="warning"
-      @confirm="executeClearKeys"
-      @cancel="showClearConfirm = false"
+    <RedisKeyCleanupModal
+      :show="showRedisCleanupModal"
+      @close="showRedisCleanupModal = false"
+      @deleted="handleRedisKeysDeleted"
     />
 
     <ConfirmModal

--- a/frontend/src/views/SystemConfig.vue
+++ b/frontend/src/views/SystemConfig.vue
@@ -10,6 +10,7 @@ import McpServerRegistry from '../components/system/McpServerRegistry.vue'
 import RagFlowResourceSelector from '../components/RagFlowResourceSelector.vue'
 import ConfirmModal from '../components/ConfirmModal.vue'
 import RedisKeyCleanupModal from '../components/system/RedisKeyCleanupModal.vue'
+import Switch from '../components/Switch.vue'
 import {
   CircleStackIcon,
   CheckCircleIcon,
@@ -26,13 +27,14 @@ import {
   TrashIcon,
   ServerStackIcon,
   PlayIcon,
-  ArrowPathIcon
+  ArrowPathIcon,
+  PaintBrushIcon
 } from '@heroicons/vue/24/outline'
 
 const { hasPermission, userInfo } = useUser()
 const canSave = hasPermission('element:system:config_save')
 
-const activeTab = ref<'diagnostics' | 'configs' | 'models' | 'tools' | 'mcp' | 'logs'>('configs')
+const activeTab = ref<'diagnostics' | 'configs' | 'models' | 'tools' | 'mcp' | 'logs' | 'branding'>('configs')
 const diagSubTab = ref<'console' | 'redis'>('console')
 
 // --- Diagnostics Logic ---
@@ -278,7 +280,79 @@ const metadataProvider = computed(() => {
 const originalConfigs = ref<{ [key: string]: string }>({})
 const configLoading = ref(false)
 const saving = ref(false)
+const brandingSaving = ref(false)
+const brandingIconUploading = ref(false)
 const showSecrets = ref<{ [key: string]: boolean }>({})
+
+const brandingConfig = ref({
+  enabled: false,
+  product_name: '云枢 · 智能体平台',
+  login_subtitle: 'Yunshu Intelligent Agent Platform',
+  icon_url: '/favicon.png',
+  hide_login_sso: false,
+  hide_version_link: false,
+  contact_markdown: '',
+  copyright_text: '',
+})
+const brandingIconInput = ref<HTMLInputElement | null>(null)
+
+const fetchBrandingConfig = async () => {
+  try {
+    const res = await axios.get('/api/portal/system/branding')
+    const data = res.data || {}
+    brandingConfig.value = {
+      enabled: !!data.enabled,
+      product_name: data.product_name || '云枢 · 智能体平台',
+      login_subtitle: data.login_subtitle || 'Yunshu Intelligent Agent Platform',
+      icon_url: data.icon_url || '/favicon.png',
+      hide_login_sso: !!data.hide_login_sso,
+      hide_version_link: !!data.hide_version_link,
+      contact_markdown: data.contact_markdown || '',
+      copyright_text: data.copyright_text || '',
+    }
+  } catch {
+    showToast('品牌配置加载失败', 'error')
+  }
+}
+
+const saveBrandingConfig = async () => {
+  brandingSaving.value = true
+  try {
+    await axios.put('/api/portal/system/branding', { ...brandingConfig.value })
+    const { loadBranding } = await import('../composables/useBranding')
+    await loadBranding(true)
+    showToast('品牌配置已保存', 'success')
+  } catch (e: any) {
+    showToast(e.response?.data?.detail || '保存失败', 'error')
+  } finally {
+    brandingSaving.value = false
+  }
+}
+
+const triggerBrandingIconUpload = () => {
+  brandingIconInput.value?.click()
+}
+
+const onBrandingIconSelected = async (e: Event) => {
+  const input = e.target as HTMLInputElement
+  const file = input.files?.[0]
+  input.value = ''
+  if (!file) return
+  brandingIconUploading.value = true
+  try {
+    const form = new FormData()
+    form.append('file', file)
+    const res = await axios.post('/api/portal/system/branding/icon', form, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    brandingConfig.value.icon_url = res.data.icon_url
+    showToast('图标上传成功', 'success')
+  } catch (err: any) {
+    showToast(err.response?.data?.detail || '上传失败', 'error')
+  } finally {
+    brandingIconUploading.value = false
+  }
+}
 
 const fetchConfigs = async () => {
   configLoading.value = true
@@ -825,6 +899,7 @@ const executeDeleteKey = async () => {
 
 onMounted(() => {
   fetchConfigs()
+  fetchBrandingConfig()
   fetchModelsForConfigs()
   if (userInfo.value?.role === 'admin') {
     fetchLogConfig()
@@ -862,6 +937,14 @@ onMounted(() => {
          >
            <Cog6ToothIcon class="w-4 h-4 mr-2" />
            参数配置
+         </button>
+         <button
+           @click="activeTab = 'branding'"
+           class="px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 flex items-center"
+           :class="activeTab === 'branding' ? 'bg-white shadow text-primary' : 'text-gray-500 hover:text-gray-700'"
+         >
+           <PaintBrushIcon class="w-4 h-4 mr-2" />
+           品牌个性化
          </button>
          <button
            @click="activeTab = 'mcp'"
@@ -1261,8 +1344,127 @@ onMounted(() => {
         </div>
       </div>
 
+      <!-- BRANDING TAB -->
+      <div v-else-if="activeTab === 'branding'" class="h-full overflow-y-auto pb-6 custom-scrollbar">
+        <div class="max-w-3xl space-y-6">
+          <div class="flex items-center justify-between bg-white shadow rounded-lg p-6">
+            <div>
+              <h3 class="text-lg font-bold text-gray-900">品牌个性化</h3>
+              <p class="text-sm text-gray-500 mt-1">开启后可自定义产品名称、登录页、图标与联系信息</p>
+            </div>
+            <Switch v-model="brandingConfig.enabled" :disabled="!canSave" />
+          </div>
+
+          <fieldset :disabled="!brandingConfig.enabled || !canSave" class="bg-white shadow rounded-lg p-6 space-y-5 disabled:opacity-60">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">产品名称</label>
+              <input
+                v-model="brandingConfig.product_name"
+                type="text"
+                class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary focus:ring-primary text-sm"
+                placeholder="云枢 · 智能体平台"
+              />
+              <p class="text-xs text-gray-400 mt-1">影响浏览器标题、左侧菜单栏名称、登录页</p>
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">登录页副标题</label>
+              <input
+                v-model="brandingConfig.login_subtitle"
+                type="text"
+                class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary focus:ring-primary text-sm"
+                placeholder="Yunshu Intelligent Agent Platform"
+              />
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">Logo / Favicon</label>
+              <div class="flex items-center gap-4">
+                <img
+                  :src="brandingConfig.icon_url || '/favicon.png'"
+                  alt="Logo 预览"
+                  class="w-12 h-12 rounded-lg border border-gray-200 object-cover bg-white"
+                />
+                <div class="flex-1 space-y-2">
+                  <input
+                    v-model="brandingConfig.icon_url"
+                    type="text"
+                    class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary focus:ring-primary text-sm font-mono"
+                    placeholder="/favicon.png 或 /branding/icon.png"
+                  />
+                  <button
+                    type="button"
+                    class="text-sm text-primary hover:text-primary/80 disabled:opacity-50"
+                    :disabled="brandingIconUploading || !brandingConfig.enabled"
+                    @click="triggerBrandingIconUpload"
+                  >
+                    {{ brandingIconUploading ? '上传中...' : '上传图片' }}
+                  </button>
+                  <input
+                    ref="brandingIconInput"
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp,image/svg+xml"
+                    class="hidden"
+                    @change="onBrandingIconSelected"
+                  />
+                </div>
+              </div>
+              <p class="text-xs text-gray-400 mt-1">用于登录页、侧栏左上角与浏览器标签图标（PNG/JPEG/WebP/SVG，最大 512KB）</p>
+            </div>
+
+            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 py-2 border-t border-gray-100">
+              <div>
+                <p class="text-sm font-medium text-gray-700">隐藏登录页 SSO</p>
+                <p class="text-xs text-gray-400">开启后登录页不再显示 SSO 登录 Tab</p>
+              </div>
+              <Switch v-model="brandingConfig.hide_login_sso" />
+            </div>
+
+            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 py-2 border-t border-gray-100">
+              <div>
+                <p class="text-sm font-medium text-gray-700">隐藏版本号外链</p>
+                <p class="text-xs text-gray-400">开启后侧栏版本号不再链接到 GitHub，并隐藏 GitHub 图标</p>
+              </div>
+              <Switch v-model="brandingConfig.hide_version_link" />
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">联系信息（Markdown）</label>
+              <textarea
+                v-model="brandingConfig.contact_markdown"
+                rows="8"
+                class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary focus:ring-primary text-sm font-mono"
+                placeholder="支持 Markdown，将在「个人中心 → 我的权限 → 关于」中展示"
+              />
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">版权信息</label>
+              <input
+                v-model="brandingConfig.copyright_text"
+                type="text"
+                class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary focus:ring-primary text-sm"
+                placeholder="© 2026 公司名称 · All Rights Reserved"
+              />
+              <p class="text-xs text-gray-400 mt-1">启用品牌个性化后，显示在登录页底部（小字展示，支持换行）</p>
+            </div>
+          </fieldset>
+
+          <div class="flex justify-end">
+            <button
+              type="button"
+              :disabled="brandingSaving || !canSave"
+              class="inline-flex items-center px-6 py-2 text-sm font-medium rounded-md text-white bg-primary hover:bg-primary/90 disabled:opacity-50"
+              @click="saveBrandingConfig"
+            >
+              {{ brandingSaving ? '保存中...' : '保存品牌配置' }}
+            </button>
+          </div>
+        </div>
+      </div>
+
       <!-- CONFIGS TAB -->
-      <div v-else class="h-full overflow-y-auto pb-6 custom-scrollbar">
+      <div v-else-if="activeTab === 'configs'" class="h-full overflow-y-auto pb-6 custom-scrollbar">
          <div v-if="configLoading" class="flex justify-center py-20">
              <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
          </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,8 @@ agentscope[service,storage,workspace]
 openai>=1.0.0
 atlassian-python-api>=3.41.11
 oracledb>=2.0.0
+aioodbc>=0.5.0
+pyodbc>=5.0.0
 APScheduler>=3.10.1
 mcp>=1.0.0
 pandas>=2.0.0

--- a/tests/ai/runners/test_data_agent_runner.py
+++ b/tests/ai/runners/test_data_agent_runner.py
@@ -4346,6 +4346,36 @@ def test_format_tool_details_includes_sql_on_success(data_config):
     assert '\n  "items"' in details or '\n  "columns"' in details
 
 
+def test_format_tool_details_uses_executed_sql_when_row_filter_applied(data_config):
+    from app.services.ai.runners.data_agent_runner import DataAgentRunner, _DataRunState
+
+    runner = DataAgentRunner(config=data_config, trace_id="trace-executed-sql", trace_buffer=[])
+    payload = json.dumps(
+        {
+            "columns": [],
+            "items": [["a"]],
+            "permission_notice": {
+                "row_filter_applied": True,
+                "dataset_name": "demo",
+                "rule_count": 1,
+                "message": "已按你的数据权限自动过滤结果",
+                "executed_sql": "SELECT metric FROM demo WHERE dept_code = 'D001' LIMIT 10",
+            },
+        },
+        ensure_ascii=False,
+    )
+    tool_args = {
+        "sql": "SELECT metric FROM demo LIMIT 10",
+        "data_source": "clickhouse_ops",
+        "dataset_name": "demo",
+    }
+    details = runner._format_tool_details("execute_sql_query", payload, _DataRunState(), tool_args)
+    assert details.startswith(
+        "[Executed SQL]:\nSELECT metric FROM demo WHERE dept_code = 'D001' LIMIT 10\n\n--- 结果 ---\n"
+    )
+    assert '"executed_sql"' not in details
+
+
 def test_format_sql_result_pretty_print_with_row_cap(data_config):
     from app.services.ai.runners.data_agent_runner import DataAgentRunner
 

--- a/tests/api/portal/test_agent_management.py
+++ b/tests/api/portal/test_agent_management.py
@@ -137,3 +137,55 @@ async def test_duplicate_agent_name(db_session):
         
         # Cleanup
         await client.delete(f"/api/portal/agents/{id1}", headers={"X-API-Key": admin_key})
+
+@pytest.mark.asyncio
+async def test_agent_reorder(db_session):
+    """Verify batch reorder updates sort_order (desc: higher value appears first)."""
+    admin_key = await AuthService.generate_api_key(f"test_admin_r_{unique_id()}", role="admin", db=db_session)
+    user_key = await AuthService.generate_api_key(f"test_user_r_{unique_id()}", role="user", db=db_session)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        created_ids = []
+        for idx, name_suffix in enumerate(["a", "b", "c"]):
+            resp = await client.post(
+                "/api/portal/agents/",
+                json={
+                    "name": f"reorder-agent-{name_suffix}-{unique_id()}",
+                    "display_name": f"Agent {name_suffix.upper()}",
+                    "sort_order": (3 - idx) * 10,
+                },
+                headers={"X-API-Key": admin_key},
+            )
+            assert resp.status_code == 200
+            created_ids.append(resp.json()["id"])
+
+        # Reverse order: last agent should become first
+        reorder_payload = {
+            "items": [
+                {"id": created_ids[2], "sort_order": 30},
+                {"id": created_ids[0], "sort_order": 20},
+                {"id": created_ids[1], "sort_order": 10},
+            ]
+        }
+        resp = await client.post(
+            "/api/portal/agents/reorder",
+            json=reorder_payload,
+            headers={"X-API-Key": admin_key},
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get("/api/portal/agents/", headers={"X-API-Key": admin_key})
+        assert resp.status_code == 200
+        ordered = [a["id"] for a in resp.json() if a["id"] in created_ids]
+        assert ordered[0] == created_ids[2]
+
+        # Non-admin cannot reorder
+        resp = await client.post(
+            "/api/portal/agents/reorder",
+            json=reorder_payload,
+            headers={"X-API-Key": user_key},
+        )
+        assert resp.status_code == 403
+
+        for agent_id in created_ids:
+            await client.delete(f"/api/portal/agents/{agent_id}", headers={"X-API-Key": admin_key})

--- a/tests/api/portal/test_saved_reports.py
+++ b/tests/api/portal/test_saved_reports.py
@@ -41,6 +41,12 @@ def _report_row(**overrides):
     return SimpleNamespace(**data)
 
 
+def _today_range_sql() -> str:
+    start = date.today()
+    end = date.fromordinal(start.toordinal() + 1)
+    return f"SELECT * FROM orders WHERE created_at >= '{start.isoformat()}' AND created_at < '{end.isoformat()}'"
+
+
 class _ScalarResult:
     def __init__(self, values):
         self._values = values
@@ -160,7 +166,7 @@ async def test_preview_saved_report_returns_rendered_sql_and_permission_status(m
 
     async def fake_execute_sql_query_core(*args, **kwargs):
         assert kwargs["auth_check_only"] is True
-        assert kwargs["sql"] == "SELECT * FROM orders WHERE created_at >= '2026-06-27' AND created_at < '2026-06-28'"
+        assert kwargs["sql"] == _today_range_sql()
         return json.dumps({"allowed": True})
 
     monkeypatch.setattr(saved_reports, "_get_user_role_ids", AsyncMock(return_value=[]))
@@ -175,7 +181,7 @@ async def test_preview_saved_report_returns_rendered_sql_and_permission_status(m
     )
 
     assert response.data.report_id == "rpt_5"
-    assert response.data.rendered_sql == "SELECT * FROM orders WHERE created_at >= '2026-06-27' AND created_at < '2026-06-28'"
+    assert response.data.rendered_sql == _today_range_sql()
     assert response.data.permission_status == "allowed"
     assert response.data.can_run is True
     assert response.data.data_source == "mysql_test"
@@ -589,7 +595,7 @@ async def test_execute_saved_report_uses_rendered_sql_and_enables_table_auth(mon
     )
 
     assert response.data == {"items": [{"orders": 3}]}
-    assert captured["sql"] == "SELECT * FROM orders WHERE created_at >= '2026-06-27' AND created_at < '2026-06-28'"
+    assert captured["sql"] == _today_range_sql()
     assert captured["bypass_table_auth"] is False
     assert report_row.last_success_at is not None
     db.flush.assert_awaited_once()

--- a/tests/api/v1/test_chat_refresh_group_questions.py
+++ b/tests/api/v1/test_chat_refresh_group_questions.py
@@ -57,7 +57,6 @@ async def test_refresh_group_questions_api_success():
                 kwargs = mock_refresh.await_args.kwargs
                 assert kwargs["user_id"] == 7
                 assert kwargs["is_admin"] is False
-                assert kwargs["dataset_menu_hash"] == "abc123"
                 assert kwargs["group_id"] == "ai-agent-meta"
                 assert kwargs["exclude_questions"][0]["query"] == "分析最近一周的智能体访问量"
         finally:

--- a/tests/api/v1/test_chatbi_execute.py
+++ b/tests/api/v1/test_chatbi_execute.py
@@ -2,12 +2,14 @@ import pytest
 import json
 import asyncio
 from unittest.mock import MagicMock, AsyncMock, patch
+from fastapi import HTTPException
 from httpx import AsyncClient
 from pydantic import ValidationError
 from types import SimpleNamespace
 
 from app.api.v1.endpoints import chatbi
 from app.api.v1.endpoints.chatbi import ChatBiSqlExecuteRequest
+from app.services.ai.chatbi_sql_query_binding import TableBinding
 
 # 构造 Mock Dataset
 mock_dataset = SimpleNamespace(
@@ -38,6 +40,18 @@ async def test_chatbi_execute_request_requires_sessionid():
 
 
 @pytest.mark.no_infrastructure
+def test_chatbi_execute_request_accepts_optional_dataset_name():
+    body = ChatBiSqlExecuteRequest.model_validate({
+        "sql": "SELECT 1",
+        "data_source": "default_clickhouse",
+        "dataset_name": "sales_dataset",
+        "sessionid": "openclaw-session-1",
+    })
+
+    assert body.dataset_name == "sales_dataset"
+
+
+@pytest.mark.no_infrastructure
 def test_openclaw_openai_sessionid_extracts_username():
     username = chatbi._openclaw_openai_username_from_sessionid(
         "agent:chatbi_bot:openai-user:chenxiaolong-6c03b966-9d89-413d-8138-01aa395e6ea2"
@@ -60,6 +74,7 @@ async def test_openclaw_session_auth_uses_session_username(monkeypatch):
     body = ChatBiSqlExecuteRequest.model_validate({
         "sql": "SELECT 1",
         "data_source": "default_clickhouse",
+        "dataset_name": "sales_dataset",
         "sessionid": "agent:chatbi_bot:openai-user:chenxiaolong-6c03b966-9d89-413d-8138-01aa395e6ea2",
     })
     captured = {}
@@ -87,8 +102,203 @@ async def test_openclaw_session_auth_uses_session_username(monkeypatch):
 
     assert captured["username"] == "chenxiaolong"
     assert captured["auth_kwargs"]["user_id"] == 42
+    assert captured["auth_kwargs"]["dataset_name"] == "sales_dataset"
     assert captured["auth_kwargs"]["auth_check_only"] is True
     assert captured["auth_kwargs"]["dry_run"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_direct_sql_dataset_name_infers_unique_dataset(monkeypatch):
+    async def fake_resolve_table_bindings_from_db(db, physical_names):
+        assert physical_names == ["orders", "customers"]
+        return {
+            "orders": TableBinding(physical_name="orders", dataset_name="sales_dataset"),
+            "customers": TableBinding(physical_name="customers", dataset_name="sales_dataset"),
+        }
+
+    monkeypatch.setattr(
+        chatbi,
+        "extract_physical_table_refs_from_select_sql",
+        lambda sql, dialect: (None, {"orders": "orders", "customers": "customers"}),
+    )
+    monkeypatch.setattr(chatbi, "resolve_table_bindings_from_db", fake_resolve_table_bindings_from_db)
+
+    dataset_name = await chatbi._resolve_direct_sql_dataset_name(
+        AsyncMock(),
+        sql="SELECT * FROM orders JOIN customers ON orders.customer_id = customers.id",
+        data_source="mysql_test",
+        explicit_dataset_name=None,
+    )
+
+    assert dataset_name == "sales_dataset"
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_direct_sql_dataset_name_rejects_cross_dataset(monkeypatch):
+    async def fake_resolve_table_bindings_from_db(db, physical_names):
+        return {
+            "orders": TableBinding(physical_name="orders", dataset_name="sales_dataset"),
+            "tickets": TableBinding(physical_name="tickets", dataset_name="support_dataset"),
+        }
+
+    monkeypatch.setattr(
+        chatbi,
+        "extract_physical_table_refs_from_select_sql",
+        lambda sql, dialect: (None, {"orders": "orders", "tickets": "tickets"}),
+    )
+    monkeypatch.setattr(chatbi, "resolve_table_bindings_from_db", fake_resolve_table_bindings_from_db)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await chatbi._resolve_direct_sql_dataset_name(
+            AsyncMock(),
+            sql="SELECT * FROM orders JOIN tickets ON orders.id = tickets.order_id",
+            data_source="mysql_test",
+            explicit_dataset_name=None,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "跨数据集" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_direct_sql_dataset_inference_rejects_when_row_filter_required(monkeypatch):
+    async def fake_resolve_table_bindings_from_db(db, physical_names):
+        return {
+            "orders": TableBinding(physical_name="orders", dataset_name="sales_dataset"),
+        }
+
+    async def fake_get_dataset_by_name(_db, name):
+        return SimpleNamespace(enable_data_perm=True) if name == "sales_dataset" else None
+
+    monkeypatch.setattr(
+        chatbi,
+        "extract_physical_table_refs_from_select_sql",
+        lambda sql, dialect: (None, {"orders": "orders", "customers": "customers"}),
+    )
+    monkeypatch.setattr(chatbi, "resolve_table_bindings_from_db", fake_resolve_table_bindings_from_db)
+    monkeypatch.setattr(chatbi.MetadataService, "get_dataset_by_name", fake_get_dataset_by_name)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await chatbi._resolve_direct_sql_dataset_name(
+            AsyncMock(),
+            sql="SELECT * FROM orders JOIN customers ON orders.customer_id = customers.id",
+            data_source="mysql_test",
+            explicit_dataset_name=None,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "行级数据权限" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_chatbi_execute_passes_explicit_dataset_name(monkeypatch):
+    body = ChatBiSqlExecuteRequest.model_validate({
+        "sql": "SELECT COUNT(*) FROM orders",
+        "data_source": "mysql_test",
+        "dataset_name": "sales_dataset",
+        "sessionid": "openclaw-session-1",
+    })
+    user_info = {
+        "user_id": "7",
+        "user_name": "alice",
+        "real_name": "Alice",
+        "role": "user",
+        "dept_code": "D001",
+        "org_path": "/D001",
+        "extra_data": "",
+    }
+    captured = {}
+
+    async def fake_execute_sql_query_core(*args, **kwargs):
+        captured.update(kwargs)
+        return json.dumps({"columns": [], "items": []})
+
+    monkeypatch.setattr(chatbi, "execute_sql_query_core", fake_execute_sql_query_core)
+
+    with patch.dict("os.environ", {"SQL_EXECUTION_MODE": "local"}):
+        await chatbi.chatbi_sql_execute(body, user_info=user_info, db=AsyncMock())
+
+    assert captured["dataset_name"] == "sales_dataset"
+    assert captured["user_dimensions"]["dept_code"] == "D001"
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_chatbi_execute_returns_permission_notice_when_row_filter_applied(monkeypatch):
+    body = ChatBiSqlExecuteRequest.model_validate({
+        "sql": "SELECT COUNT(*) FROM orders",
+        "data_source": "mysql_test",
+        "dataset_name": "sales_dataset",
+        "sessionid": "openclaw-session-1",
+    })
+    user_info = {
+        "user_id": "7",
+        "user_name": "alice",
+        "real_name": "Alice",
+        "role": "user",
+        "dept_code": "D001",
+        "org_path": "/D001",
+        "extra_data": "",
+    }
+
+    async def fake_execute_sql_query_core(*args, **kwargs):
+        kwargs["permission_notice"]["row_filter_applied"] = True
+        kwargs["permission_notice"]["dataset_name"] = "sales_dataset"
+        kwargs["permission_notice"]["rule_count"] = 2
+        kwargs["permission_notice"]["message"] = "已按你的数据权限自动过滤结果"
+        return json.dumps({"columns": [], "items": []})
+
+    monkeypatch.setattr(chatbi, "execute_sql_query_core", fake_execute_sql_query_core)
+
+    with patch.dict("os.environ", {"SQL_EXECUTION_MODE": "local"}):
+        response = await chatbi.chatbi_sql_execute(body, user_info=user_info, db=AsyncMock())
+
+    assert response.data.permission_notice == {
+        "row_filter_applied": True,
+        "dataset_name": "sales_dataset",
+        "rule_count": 2,
+        "message": "已按你的数据权限自动过滤结果",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_chatbi_checkauth_passes_explicit_dataset_name(monkeypatch):
+    body = chatbi.ChatBiSqlCheckAuthRequest.model_validate({
+        "username": "alice",
+        "sql": "SELECT COUNT(*) FROM orders",
+        "data_source": "mysql_test",
+        "dataset_name": "sales_dataset",
+    })
+    captured = {}
+
+    async def fake_resolve_user_by_username(username, db):
+        return {
+            "user_id": "7",
+            "user_name": username,
+            "real_name": "Alice",
+            "role": "user",
+            "dept_code": "D001",
+            "org_path": "/D001",
+            "extra_data": "",
+        }
+
+    async def fake_execute_sql_query_core(*args, **kwargs):
+        captured.update(kwargs)
+        return json.dumps({"allowed": True})
+
+    monkeypatch.setattr(chatbi.AuthService, "resolve_user_by_username", fake_resolve_user_by_username)
+    monkeypatch.setattr(chatbi, "execute_sql_query_core", fake_execute_sql_query_core)
+
+    with patch.dict("os.environ", {"SQL_EXECUTION_MODE": "local"}):
+        await chatbi.chatbi_sql_checkauth(body, db=AsyncMock())
+
+    assert captured["dataset_name"] == "sales_dataset"
+    assert captured["auth_check_only"] is True
 
 
 @pytest.mark.asyncio
@@ -130,6 +340,7 @@ async def test_chatbi_execute_uses_session_user_for_openclaw_sql_execution(monke
 
     monkeypatch.setattr(chatbi.AuthService, "resolve_user_by_username", fake_resolve_user_by_username)
     monkeypatch.setattr(chatbi, "execute_sql_query_core", fake_execute_sql_query_core)
+    monkeypatch.setattr(chatbi, "resolve_table_bindings_from_db", AsyncMock(return_value={}))
 
     with patch.dict("os.environ", {"SQL_EXECUTION_MODE": "local"}):
         await chatbi.chatbi_sql_execute(body, user_info=api_key_user, db=AsyncMock())

--- a/tests/frontend/test_dataset_menu_loading_contract.py
+++ b/tests/frontend/test_dataset_menu_loading_contract.py
@@ -172,13 +172,36 @@ def test_saved_report_parameterized_execution_contract():
     assert "!reportRunPreview" in source
 
 
+def test_row_permission_notice_renders_above_chatbi_results():
+    embed_source = _source("frontend/src/views/EmbedChat.vue")
+    debug_source = _source("frontend/src/views/AgentDebug.vue")
+    react_stream_source = _source("app/services/ai/runners/chatbi/react_stream.py")
+    data_api_source = _source("app/services/ai/tools/data_api.py")
+
+    for source in (embed_source, debug_source):
+        assert "interface PermissionNotice" in source
+        assert "permissionNotice?: PermissionNotice;" in source
+        assert "msg.permissionNotice?.row_filter_applied" in source
+        assert "已按你的数据权限自动过滤结果" in source
+        assert "agentMsg.value.permissionNotice = execResult?.permission_notice" in source
+        assert "data.permission_notice" in source
+
+    assert '"type": "meta", "permission_notice": notice' in react_stream_source
+    assert '"row_filter_applied": True' in react_stream_source or 'log_payload["row_filter_applied"] = True' in react_stream_source
+    assert "logHasRowFilterApplied" in embed_source
+    assert "logHasRowFilterApplied" in debug_source
+    assert "resolve_executed_sql_for_tool_log" in _source("app/services/ai/runners/chatbi/tool_result_handlers.py")
+    assert "attach_permission_notice_to_json_result" in data_api_source
+    assert "permission_notice=permission_notice" in data_api_source
+
+
 def test_saved_report_tags_are_not_raw_question_prefixes():
     embed_source = _source("frontend/src/views/EmbedChat.vue")
     debug_source = _source("frontend/src/views/AgentDebug.vue")
 
     for source in (embed_source, debug_source):
         assert "deriveSavedReportTagsInput" in source
-        assert "tags_input: deriveSavedReportTagsInput(originalQuery)" in source
+        assert "tags_input: deriveSavedReportTagsInput(requirementIntent, originalQuery)" in source
         assert "originalQuery.slice(0, 12)" not in source
 
 

--- a/tests/frontend/test_redis_key_groups.py
+++ b/tests/frontend/test_redis_key_groups.py
@@ -1,0 +1,26 @@
+"""Contract tests for Redis key grouping utility used in cleanup modal."""
+
+from pathlib import Path
+
+
+def test_redis_key_groups_module_exists():
+    path = Path("frontend/src/utils/redisKeyGroups.ts")
+    assert path.exists()
+
+
+def test_redis_key_groups_supports_type_and_business_modes():
+    content = Path("frontend/src/utils/redisKeyGroups.ts").read_text(encoding="utf-8")
+    assert "groupRedisKeys" in content
+    assert "'redis_type'" in content or '"redis_type"' in content
+    assert "'business'" in content or '"business"' in content
+    assert "conversation:" in content
+
+
+def test_redis_cleanup_modal_wired_in_system_config():
+    modal = Path("frontend/src/components/system/RedisKeyCleanupModal.vue").read_text(encoding="utf-8")
+    content = Path("frontend/src/views/SystemConfig.vue").read_text(encoding="utf-8")
+    assert "RedisKeyCleanupModal" in content
+    assert "清理 Keys" in content
+    assert "/api/portal/system/redis/delete-keys" in modal
+    assert "查看详情" in modal
+    assert "/api/portal/system/redis/key-detail" in modal

--- a/tests/services/test_branding_settings_service.py
+++ b/tests/services/test_branding_settings_service.py
@@ -1,0 +1,89 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.branding_settings_service import (
+    BrandingSettingsService,
+    DEFAULT_ICON_URL,
+    DEFAULT_LOGIN_SUBTITLE,
+    DEFAULT_PRODUCT_NAME,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_public_branding_disabled_uses_defaults():
+    with patch.object(
+        BrandingSettingsService,
+        "get_raw_settings",
+        new=AsyncMock(
+            return_value={
+                "enabled": False,
+                "product_name": "自定义名称",
+                "login_subtitle": "Custom",
+                "icon_url": "/custom.png",
+                "hide_login_sso": True,
+                "hide_version_link": True,
+                "contact_markdown": "联系管理员",
+                "copyright_text": "© Test",
+            }
+        ),
+    ):
+        result = await BrandingSettingsService.get_public_branding()
+
+    assert result["enabled"] is False
+    assert result["product_name"] == DEFAULT_PRODUCT_NAME
+    assert result["login_subtitle"] == DEFAULT_LOGIN_SUBTITLE
+    assert result["icon_url"] == DEFAULT_ICON_URL
+    assert result["hide_login_sso"] is False
+    assert result["hide_version_link"] is False
+    assert result["contact_markdown"] == ""
+    assert result["copyright_text"] == ""
+
+
+@pytest.mark.asyncio
+async def test_get_public_branding_enabled_returns_custom():
+    with patch.object(
+        BrandingSettingsService,
+        "get_raw_settings",
+        new=AsyncMock(
+            return_value={
+                "enabled": True,
+                "product_name": "企业智能体平台",
+                "login_subtitle": "Enterprise Agent",
+                "icon_url": "/branding/icon.png",
+                "hide_login_sso": True,
+                "hide_version_link": True,
+                "contact_markdown": "**技术支持**",
+                "copyright_text": "© 2026 Demo",
+            }
+        ),
+    ):
+        result = await BrandingSettingsService.get_public_branding()
+
+    assert result["enabled"] is True
+    assert result["product_name"] == "企业智能体平台"
+    assert result["hide_login_sso"] is True
+    assert result["contact_markdown"] == "**技术支持**"
+    assert result["copyright_text"] == "© 2026 Demo"
+
+
+@pytest.mark.asyncio
+async def test_update_settings_persists_all_keys():
+    with patch("app.services.branding_settings_service.ConfigService.set_config", new=AsyncMock()) as mock_set:
+        await BrandingSettingsService.update_settings(
+            enabled=True,
+            product_name="A",
+            login_subtitle="B",
+            icon_url="/icon.png",
+            hide_login_sso=True,
+            hide_version_link=True,
+            contact_markdown="hello",
+            copyright_text="© Co",
+            changed_by="admin",
+        )
+
+    assert mock_set.await_count == 8
+    keys = [call.kwargs.get("key") or call.args[0] for call in mock_set.await_args_list]
+    assert BrandingSettingsService.CONFIG_ENABLED in keys
+    assert BrandingSettingsService.CONFIG_CONTACT_MARKDOWN in keys
+    assert BrandingSettingsService.CONFIG_COPYRIGHT_TEXT in keys

--- a/tests/services/test_data_adapters.py
+++ b/tests/services/test_data_adapters.py
@@ -4,6 +4,7 @@ from app.services.data_adapter.base import SQLSafetyError
 from app.services.data_adapter.mysql import MySQLAdapter
 from app.services.data_adapter.clickhouse import ClickHouseAdapter
 from app.services.data_adapter.oracle import OracleAdapter
+from app.services.data_adapter.sqlserver import SQLServerAdapter
 
 # 测试 SQL 安全策略校验（基于基类的 _validate_sql_safety 逻辑）
 @pytest.mark.no_infrastructure
@@ -185,3 +186,57 @@ async def test_oracle_adapter():
         res = await adapter.execute_sql("SELECT ID, NAME FROM T_USER")
         assert res["items"] == [[1, "Oracle"]]
         assert res["columns"] == [{"name": "ID", "type": "None"}, {"name": "NAME", "type": "None"}]
+
+
+@pytest.mark.asyncio
+async def test_sqlserver_adapter():
+    adapter = SQLServerAdapter(source_id=4)
+
+    mock_rows = [("dbo_users", "BASE TABLE"), ("dbo_user_view", "VIEW")]
+    mock_cursor = AsyncMock()
+    mock_cursor.fetchall.return_value = mock_rows
+
+    mock_conn = MagicMock()
+    mock_cursor_cm = MagicMock()
+    mock_cursor_cm.__aenter__ = AsyncMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value = mock_cursor_cm
+
+    mock_pool = MagicMock()
+    mock_conn_cm = MagicMock()
+    mock_conn_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_pool.acquire.return_value = mock_conn_cm
+
+    with patch("app.services.pool_manager.DataSourcePoolManager.get_pool", return_value=mock_pool):
+        tables = await adapter.get_tables()
+        assert len(tables) == 2
+        assert tables[0] == {"name": "dbo_users", "type": "TABLE"}
+        assert tables[1] == {"name": "dbo_user_view", "type": "VIEW"}
+        assert "INFORMATION_SCHEMA.TABLES" in mock_cursor.execute.call_args[0][0]
+
+        mock_cursor.description = [("id", str), ("name", str)]
+        cols = await adapter.get_columns(table_name="dbo_users")
+        assert len(cols) == 2
+        assert cols[0] == {"name": "id", "type": "String", "comment": ""}
+        mock_cursor.execute.assert_called_with("SELECT TOP 0 * FROM [dbo_users]")
+
+        cols_custom = await adapter.get_columns(
+            custom_sql="SELECT * FROM dbo_users WHERE id = {{ user_id }}",
+            params={"user_id": 123},
+        )
+        assert len(cols_custom) == 2
+        mock_cursor.execute.assert_called_with(
+            "SELECT TOP 0 * FROM (SELECT * FROM dbo_users WHERE id = 123) AS t"
+        )
+
+        mock_cursor.fetchall.return_value = [(1, "MSSQL")]
+        res = await adapter.execute_sql("SELECT id, name FROM dbo_users")
+        assert res["items"] == [[1, "MSSQL"]]
+        assert res["columns"] == [{"name": "id", "type": "<class 'str'>"}, {"name": "name", "type": "<class 'str'>"}]
+
+        mock_cursor.fetchall.return_value = [(1, "MSSQL")]
+        res_preview = await adapter.preview("SELECT id, name FROM dbo_users", limit=50)
+        assert len(res_preview["rows"]) == 1
+        assert mock_cursor.execute.call_args[0][0].upper().startswith("SELECT TOP 50")
+
+        with pytest.raises(ValueError, match="安全策略违规"):
+            await adapter.preview("UPDATE dbo_users SET name = '{{ name }}'", params={"name": "MSSQL"})

--- a/tests/services/test_dataset_navigation_service.py
+++ b/tests/services/test_dataset_navigation_service.py
@@ -371,13 +371,14 @@ async def test_record_question_click_stores_redis_rank_and_metadata():
         await DatasetNavigationService.record_question_click(
             user_id=7,
             is_admin=False,
-            dataset_menu_hash="abc123",
             query="查询智能体访问日志最近10条明细记录",
             label="查询明细",
             group_id="ai_agent_meta",
         )
 
     redis.zincrby.assert_awaited_once()
+    rank_call = redis.zincrby.await_args
+    assert rank_call.args[0] == "agent:dataset_navigation_click_rank:7"
     redis.hset.assert_awaited_once()
     assert redis.expire.await_count == 2
 
@@ -392,11 +393,11 @@ async def test_clear_question_click_removes_redis_rank_and_metadata():
         cleared = await DatasetNavigationService.clear_question_click(
             user_id=7,
             is_admin=False,
-            dataset_menu_hash="abc123",
             query="查询智能体访问日志最近10条明细记录",
         )
 
     assert cleared is True
+    assert redis.zrem.await_args.args[0] == "agent:dataset_navigation_click_rank:7"
     redis.zrem.assert_awaited_once()
     redis.hdel.assert_awaited_once()
 
@@ -550,12 +551,26 @@ async def test_build_navigation_for_user_sets_llm_generation_failed():
 
 @pytest.mark.asyncio
 @pytest.mark.no_infrastructure
-async def test_bump_navigation_cache_generation_increments_redis_counter():
-    redis = AsyncMock()
-    redis.incr = AsyncMock(return_value=2)
-    with patch("app.services.dataset_navigation_service.get_redis", AsyncMock(return_value=redis)):
-        await DatasetNavigationService.bump_navigation_cache_generation()
-    redis.incr.assert_awaited_once()
+async def test_invalidate_all_navigation_caches_deletes_portal_keys():
+    deleted = []
+
+    class FakeRedis:
+        async def scan_iter(self, match, count=200):
+            if match == "agent:dataset_navigation:*":
+                yield "agent:dataset_navigation:7"
+                yield "agent:dataset_navigation:7:legacy:hash:v5:0"
+            elif match == "agent:dataset_navigation_click_rank:*":
+                yield "agent:dataset_navigation_click_rank:7"
+
+        async def delete(self, *keys):
+            deleted.extend(keys)
+
+    with patch("app.services.dataset_navigation_service.get_redis", AsyncMock(return_value=FakeRedis())):
+        await DatasetNavigationService.invalidate_all_navigation_caches()
+
+    assert "agent:dataset_navigation:7" in deleted
+    assert "agent:dataset_navigation:7:legacy:hash:v5:0" in deleted
+    assert "agent:dataset_navigation_click_rank:7" in deleted
 
 
 @pytest.mark.no_infrastructure
@@ -718,7 +733,6 @@ async def test_refresh_group_questions_filters_to_authorized_tables_and_excludes
             tables=["智能体访问日志", "未授权表"],
             user_id=7,
             is_admin=False,
-            dataset_menu_hash="abc123",
             group_id="ai-agent-meta",
             exclude_questions=[
                 {"label": "当前问题", "query": "分析最近一周的智能体访问量"},
@@ -754,7 +768,6 @@ async def test_recent_refresh_questions_are_stored_with_short_ttl():
     ):
         await DatasetNavigationService._remember_recent_refresh_questions(
             user_key="7",
-            dataset_menu_hash="abc123",
             purpose="questions",
             group_identity="ai-agent-meta",
             questions=[
@@ -763,13 +776,17 @@ async def test_recent_refresh_questions_are_stored_with_short_ttl():
         )
         recent = await DatasetNavigationService._load_recent_refresh_questions(
             user_key="7",
-            dataset_menu_hash="abc123",
             purpose="questions",
             group_identity="ai-agent-meta",
         )
 
     assert recent == ["分析最近一周的智能体访问量"]
-    assert list(redis.ttls.values()) == [300]
+    expected_key = DatasetNavigationService._recent_refresh_questions_key(
+        user_key="7",
+        purpose="questions",
+        group_identity="ai-agent-meta",
+    )
+    assert redis.ttls[expected_key] == 300
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_pool_manager.py
+++ b/tests/services/test_pool_manager.py
@@ -131,3 +131,18 @@ async def test_pool_manager_oracle_mode_dsn():
         mock_oracledb.create_pool_async.assert_called_once()
         dsn_called_sn = mock_oracledb.create_pool_async.call_args[1]["dsn"]
         assert dsn_called_sn == "oracle.host:1521/ORCLPDB"
+
+@pytest.mark.asyncio
+async def test_pool_manager_sqlserver_type_routing():
+    DataSourcePoolManager._pools.clear()
+
+    config = make_mock_config(source_id=5, db_type="sqlserver", host="mssql.host", port=1433, db_name="erp")
+    mock_pool = MagicMock()
+    mock_pool.close = AsyncMock()
+
+    with patch("app.services.db_connection_service.DbConnectionService.get_config", new_callable=AsyncMock, return_value=config), \
+         patch.object(DataSourcePoolManager, "_create_sqlserver_pool", new_callable=AsyncMock, return_value=mock_pool) as mock_create_sqlserver:
+
+        pool = await DataSourcePoolManager.get_pool(source_id=5)
+        assert pool is mock_pool
+        mock_create_sqlserver.assert_awaited_once_with(config)

--- a/tests/services/test_sql_permission_messages.py
+++ b/tests/services/test_sql_permission_messages.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -196,3 +197,75 @@ async def test_dataset_table_consistency_validation_failed(monkeypatch):
     assert "[DRY_RUN]" in result_dual
     assert "不属于当前指定的数据集" not in result_dual
     assert "表 'dual'" not in result_dual
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_infrastructure
+async def test_execute_sql_query_core_marks_permission_notice_when_row_filter_rewrites(monkeypatch):
+    fake_ds = SimpleNamespace(
+        id=1,
+        name="sales_dataset",
+        enable_data_perm=True,
+        row_filter_config={
+            "default_policy": [
+                {"target_table": "orders", "condition": "orders.dept_code = {user.dept_code}"}
+            ]
+        },
+    )
+
+    async def fake_get_dataset_by_name(_session, name):
+        return fake_ds if name == "sales_dataset" else None
+
+    async def fake_enforce(*args, **kwargs):
+        return None
+
+    class FakePermissionService:
+        def __init__(self, _session):
+            pass
+
+        async def get_user_permissions(self, _user_id):
+            return SimpleNamespace(roles=[])
+
+    async def fake_sandbox_verify(_session, *, sql, data_source, dialect):
+        return SimpleNamespace(allowed=True, optimized_sql=sql, message="")
+
+    monkeypatch.setattr(sql_service.MetadataService, "get_dataset_by_name", fake_get_dataset_by_name)
+    monkeypatch.setattr(sql_service, "PermissionService", FakePermissionService)
+    monkeypatch.setattr(
+        "app.services.ai.chatbi_sql_query_binding.enforce_physical_table_permissions",
+        fake_enforce,
+    )
+    monkeypatch.setattr(
+        "app.services.ai.chatbi_sql_query_binding.enforce_dataset_table_scope",
+        fake_enforce,
+    )
+    monkeypatch.setattr(
+        "app.services.ai.chatbi_sql_query_binding.build_data_perm_table_metadata",
+        lambda _binding, _dataset_name: {"orders": {"dept_code"}},
+    )
+    monkeypatch.setattr(
+        "app.services.ai.sql_sandbox_gate.SQLSandboxGate.verify_and_optimize",
+        fake_sandbox_verify,
+    )
+
+    permission_notice = {}
+    result = await sql_service.execute_sql_query_core(
+        AsyncMock(),
+        sql="SELECT * FROM orders o",
+        data_source="clickhouse_datasource",
+        dataset_name="sales_dataset",
+        user_id=4,
+        user_dimensions={"dept_code": "D001"},
+        dry_run=True,
+        is_admin=False,
+        bypass_table_auth=False,
+        permission_notice=permission_notice,
+    )
+
+    assert "[DRY_RUN]" in result
+    assert permission_notice["row_filter_applied"] is True
+    assert permission_notice["dataset_name"] == "sales_dataset"
+    assert permission_notice["rule_count"] == 1
+    assert permission_notice["message"] == "已按你的数据权限自动过滤结果"
+    assert "dept_code" in str(permission_notice.get("executed_sql") or "")
+    assert "D001" in str(permission_notice.get("executed_sql") or "")

--- a/tests/services/test_sqlserver_support.py
+++ b/tests/services/test_sqlserver_support.py
@@ -1,0 +1,151 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from types import SimpleNamespace
+
+from app.services.data_adapter.factory import get_adapter
+from app.services.data_adapter.sqlserver import build_sqlserver_odbc_dsn, normalize_sqlserver_type
+from app.services.db_import_service import DBImportService
+from app.services.pool_manager import DataSourcePoolManager
+from app.services.sql_query_execution_service import dialect_from_data_source
+
+
+def test_normalize_sqlserver_type_aliases():
+    assert normalize_sqlserver_type("sqlserver")
+    assert normalize_sqlserver_type("MSSQL")
+    assert normalize_sqlserver_type("tsql")
+    assert not normalize_sqlserver_type("mysql")
+
+
+def test_build_sqlserver_odbc_dsn():
+    dsn = build_sqlserver_odbc_dsn(
+        {
+            "host": "mssql.local",
+            "port": 1433,
+            "database": "erp",
+            "user": "sa",
+            "password": "secret",
+        }
+    )
+    assert "DRIVER={ODBC Driver 18 for SQL Server}" in dsn
+    assert "SERVER=mssql.local,1433" in dsn
+    assert "DATABASE=erp" in dsn
+    assert "UID=sa" in dsn
+    assert "PWD=secret" in dsn
+    assert "TrustServerCertificate=yes" in dsn
+
+
+def test_dialect_from_data_source_sqlserver():
+    assert dialect_from_data_source("sqlserver_erp") == "sqlserver"
+    assert dialect_from_data_source("mssql_prod") == "sqlserver"
+    assert dialect_from_data_source("default_clickhouse") == "clickhouse"
+
+
+@pytest.mark.asyncio
+async def test_factory_returns_sqlserver_adapter():
+    db_config = SimpleNamespace(id=9, name="sqlserver_erp", db_type="sqlserver")
+
+    with patch("app.core.orm.AsyncSessionLocal") as mock_session_local, \
+         patch("app.services.db_connection_service.DbConnectionService.get_config_by_name", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = db_config
+        mock_session_local.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_session_local.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        adapter = await get_adapter("sqlserver_erp")
+        assert adapter.__class__.__name__ == "SQLServerAdapter"
+        assert adapter.source_id == 9
+
+
+@pytest.mark.asyncio
+async def test_pool_manager_create_sqlserver_pool():
+    config = SimpleNamespace(
+        host="mssql.local",
+        port=1433,
+        database_name="erp",
+        db_user="sa",
+        password="secret",
+    )
+    mock_pool = MagicMock()
+    mock_aioodbc = MagicMock()
+    mock_aioodbc.create_pool = AsyncMock(return_value=mock_pool)
+
+    with patch.dict("sys.modules", {"aioodbc": mock_aioodbc}):
+        pool = await DataSourcePoolManager._create_sqlserver_pool(config)
+
+    assert pool is mock_pool
+    mock_aioodbc.create_pool.assert_awaited_once()
+    dsn = mock_aioodbc.create_pool.await_args.kwargs["dsn"]
+    assert "SERVER=mssql.local,1433" in dsn
+    assert "DATABASE=erp" in dsn
+
+
+@pytest.mark.asyncio
+async def test_db_import_service_sqlserver_connection():
+    mock_conn = MagicMock()
+    mock_cursor = AsyncMock()
+    mock_cursor_cm = MagicMock()
+    mock_cursor_cm.__aenter__ = AsyncMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value = mock_cursor_cm
+    mock_conn.close = AsyncMock()
+
+    mock_aioodbc = MagicMock()
+    mock_aioodbc.connect = AsyncMock(return_value=mock_conn)
+
+    config = {
+        "host": "mssql.local",
+        "port": 1433,
+        "database": "erp",
+        "user": "sa",
+        "password": "secret",
+    }
+
+    with patch.dict("sys.modules", {"aioodbc": mock_aioodbc}):
+        ok = await DBImportService.test_sqlserver_connection(config)
+
+    assert ok is True
+    mock_aioodbc.connect.assert_awaited_once()
+    mock_cursor.execute.assert_awaited_with("SELECT 1")
+    mock_conn.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_db_import_service_sqlserver_tables_and_ddl():
+    mock_conn = MagicMock()
+    mock_cursor = AsyncMock()
+    mock_cursor_cm = MagicMock()
+    mock_cursor_cm.__aenter__ = AsyncMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value = mock_cursor_cm
+    mock_conn.close = AsyncMock()
+
+    mock_aioodbc = MagicMock()
+    mock_aioodbc.connect = AsyncMock(return_value=mock_conn)
+
+    config = {
+        "host": "mssql.local",
+        "port": 1433,
+        "database": "erp",
+        "user": "sa",
+        "password": "secret",
+    }
+
+    mock_cursor.fetchone = AsyncMock(side_effect=[("BASE TABLE",)])
+    mock_cursor.fetchall = AsyncMock(
+        side_effect=[
+            [("users", "用户表", "table"), ("user_view", "", "view")],
+            [
+                ("id", "int", None, 10, 0, "NO", None),
+                ("name", "nvarchar", 50, None, None, "YES", None),
+            ],
+        ]
+    )
+
+    with patch.dict("sys.modules", {"aioodbc": mock_aioodbc}):
+        tables = await DBImportService.get_sqlserver_tables(config)
+        ddl = await DBImportService.get_sqlserver_ddl(config, ["users"])
+
+    assert tables == [
+        {"name": "users", "comment": "用户表", "type": "table"},
+        {"name": "user_view", "comment": "", "type": "view"},
+    ]
+    assert "CREATE TABLE [users]" in ddl
+    assert "[id] int" in ddl
+    assert "[name] nvarchar(50) NULL" in ddl

--- a/tests/utils/test_sql_rewriter.py
+++ b/tests/utils/test_sql_rewriter.py
@@ -50,6 +50,153 @@ def test_union_rewrite():
     rewritten = rewriter.rewrite(sql, filters, context)
     assert rewritten.count("WHERE org_id = 5") == 2
 
+def test_table_qualified_filter_uses_query_alias():
+    rewriter = SQLRewriter(dialect="clickhouse")
+    sql = "SELECT * FROM orders o"
+    filters = [{"condition": "orders.dept_code = {user.dept}"}]
+    context = {"dept": "D001"}
+
+    rewritten = rewriter.rewrite(sql, filters, context)
+
+    assert "o.dept_code = 'D001'" in rewritten
+    assert "orders.dept_code" not in rewritten
+
+def test_table_name_in_condition_is_case_insensitive():
+    rewriter = SQLRewriter(
+        dialect="clickhouse",
+        table_metadata={"orders": {"dept_code"}},
+    )
+    sql = "SELECT * FROM orders o"
+    filters = [{"condition": "Orders.dept_code = {user.dept}"}]
+    context = {"dept": "D001"}
+
+    rewritten = rewriter.rewrite(sql, filters, context)
+
+    assert "o.dept_code = 'D001'" in rewritten
+
+def test_table_filter_only_applies_to_matching_select_scope():
+    rewriter = SQLRewriter(dialect="clickhouse")
+    sql = (
+        "SELECT * FROM orders o "
+        "WHERE o.customer_id IN (SELECT c.id FROM customers c)"
+    )
+    filters = [{"condition": "orders.dept_code = {user.dept}"}]
+    context = {"dept": "D001"}
+
+    rewritten = rewriter.rewrite(sql, filters, context)
+
+    assert rewritten.count("dept_code = 'D001'") == 1
+    assert "o.dept_code = 'D001'" in rewritten
+    assert "c.dept_code = 'D001'" not in rewritten
+
+def test_different_table_filters_apply_to_their_own_select_scopes():
+    rewriter = SQLRewriter(dialect="clickhouse")
+    sql = (
+        "SELECT * FROM orders o "
+        "WHERE o.customer_id IN (SELECT c.id FROM customers c)"
+    )
+    filters = [
+        {"condition": "orders.dept_code = {user.dept}"},
+        {"condition": "customers.region_code = {user.region}"},
+    ]
+    context = {"dept": "D001", "region": "SH"}
+
+    rewritten = rewriter.rewrite(sql, filters, context)
+
+    assert "o.dept_code = 'D001'" in rewritten
+    assert "c.region_code = 'SH'" in rewritten
+    assert rewritten.count("dept_code = 'D001'") == 1
+    assert rewritten.count("region_code = 'SH'") == 1
+
+def test_unrelated_table_filter_is_skipped():
+    rewriter = SQLRewriter(dialect="clickhouse")
+    sql = "SELECT * FROM customers c"
+    filters = [{"condition": "orders.dept_code = {user.dept}"}]
+    context = {"dept": "D001"}
+
+    rewritten = rewriter.rewrite(sql, filters, context)
+
+    assert "WHERE" not in rewritten
+    assert "orders.dept_code" not in rewritten
+
+def test_cte_filter_applies_inside_physical_table_scope_only():
+    rewriter = SQLRewriter(dialect="clickhouse")
+    sql = (
+        "WITH recent_orders AS (SELECT * FROM orders o) "
+        "SELECT * FROM recent_orders ro"
+    )
+    filters = [{"condition": "orders.dept_code = {user.dept}"}]
+    context = {"dept": "D001"}
+
+    rewritten = rewriter.rewrite(sql, filters, context)
+
+    assert "o.dept_code = 'D001'" in rewritten
+    assert rewritten.count("dept_code = 'D001'") == 1
+
+def test_unqualified_filter_does_not_apply_to_outer_cte_alias_scope():
+    rewriter = SQLRewriter(dialect="clickhouse")
+    sql = (
+        "WITH recent_orders AS (SELECT * FROM orders o) "
+        "SELECT * FROM recent_orders ro"
+    )
+    filters = [{"condition": "dept_code = {user.dept}"}]
+    context = {"dept": "D001"}
+
+    rewritten = rewriter.rewrite(sql, filters, context)
+
+    assert rewritten.count("dept_code = 'D001'") == 1
+    assert "FROM recent_orders AS ro WHERE dept_code" not in rewritten
+
+def test_target_table_filter_with_unqualified_condition_uses_matching_scope():
+    rewriter = SQLRewriter(dialect="clickhouse")
+    sql = (
+        "SELECT * FROM orders o "
+        "WHERE o.customer_id IN (SELECT c.id FROM customers c)"
+    )
+    filters = [{"target_table": "orders", "condition": "dept_code = {user.dept}"}]
+    context = {"dept": "D001"}
+
+    rewritten = rewriter.rewrite(sql, filters, context)
+
+    assert rewritten.count("dept_code = 'D001'") == 1
+    assert "SELECT c.id FROM customers AS c WHERE dept_code = 'D001'" not in rewritten
+
+def test_unqualified_all_filter_skips_multi_table_subquery_scope():
+    rewriter = SQLRewriter(
+        dialect="clickhouse",
+        table_metadata={"orders": {"dept_code"}, "customers": {"id"}},
+    )
+    sql = (
+        "SELECT * FROM orders o "
+        "WHERE o.customer_id IN (SELECT c.id FROM customers c)"
+    )
+    filters = [{"condition": "dept_code = {user.dept}"}]
+    context = {"dept": "D001"}
+
+    rewritten = rewriter.rewrite(sql, filters, context)
+
+    assert rewritten.count("dept_code = 'D001'") == 1
+    assert "o.dept_code = 'D001'" in rewritten
+    assert "c.dept_code = 'D001'" not in rewritten
+    assert "FROM customers AS c WHERE dept_code" not in rewritten
+
+def test_rewrite_stats_reports_applied_condition_count():
+    rewriter = SQLRewriter(dialect="clickhouse")
+    sql = (
+        "SELECT * FROM orders o "
+        "WHERE o.customer_id IN (SELECT c.id FROM customers c)"
+    )
+    filters = [
+        {"condition": "orders.dept_code = {user.dept}"},
+        {"condition": "customers.region_code = {user.region}"},
+    ]
+    context = {"dept": "D001", "region": "SH"}
+    stats: dict[str, int] = {}
+
+    rewriter.rewrite(sql, filters, context, rewrite_stats=stats)
+
+    assert stats.get("applied_rule_count") == 2
+
 def test_strategy_resolution():
     config = {
         "user_overrides": {


### PR DESCRIPTION

## 概要 (Overview)

本 PR 在 `fe2900fe` 之后合并多项平台能力增强：新增 **SQL Server 数据源**全链路支持、**品牌个性化**配置（登录页/侧栏/版权/关于页）、**系统诊断 Redis** 选择性清理与 Key 详情查看、**智能体中心拖拽排序**，并优化数据门户 Redis 缓存策略、行级权限下拉样式及若干 UI 细节。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)
- [x] **SQL Server 数据源**：适配器、连接池、元数据导入（测试连接/表列表/DDL）、工厂路由、SQL 方言识别；前端数据源管理与导入弹窗支持 `sqlserver`
- [x] **品牌个性化**：系统配置新增「品牌个性化」Tab，支持产品名、登录副标题、Logo/Favicon 上传、隐藏 SSO/版本外链、联系信息 Markdown、登录页版权；个人中心「我的权限 → 关于」展示联系信息
- [x] **系统诊断 Redis**：支持按分组选择性清理 Key、Key 列表浏览与详情查看（`RedisKeyCleanupModal`、`redisKeyGroups`）
- [x] **智能体中心**：支持拖拽排序并持久化 `sort_order`
- [x] **数据门户 Redis 缓存**：按 `user_id` 单 Key 存储，TTL 延长至 90 天

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)
- [x] 登录页 Tab 顺序调整为：**本地账号 → API Key**（SSO 仍按配置显示）
- [x] 侧栏/登录页/浏览器 Title 与 Favicon 随品牌配置动态生效
- [x] 行级权限配置下拉组件重构（`RowFilterOptionSelect`），数据集管理页样式优化
- [x] 系统诊断 Redis 操作区窄屏下按钮折行问题修复

### 3. 🐞 关键修复 (Bug Fixes)
- [x] 修复系统诊断 Redis 操作按钮在窄栏布局下文字折行

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `b92b94f` | feat: 新增品牌个性化配置并优化登录页 Tab 顺序 |
| `f1eee32` | feat: 新增 SQL Server 数据源全链路支持 |
| `325181e` | feat: 数据门户 Redis 按 user_id 单 Key 并延长缓存 TTL 至 90 天 |
| `84fc2c4` | fix: 修复系统诊断 Redis 操作按钮在窄栏下文字折行 |
| `89e95cc` | feat: 系统诊断支持 Redis 选择性清理与 Key 详情查看 |
| `597766e` | feat: 支持智能体中心拖拽排序，并优化行级权限配置下拉样式 |

---

## 测试覆盖 (Testing)
- [x] **SQL Server**：`test_sqlserver_adapter`、`test_sqlserver_support`、`test_pool_manager_sqlserver_type_routing` 等 mock 单元测试通过
- [x] **品牌个性化**：`test_branding_settings_service` 单元测试通过
- [x] **智能体管理**：`test_agent_management` 覆盖拖拽排序 API
- [x] **Redis 分组**：`test_redis_key_groups` 前端工具函数测试
- [ ] **UI 兼容性**：建议在 Chrome / Safari 验证登录页、侧栏品牌、系统诊断 Redis 弹窗
- [ ] **回归测试**：建议手动验证 MySQL/ClickHouse/Oracle 数据源、ChatBI 查数、智能体排序保存

> [!IMPORTANT]
> 提交前请务必确认已更新 `tests/CHECKLIST.md` 中的自动化测试清单。

---

## 其他备注 (Notes)

**数据库迁移（需执行）：**
- `db-prod/V84-branding-config.sql` — 品牌个性化 `system_configs` 初始项

**依赖变更：**
- `requirements.txt` 新增 `aioodbc`、`pyodbc`（SQL Server 连接）

**部署注意：**
- SQL Server 需安装 ODBC Driver 17/18；可通过环境变量 `MSSQL_ODBC_DRIVER` 指定驱动名
- 品牌图标上传目录 `data/branding/`，已通过 `/branding` 静态路径挂载
- 启用品牌个性化后，登录页版权、侧栏 GitHub 外链等行为由配置开关控制

**变更规模：** 45 files, +2666 / -279 lines

