### PR TITLE
Pull Request: Token 额度管理体系 + 个人消耗看板 + 数据权限变量优化

### DIFF
--- a/app/api/portal/api.py
+++ b/app/api/portal/api.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 from app.core.dependencies import require_admin, require_api_key
-from app.api.portal.endpoints import auth, audit, management, keys, dashboard, system, chat, metadata, agents, prompts, slash_commands, health, models, tools, ragflow, roles, mcp, changelog, chat_feedback, chatbi_examples, skills, memory, saved_reports, portal_prefs
+from app.api.portal.endpoints import auth, audit, management, keys, dashboard, system, chat, metadata, agents, prompts, slash_commands, health, models, tools, ragflow, roles, mcp, changelog, chat_feedback, chatbi_examples, skills, memory, saved_reports, portal_prefs, quota
 
 portal_router = APIRouter()
 
@@ -73,3 +73,6 @@ portal_router.include_router(saved_reports.router, prefix="/saved-reports", tags
 
 # 20. 数据门户个人偏好 (Portal Preferences)
 portal_router.include_router(portal_prefs.router, prefix="/portal-prefs", tags=["门户偏好"], dependencies=[Depends(require_api_key)])
+
+# 21. Token 额度 (Quota)
+portal_router.include_router(quota.router, prefix="/quota", tags=["Token额度"], dependencies=[Depends(require_api_key)])

--- a/app/api/portal/endpoints/dashboard.py
+++ b/app/api/portal/endpoints/dashboard.py
@@ -19,6 +19,35 @@ def is_admin(user: dict) -> bool:
     """Check if user is admin"""
     return user.get("role") == "admin"
 
+
+def _resolve_token_stats_range(
+    days: int = 7,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> tuple[datetime, datetime, int]:
+    """解析 Token 统计时间范围，返回 (start, end, span_days)。"""
+    now = datetime.now()
+    if start_date and end_date:
+        start = datetime.strptime(start_date, "%Y-%m-%d").replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        end = datetime.strptime(end_date, "%Y-%m-%d").replace(
+            hour=23, minute=59, second=59, microsecond=999999
+        )
+        if end < start:
+            raise HTTPException(status_code=400, detail="结束日期不能早于开始日期")
+        span_days = (end.date() - start.date()).days + 1
+        if span_days > 90:
+            raise HTTPException(status_code=400, detail="时间范围不能超过 90 天")
+        return start, end, span_days
+
+    span_days = min(max(int(days or 7), 1), 90)
+    start = (now - timedelta(days=span_days - 1)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    end = now.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return start, end, span_days
+
 @router.get("/admin-stats")
 async def get_admin_stats(
     period: str = Query("today", pattern="^(today|week|month)$"),
@@ -522,28 +551,32 @@ async def get_agent_stats(
 @router.get("/token-stats/trends")
 async def get_token_stats_trends(
     days: int = Query(7, ge=1, le=90),
+    start_date: Optional[str] = Query(None, description="开始日期 YYYY-MM-DD"),
+    end_date: Optional[str] = Query(None, description="结束日期 YYYY-MM-DD"),
     user: dict = Depends(require_api_key),
-    db: AsyncSession = Depends(get_db_session)
+    db: AsyncSession = Depends(get_db_session),
 ):
     admin_flag = is_admin(user)
     user_name = user["user_name"]
-    start_date = (datetime.now() - timedelta(days=days - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
-    
+    range_start, range_end, span_days = _resolve_token_stats_range(days, start_date, end_date)
+
     stmt = select(
         func.date(AgentExecutionHistory.created_at).label("date"),
         func.count().label("calls"),
         func.coalesce(func.sum(AgentExecutionHistory.prompt_tokens), 0).label("prompt_tokens"),
         func.coalesce(func.sum(AgentExecutionHistory.completion_tokens), 0).label("completion_tokens"),
         func.coalesce(func.sum(AgentExecutionHistory.total_tokens), 0).label("total_tokens"),
-    ).where(AgentExecutionHistory.created_at >= start_date)
-    
+    ).where(
+        AgentExecutionHistory.created_at >= range_start,
+        AgentExecutionHistory.created_at <= range_end,
+    )
+
     if not admin_flag:
         stmt = stmt.where(AgentExecutionHistory.username == user_name)
-        
+
     stmt = stmt.group_by(func.date(AgentExecutionHistory.created_at)).order_by("date")
     rows = (await db.execute(stmt)).all()
-    
-    # 构造默认无数据的空值，确保前端折线图有连续日期
+
     results_map = {}
     for r in rows:
         results_map[str(r.date)] = {
@@ -552,12 +585,14 @@ async def get_token_stats_trends(
             "completion_tokens": int(r.completion_tokens or 0),
             "total_tokens": int(r.total_tokens or 0),
         }
-        
+
     trends = []
     empty_stats = {"calls": 0, "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
-    for i in range(days):
-        d = start_date + timedelta(days=i)
-        d_str = d.strftime('%Y-%m-%d')
+    for i in range(span_days):
+        d = range_start + timedelta(days=i)
+        if d > range_end:
+            break
+        d_str = d.strftime("%Y-%m-%d")
         stats = results_map.get(d_str, empty_stats)
         trends.append({
             "date": d_str,
@@ -566,8 +601,78 @@ async def get_token_stats_trends(
             "completion_tokens": stats["completion_tokens"],
             "total_tokens": stats["total_tokens"],
         })
-        
+
     return trends
+
+
+@router.get("/token-stats/records")
+async def get_token_stats_records(
+    days: int = Query(7, ge=1, le=90),
+    start_date: Optional[str] = Query(None, description="开始日期 YYYY-MM-DD"),
+    end_date: Optional[str] = Query(None, description="结束日期 YYYY-MM-DD"),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    user: dict = Depends(require_api_key),
+    db: AsyncSession = Depends(get_db_session),
+):
+    """当前用户的 Token 消耗明细（按会话/交互粒度）。"""
+    admin_flag = is_admin(user)
+    user_name = user["user_name"]
+    range_start, range_end, _ = _resolve_token_stats_range(days, start_date, end_date)
+
+    base_filters = [
+        AgentExecutionHistory.created_at >= range_start,
+        AgentExecutionHistory.created_at <= range_end,
+    ]
+    if not admin_flag:
+        base_filters.append(AgentExecutionHistory.username == user_name)
+
+    count_stmt = select(func.count()).select_from(AgentExecutionHistory).where(*base_filters)
+    total = int((await db.execute(count_stmt)).scalar() or 0)
+
+    stmt = (
+        select(
+            AgentExecutionHistory.id,
+            AgentExecutionHistory.created_at,
+            AgentExecutionHistory.agent_id,
+            AIAgent.display_name,
+            AgentExecutionHistory.model_id,
+            AgentExecutionHistory.prompt_tokens,
+            AgentExecutionHistory.completion_tokens,
+            AgentExecutionHistory.total_tokens,
+            AgentExecutionHistory.status,
+        )
+        .outerjoin(AIAgent, AgentExecutionHistory.agent_id == AIAgent.id)
+        .where(*base_filters)
+        .order_by(desc(AgentExecutionHistory.created_at))
+        .offset((page - 1) * size)
+        .limit(size)
+    )
+    rows = (await db.execute(stmt)).all()
+
+    items = []
+    for r in rows:
+        prompt = int(r.prompt_tokens or 0)
+        completion = int(r.completion_tokens or 0)
+        total_tokens = prompt + completion if (prompt + completion) > 0 else int(r.total_tokens or 0)
+        items.append({
+            "id": r.id,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+            "agent_id": r.agent_id,
+            "agent_name": r.display_name or r.agent_id,
+            "model_id": r.model_id or "",
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+            "total_tokens": total_tokens,
+            "status": r.status or "success",
+        })
+
+    return {
+        "items": items,
+        "total": total,
+        "page": page,
+        "size": size,
+    }
 
 @router.get("/token-stats/agents")
 async def get_token_stats_agents(

--- a/app/api/portal/endpoints/quota.py
+++ b/app/api/portal/endpoints/quota.py
@@ -1,0 +1,156 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import require_api_key, require_permission
+from app.core.orm import get_db_session
+from app.models.permission import Role
+from app.models.user import User
+from app.schemas.quota import QuotaPolicyResponse, QuotaPolicyUpdate, QuotaStatusResponse
+from app.services.quota_service import QuotaService
+
+router = APIRouter()
+
+
+@router.get("/me", response_model=QuotaStatusResponse)
+async def get_my_quota(
+    user: dict = Depends(require_api_key),
+    db: AsyncSession = Depends(get_db_session),
+):
+    service = QuotaService(db)
+    return await service.get_user_quota_status(
+        int(user["user_id"]),
+        user["user_name"],
+    )
+
+
+@router.get("/system", response_model=QuotaPolicyResponse)
+async def get_system_quota(
+    admin: dict = Depends(require_permission("menu", "menu:system:users")),
+    db: AsyncSession = Depends(get_db_session),
+):
+    service = QuotaService(db)
+    return await service.get_scope_policy("system", None)
+
+
+@router.put("/system", response_model=QuotaPolicyResponse)
+async def update_system_quota(
+    body: QuotaPolicyUpdate,
+    admin: dict = Depends(require_permission("menu", "menu:system:users")),
+    db: AsyncSession = Depends(get_db_session),
+):
+    service = QuotaService(db)
+    return await service.upsert_scope_policy(
+        "system",
+        None,
+        enabled=body.enabled,
+        limit_tokens=body.limit_tokens,
+    )
+
+
+@router.delete("/system")
+async def delete_system_quota(
+    admin: dict = Depends(require_permission("menu", "menu:system:users")),
+    db: AsyncSession = Depends(get_db_session),
+):
+    service = QuotaService(db)
+    await service.delete_scope_policy("system", None)
+    return {"message": "已恢复为无系统默认额度"}
+
+
+@router.get("/users/{user_id}", response_model=QuotaPolicyResponse)
+async def get_user_quota_policy(
+    user_id: int,
+    admin: dict = Depends(require_permission("element", "element:user:edit")),
+    db: AsyncSession = Depends(get_db_session),
+):
+    user = await db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="用户不存在")
+    service = QuotaService(db)
+    return await service.get_scope_policy(
+        "user",
+        user_id,
+        preview_user_id=user_id,
+        preview_username=user.user_name,
+    )
+
+
+@router.put("/users/{user_id}", response_model=QuotaPolicyResponse)
+async def update_user_quota_policy(
+    user_id: int,
+    body: QuotaPolicyUpdate,
+    admin: dict = Depends(require_permission("element", "element:user:edit")),
+    db: AsyncSession = Depends(get_db_session),
+):
+    user = await db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="用户不存在")
+    service = QuotaService(db)
+    result = await service.upsert_scope_policy(
+        "user",
+        user_id,
+        enabled=body.enabled,
+        limit_tokens=body.limit_tokens,
+    )
+    result.effective = await service.get_user_quota_status(user_id, user.user_name)
+    return result
+
+
+@router.delete("/users/{user_id}")
+async def delete_user_quota_policy(
+    user_id: int,
+    admin: dict = Depends(require_permission("element", "element:user:edit")),
+    db: AsyncSession = Depends(get_db_session),
+):
+    user = await db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="用户不存在")
+    service = QuotaService(db)
+    await service.delete_scope_policy("user", user_id)
+    return {"message": "已清除用户专属额度，将继承角色/系统策略"}
+
+
+@router.get("/roles/{role_id}", response_model=QuotaPolicyResponse)
+async def get_role_quota_policy(
+    role_id: int,
+    admin: dict = Depends(require_permission("menu", "menu:system:roles")),
+    db: AsyncSession = Depends(get_db_session),
+):
+    role = await db.get(Role, role_id)
+    if not role:
+        raise HTTPException(status_code=404, detail="角色不存在")
+    service = QuotaService(db)
+    return await service.get_scope_policy("role", role_id)
+
+
+@router.put("/roles/{role_id}", response_model=QuotaPolicyResponse)
+async def update_role_quota_policy(
+    role_id: int,
+    body: QuotaPolicyUpdate,
+    admin: dict = Depends(require_permission("menu", "menu:system:roles")),
+    db: AsyncSession = Depends(get_db_session),
+):
+    role = await db.get(Role, role_id)
+    if not role:
+        raise HTTPException(status_code=404, detail="角色不存在")
+    service = QuotaService(db)
+    return await service.upsert_scope_policy(
+        "role",
+        role_id,
+        enabled=body.enabled,
+        limit_tokens=body.limit_tokens,
+    )
+
+
+@router.delete("/roles/{role_id}")
+async def delete_role_quota_policy(
+    role_id: int,
+    admin: dict = Depends(require_permission("menu", "menu:system:roles")),
+    db: AsyncSession = Depends(get_db_session),
+):
+    role = await db.get(Role, role_id)
+    if not role:
+        raise HTTPException(status_code=404, detail="角色不存在")
+    service = QuotaService(db)
+    await service.delete_scope_policy("role", role_id)
+    return {"message": "已清除角色额度模板"}

--- a/app/models/quota.py
+++ b/app/models/quota.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, String, Boolean, DateTime, BigInteger
+from datetime import datetime
+from app.core.orm import Base
+
+
+class QuotaPolicy(Base):
+    __tablename__ = "ai_agent_quota_policies"
+
+    id = Column(BigInteger, primary_key=True, index=True, autoincrement=True)
+    scope_type = Column(String(20), nullable=False, comment="user|role|system")
+    scope_id = Column(BigInteger, nullable=True, comment="user_id 或 role_id")
+    period = Column(String(20), nullable=False, default="monthly")
+    limit_tokens = Column(BigInteger, nullable=True, comment="NULL 表示不限额")
+    enabled = Column(Boolean, default=True)
+    action_on_exceed = Column(String(20), nullable=False, default="block")
+    created_at = Column(DateTime, default=datetime.now)
+    updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now)

--- a/app/schemas/quota.py
+++ b/app/schemas/quota.py
@@ -1,0 +1,35 @@
+from typing import Optional, Literal
+from pydantic import BaseModel, Field
+
+
+class QuotaPolicyUpdate(BaseModel):
+    enabled: bool = True
+    limit_tokens: Optional[int] = Field(
+        None,
+        ge=0,
+        description="月 Token 上限；null 表示不限额",
+    )
+
+
+class QuotaStatusResponse(BaseModel):
+    period: str = "monthly"
+    period_start: str
+    period_end: str
+    used_tokens: int = 0
+    limit_tokens: Optional[int] = None
+    remaining_tokens: Optional[int] = None
+    source: Literal["user", "role", "system", "unlimited", "admin_bypass"] = "unlimited"
+    source_label: Optional[str] = None
+    action_on_exceed: str = "block"
+    is_admin_bypass: bool = False
+    policy_enabled: bool = True
+
+
+class QuotaPolicyResponse(BaseModel):
+    scope_type: str
+    scope_id: Optional[int] = None
+    enabled: bool = False
+    limit_tokens: Optional[int] = None
+    action_on_exceed: str = "block"
+    inherit: bool = True
+    effective: Optional[QuotaStatusResponse] = None

--- a/app/services/ai/agent_service.py
+++ b/app/services/ai/agent_service.py
@@ -88,6 +88,15 @@ class AgentService:
         }
         return sorted(path for path in paths if path)
 
+    @staticmethod
+    async def _quota_block_message(user_info: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not user_info:
+            return None
+        from app.services.quota_service import QuotaService
+
+        async with AsyncSessionLocal() as quota_session:
+            return await QuotaService(quota_session).check_before_call(user_info)
+
     async def chat_completion_stream(
         self,
         messages: List[Dict[str, str]],
@@ -113,6 +122,17 @@ class AgentService:
         yield {"trace_id": trace_id, "status": "init"}
 
         lane_user_id = user_info.get("user_id") if user_info else None
+
+        if user_info:
+            quota_block = await self._quota_block_message(user_info)
+            if quota_block:
+                yield {
+                    "type": "error",
+                    "status": "quota_exceeded",
+                    "content": quota_block,
+                    "trace_id": trace_id,
+                }
+                return
 
         try:
             async with conversation_run_lane.hold(
@@ -1205,6 +1225,17 @@ class AgentService:
             }
             return
 
+        if confirmed and user_info:
+            quota_block = await self._quota_block_message(user_info)
+            if quota_block:
+                yield {
+                    "type": "error",
+                    "status": "quota_exceeded",
+                    "content": quota_block,
+                    "trace_id": pending.trace_id,
+                }
+                return
+
         runner = self._build_agentscope_runner_from_pending(pending, user_info=user_info)
 
         yield {
@@ -1399,6 +1430,17 @@ class AgentService:
                 "content": "该请求不是外部执行挂起，请使用 permission confirm 接口。",
             }
             return
+
+        if user_info:
+            quota_block = await self._quota_block_message(user_info)
+            if quota_block:
+                yield {
+                    "type": "error",
+                    "status": "quota_exceeded",
+                    "content": quota_block,
+                    "trace_id": pending.trace_id,
+                }
+                return
 
         runner = self._build_agentscope_runner_from_pending(pending, user_info=user_info)
         execution_results = self._build_external_execution_results(results)

--- a/app/services/data_adapter/clickhouse.py
+++ b/app/services/data_adapter/clickhouse.py
@@ -44,12 +44,32 @@ class ClickHouseAdapter(DataSourceAdapter):
         
         async with pool.connection() as conn:
             async with conn.cursor() as cursor:
-                sql = "SELECT name, engine FROM system.tables WHERE database = currentDatabase() ORDER BY name"
-                await cursor.execute(sql)
-                rows = await cursor.fetchall()
-                
+                try:
+                    sql = "SELECT name, comment, engine FROM system.tables WHERE database = currentDatabase() ORDER BY name"
+                    await cursor.execute(sql)
+                    rows = await cursor.fetchall()
+                except Exception as e:
+                    if "Missing columns" not in str(e) and "Code: 47" not in str(e):
+                        raise
+                    logger.warning("ClickHouse system.tables missing comment column, falling back: %s", e)
+                    sql = "SELECT name, engine FROM system.tables WHERE database = currentDatabase() ORDER BY name"
+                    await cursor.execute(sql)
+                    rows = await cursor.fetchall()
+                    return [
+                        {
+                            "name": row[0],
+                            "comment": "",
+                            "type": "VIEW" if "VIEW" in str(row[1]).upper() else "TABLE",
+                        }
+                        for row in rows
+                    ]
+
                 return [
-                    {"name": row[0], "type": "VIEW" if "VIEW" in row[1].upper() else "TABLE"}
+                    {
+                        "name": row[0],
+                        "comment": row[1] or "",
+                        "type": "VIEW" if "VIEW" in str(row[2]).upper() else "TABLE",
+                    }
                     for row in rows
                 ]
 

--- a/app/services/data_adapter/mysql.py
+++ b/app/services/data_adapter/mysql.py
@@ -32,19 +32,28 @@ class MySQLAdapter(DataSourceAdapter):
         raise NotImplementedError("本地适配器在智能体平台中仅供执行只读物理 SQL，暂不支持逻辑查询 execute_summary 方法。")
 
     async def get_tables(self) -> List[Dict[str, str]]:
-        """获取当前库下的所有表和视图名称"""
+        """获取当前库下的所有表和视图名称（含中文备注）"""
         from app.services.pool_manager import DataSourcePoolManager
         pool = await DataSourcePoolManager.get_pool(self.source_id)
 
         async with pool.acquire() as conn:
             async with conn.cursor() as cursor:
-                # SHOW FULL TABLES 返回: (Table_name, Table_type)
-                # Table_type: 'BASE TABLE', 'VIEW', 'SYSTEM VIEW'
-                await cursor.execute("SHOW FULL TABLES")
+                await cursor.execute(
+                    """
+                    SELECT TABLE_NAME, IFNULL(TABLE_COMMENT, ''), TABLE_TYPE
+                    FROM information_schema.TABLES
+                    WHERE TABLE_SCHEMA = DATABASE()
+                    ORDER BY TABLE_NAME
+                    """
+                )
                 rows = await cursor.fetchall()
 
         return [
-            {"name": row[0], "type": "VIEW" if "VIEW" in row[1].upper() else "TABLE"}
+            {
+                "name": row[0],
+                "comment": row[1] or "",
+                "type": "VIEW" if "VIEW" in str(row[2]).upper() else "TABLE",
+            }
             for row in rows
         ]
 
@@ -69,10 +78,25 @@ class MySQLAdapter(DataSourceAdapter):
                 
             final_sql = f"SELECT * FROM ({sql}) as t LIMIT 0"
         elif table_name:
-            final_sql = f"SELECT * FROM `{table_name}` LIMIT 0"
+            async with pool.acquire() as conn:
+                async with conn.cursor() as cursor:
+                    await cursor.execute(
+                        """
+                        SELECT COLUMN_NAME, DATA_TYPE, IFNULL(COLUMN_COMMENT, '')
+                        FROM information_schema.COLUMNS
+                        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s
+                        ORDER BY ORDINAL_POSITION
+                        """,
+                        (table_name,),
+                    )
+                    rows = await cursor.fetchall()
+            return [
+                {"name": row[0], "type": row[1] or "String", "comment": row[2] or ""}
+                for row in rows
+            ]
         else:
             return []
-        
+
         async with pool.acquire() as conn:
             async with conn.cursor() as cursor:
                 try:
@@ -81,7 +105,7 @@ class MySQLAdapter(DataSourceAdapter):
                 except Exception as e:
                     logger.error(f"MySQL 获取字段信息失败: {e}. SQL: {final_sql}")
                     raise ValueError(f"不合法的 SQL 语句或数据表: {e}")
-        
+
         return [{"name": col, "type": "String", "comment": ""} for col in columns]
 
     async def execute_sql(self, sql: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:

--- a/app/services/data_adapter/oracle.py
+++ b/app/services/data_adapter/oracle.py
@@ -67,15 +67,23 @@ class OracleAdapter(DataSourceAdapter):
             return await asyncio.to_thread(sync_execute)
 
     async def get_tables(self) -> List[Dict[str, str]]:
-        """获取当前用户下的表和视图名称"""
+        """获取当前用户下的表和视图名称（含中文备注）"""
         sql = """
-            SELECT table_name, 'TABLE' as type FROM user_tables 
-            UNION ALL 
-            SELECT view_name as table_name, 'VIEW' as type FROM user_views 
-            ORDER BY type, table_name
+            SELECT t.table_name, t.table_type, NVL(tc.comments, '')
+            FROM (
+                SELECT table_name, 'TABLE' AS table_type FROM user_tables
+                UNION ALL
+                SELECT view_name AS table_name, 'VIEW' AS table_type FROM user_views
+            ) t
+            LEFT JOIN user_tab_comments tc
+                ON tc.table_name = t.table_name AND tc.table_type = t.table_type
+            ORDER BY t.table_type, t.table_name
         """
         rows, _ = await self._run_query_internal(sql)
-        return [{"name": row[0], "type": row[1]} for row in rows]
+        return [
+            {"name": row[0], "comment": row[2] or "", "type": row[1]}
+            for row in rows
+        ]
 
     async def get_columns(self, table_name: Optional[str] = None, custom_sql: Optional[str] = None, params: Optional[Dict[str, Any]] = None) -> List[Dict[str, str]]:
         """获取表或自定义查询 SQL 的字段列定义"""

--- a/app/services/data_adapter/sqlserver.py
+++ b/app/services/data_adapter/sqlserver.py
@@ -66,16 +66,22 @@ class SQLServerAdapter(DataSourceAdapter):
         raise NotImplementedError("本地适配器在智能体平台中仅供执行只读物理 SQL，暂不支持逻辑查询 execute_summary 方法。")
 
     async def get_tables(self) -> List[Dict[str, str]]:
-        """获取当前库下的所有表和视图名称"""
+        """获取当前库下的所有表和视图名称（含中文备注）"""
         from app.services.pool_manager import DataSourcePoolManager
 
         pool = await DataSourcePoolManager.get_pool(self.source_id)
         sql = """
-            SELECT TABLE_NAME, TABLE_TYPE
-            FROM INFORMATION_SCHEMA.TABLES
-            WHERE TABLE_TYPE IN ('BASE TABLE', 'VIEW')
-              AND TABLE_CATALOG = DB_NAME()
-            ORDER BY TABLE_NAME
+            SELECT
+                t.TABLE_NAME,
+                ISNULL(CAST(ep.value AS NVARCHAR(MAX)), '') AS TABLE_COMMENT,
+                CASE WHEN t.TABLE_TYPE = 'VIEW' THEN 'VIEW' ELSE 'TABLE' END AS obj_type
+            FROM INFORMATION_SCHEMA.TABLES t
+            LEFT JOIN sys.tables st ON st.name = t.TABLE_NAME
+            LEFT JOIN sys.extended_properties ep
+                ON ep.major_id = st.object_id AND ep.minor_id = 0 AND ep.name = 'MS_Description'
+            WHERE t.TABLE_TYPE IN ('BASE TABLE', 'VIEW')
+              AND t.TABLE_CATALOG = DB_NAME()
+            ORDER BY t.TABLE_NAME
         """
 
         async with pool.acquire() as conn:
@@ -84,7 +90,7 @@ class SQLServerAdapter(DataSourceAdapter):
                 rows = await cursor.fetchall()
 
         return [
-            {"name": row[0], "type": "VIEW" if row[1] == "VIEW" else "TABLE"}
+            {"name": row[0], "comment": row[1] or "", "type": row[2]}
             for row in rows
         ]
 
@@ -114,7 +120,31 @@ class SQLServerAdapter(DataSourceAdapter):
                 min_limit=0,
             )
         elif table_name:
-            final_sql = f"SELECT TOP 0 * FROM [{table_name}]"
+            meta_sql = """
+                SELECT
+                    c.COLUMN_NAME,
+                    c.DATA_TYPE,
+                    ISNULL(CAST(ep.value AS NVARCHAR(MAX)), '') AS COLUMN_COMMENT
+                FROM INFORMATION_SCHEMA.COLUMNS c
+                LEFT JOIN sys.tables st ON st.name = c.TABLE_NAME
+                LEFT JOIN sys.columns sc
+                    ON sc.object_id = st.object_id AND sc.name = c.COLUMN_NAME
+                LEFT JOIN sys.extended_properties ep
+                    ON ep.major_id = sc.object_id
+                    AND ep.minor_id = sc.column_id
+                    AND ep.name = 'MS_Description'
+                WHERE c.TABLE_NAME = ?
+                  AND c.TABLE_CATALOG = DB_NAME()
+                ORDER BY c.ORDINAL_POSITION
+            """
+            async with pool.acquire() as conn:
+                async with conn.cursor() as cursor:
+                    await cursor.execute(meta_sql, (table_name,))
+                    rows = await cursor.fetchall()
+            return [
+                {"name": row[0], "type": row[1] or "String", "comment": row[2] or ""}
+                for row in rows
+            ]
         else:
             return []
 

--- a/app/services/quota_service.py
+++ b/app/services/quota_service.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from calendar import monthrange
+from datetime import datetime
+from typing import Optional, Tuple
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit import AgentExecutionHistory
+from app.models.permission import Role, UserRoleRelation
+from app.models.quota import QuotaPolicy
+from app.models.user import User
+from app.schemas.quota import QuotaPolicyResponse, QuotaStatusResponse
+from app.services.permission_service import PermissionService
+
+
+class QuotaService:
+    PERIOD_MONTHLY = "monthly"
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    @staticmethod
+    def _month_window(now: Optional[datetime] = None) -> Tuple[datetime, datetime]:
+        now = now or datetime.now()
+        start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        last_day = monthrange(now.year, now.month)[1]
+        end = now.replace(day=last_day, hour=23, minute=59, second=59, microsecond=999999)
+        return start, end
+
+    async def get_monthly_usage(self, username: str) -> int:
+        if not username:
+            return 0
+        start, end = self._month_window()
+        stmt = select(
+            func.coalesce(func.sum(AgentExecutionHistory.total_tokens), 0)
+        ).where(
+            AgentExecutionHistory.username == username,
+            AgentExecutionHistory.created_at >= start,
+            AgentExecutionHistory.created_at <= end,
+        )
+        return int((await self.db.execute(stmt)).scalar() or 0)
+
+    async def _get_policies_for_scope_ids(
+        self, scope_type: str, scope_ids: list[int]
+    ) -> dict[int, QuotaPolicy]:
+        if not scope_ids:
+            return {}
+        stmt = select(QuotaPolicy).where(
+            QuotaPolicy.scope_type == scope_type,
+            QuotaPolicy.period == self.PERIOD_MONTHLY,
+            QuotaPolicy.scope_id.in_(scope_ids),
+        )
+        rows = (await self.db.execute(stmt)).scalars().all()
+        return {int(row.scope_id): row for row in rows if row.scope_id is not None}
+
+    async def _get_policy(
+        self, scope_type: str, scope_id: Optional[int]
+    ) -> Optional[QuotaPolicy]:
+        stmt = select(QuotaPolicy).where(
+            QuotaPolicy.scope_type == scope_type,
+            QuotaPolicy.period == self.PERIOD_MONTHLY,
+        )
+        if scope_id is None:
+            stmt = stmt.where(QuotaPolicy.scope_id.is_(None))
+        else:
+            stmt = stmt.where(QuotaPolicy.scope_id == scope_id)
+        return (await self.db.execute(stmt)).scalar_one_or_none()
+
+    async def _resolve_effective_limit(
+        self, user_id: int, username: str
+    ) -> Tuple[Optional[int], str, Optional[str]]:
+        user = await self.db.get(User, user_id)
+        if not user:
+            return None, "unlimited", None
+
+        roles = [user.role] if user.role else []
+        role_stmt = (
+            select(Role.id, Role.name)
+            .join(UserRoleRelation, Role.id == UserRoleRelation.role_id)
+            .where(UserRoleRelation.user_id == user_id)
+        )
+        business_roles = (await self.db.execute(role_stmt)).all()
+        if PermissionService.is_admin_user(roles):
+            return None, "admin_bypass", "系统管理员"
+
+        user_policy = await self._get_policy("user", user_id)
+        if user_policy and user_policy.enabled:
+            if user_policy.limit_tokens is None:
+                return None, "user", "用户专属（不限额）"
+            return int(user_policy.limit_tokens), "user", "用户专属"
+
+        role_limits: list[Tuple[int, str]] = []
+        has_unlimited_role = False
+        role_ids = [int(role_id) for role_id, _ in business_roles]
+        role_policies = await self._get_policies_for_scope_ids("role", role_ids)
+        for role_id, role_name in business_roles:
+            role_policy = role_policies.get(int(role_id))
+            if not role_policy or not role_policy.enabled:
+                continue
+            if role_policy.limit_tokens is None:
+                has_unlimited_role = True
+                break
+            role_limits.append((int(role_policy.limit_tokens), role_name))
+
+        if has_unlimited_role:
+            best_role = max(business_roles, key=lambda r: r[1]) if business_roles else None
+            label = f"角色：{best_role[1]}" if best_role else "角色模板（不限额）"
+            return None, "role", label
+
+        if role_limits:
+            limit, name = max(role_limits, key=lambda item: item[0])
+            return limit, "role", f"角色：{name}"
+
+        system_policy = await self._get_policy("system", None)
+        if system_policy and system_policy.enabled:
+            if system_policy.limit_tokens is None:
+                return None, "system", "系统默认（不限额）"
+            return int(system_policy.limit_tokens), "system", "系统默认"
+
+        return None, "unlimited", None
+
+    def _build_status(
+        self,
+        *,
+        used_tokens: int,
+        limit_tokens: Optional[int],
+        source: str,
+        source_label: Optional[str],
+        is_admin_bypass: bool,
+        action_on_exceed: str = "block",
+        policy_enabled: bool = True,
+        now: Optional[datetime] = None,
+    ) -> QuotaStatusResponse:
+        start, end = self._month_window(now)
+        remaining = None
+        if limit_tokens is not None:
+            remaining = max(limit_tokens - used_tokens, 0)
+        return QuotaStatusResponse(
+            period=self.PERIOD_MONTHLY,
+            period_start=start.strftime("%Y-%m-%d"),
+            period_end=end.strftime("%Y-%m-%d"),
+            used_tokens=used_tokens,
+            limit_tokens=limit_tokens,
+            remaining_tokens=remaining,
+            source=source,  # type: ignore[arg-type]
+            source_label=source_label,
+            action_on_exceed=action_on_exceed,
+            is_admin_bypass=is_admin_bypass,
+            policy_enabled=policy_enabled,
+        )
+
+    async def get_user_quota_status(
+        self, user_id: int, username: str
+    ) -> QuotaStatusResponse:
+        used = await self.get_monthly_usage(username)
+        limit, source, label = await self._resolve_effective_limit(user_id, username)
+        is_admin = source == "admin_bypass"
+        return self._build_status(
+            used_tokens=used,
+            limit_tokens=limit,
+            source=source,
+            source_label=label,
+            is_admin_bypass=is_admin,
+        )
+
+    async def check_before_call(self, user_info: dict) -> Optional[str]:
+        user_id = user_info.get("user_id")
+        username = user_info.get("user_name") or user_info.get("username")
+        if not user_id or not username:
+            return None
+
+        status = await self.get_user_quota_status(int(user_id), str(username))
+        if status.is_admin_bypass or status.limit_tokens is None:
+            return None
+        if status.used_tokens >= status.limit_tokens:
+            return (
+                f"本月 Token 额度已用尽（已用 {status.used_tokens:,} / 上限 {status.limit_tokens:,}），"
+                "请联系管理员调整额度。"
+            )
+        return None
+
+    def build_warning_message(self, status: QuotaStatusResponse) -> Optional[str]:
+        if status.is_admin_bypass or status.limit_tokens is None:
+            return None
+        if status.used_tokens >= status.limit_tokens:
+            return None
+        threshold = int(status.limit_tokens * 0.8)
+        if status.used_tokens < threshold:
+            return None
+        remaining = max(status.limit_tokens - status.used_tokens, 0)
+        return (
+            f"本月 Token 额度即将用尽（已用 {status.used_tokens:,} / 上限 {status.limit_tokens:,}，"
+            f"剩余 {remaining:,}）。"
+        )
+
+    async def get_scope_policy(
+        self,
+        scope_type: str,
+        scope_id: Optional[int],
+        *,
+        preview_user_id: Optional[int] = None,
+        preview_username: Optional[str] = None,
+    ) -> QuotaPolicyResponse:
+        policy = await self._get_policy(scope_type, scope_id)
+        effective = None
+        if scope_type == "user" and scope_id and preview_username:
+            effective = await self.get_user_quota_status(scope_id, preview_username)
+        response = QuotaPolicyResponse(
+            scope_type=scope_type,
+            scope_id=scope_id,
+            enabled=bool(policy.enabled) if policy else False,
+            limit_tokens=int(policy.limit_tokens) if policy and policy.limit_tokens is not None else None,
+            action_on_exceed=policy.action_on_exceed if policy else "block",
+            inherit=policy is None,
+            effective=effective,
+        )
+        return response
+
+    async def upsert_scope_policy(
+        self,
+        scope_type: str,
+        scope_id: Optional[int],
+        *,
+        enabled: bool,
+        limit_tokens: Optional[int],
+    ) -> QuotaPolicyResponse:
+        policy = await self._get_policy(scope_type, scope_id)
+        if policy:
+            policy.enabled = enabled
+            policy.limit_tokens = limit_tokens
+            policy.action_on_exceed = "block"
+        else:
+            policy = QuotaPolicy(
+                scope_type=scope_type,
+                scope_id=scope_id,
+                period=self.PERIOD_MONTHLY,
+                enabled=enabled,
+                limit_tokens=limit_tokens,
+                action_on_exceed="block",
+            )
+            self.db.add(policy)
+        await self.db.commit()
+        await self.db.refresh(policy)
+        return QuotaPolicyResponse(
+            scope_type=scope_type,
+            scope_id=scope_id,
+            enabled=bool(policy.enabled),
+            limit_tokens=int(policy.limit_tokens) if policy.limit_tokens is not None else None,
+            action_on_exceed=policy.action_on_exceed,
+            inherit=False,
+        )
+
+    async def delete_scope_policy(
+        self, scope_type: str, scope_id: Optional[int]
+    ) -> None:
+        policy = await self._get_policy(scope_type, scope_id)
+        if policy:
+            await self.db.delete(policy)
+            await self.db.commit()

--- a/app/services/user_sync_service.py
+++ b/app/services/user_sync_service.py
@@ -197,15 +197,63 @@ class UserSyncService:
         return await adapter.get_tables()
 
     @staticmethod
+    def _format_sample_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, (dict, list)):
+            text = json.dumps(value, ensure_ascii=False)
+        elif hasattr(value, "isoformat"):
+            try:
+                text = value.isoformat()
+            except Exception:
+                text = str(value)
+        else:
+            text = str(value).strip()
+        if not text:
+            return None
+        if len(text) > 80:
+            return text[:77] + "..."
+        return text
+
+    @staticmethod
+    async def _fetch_table_sample_row(
+        adapter: Any,
+        table_name: str,
+        db_type: str,
+    ) -> Dict[str, Any]:
+        table_sql = UserSyncService._quote_ident(table_name, db_type)
+        sql = f"SELECT * FROM {table_sql}"
+        try:
+            result = await adapter.preview(sql, limit=1)
+            rows = UserSyncService._rows_to_dicts(result)
+            return rows[0] if rows else {}
+        except Exception as exc:
+            logger.warning("Failed to fetch sample row for table %s: %s", table_name, exc)
+            return {}
+
+    @staticmethod
     async def list_columns(
         db: AsyncSession,
         connection_config_id: int,
         table_name: str,
     ) -> List[Dict[str, str]]:
-        _, adapter = await UserSyncService._get_adapter_for_config(db, connection_config_id)
+        db_config, adapter = await UserSyncService._get_adapter_for_config(db, connection_config_id)
         if not hasattr(adapter, "get_columns"):
             raise ValueError("当前数据源适配器不支持列查询")
-        return await adapter.get_columns(table_name=table_name)
+        columns = await adapter.get_columns(table_name=table_name)
+        sample_row = await UserSyncService._fetch_table_sample_row(
+            adapter,
+            table_name,
+            db_config.db_type,
+        )
+        enriched: List[Dict[str, str]] = []
+        for col in columns:
+            item = dict(col)
+            sample = UserSyncService._format_sample_value(sample_row.get(col.get("name")))
+            if sample is not None:
+                item["sample"] = sample
+            enriched.append(item)
+        return enriched
 
     @staticmethod
     def _rows_to_dicts(result: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/app/services/user_sync_service.py
+++ b/app/services/user_sync_service.py
@@ -125,8 +125,9 @@ class UserSyncService:
                 continue
             raw = row.get(alias)
             if raw is None:
-                continue
-            payload[json_key] = UserSyncService._serialize_extra_value(raw)
+                payload[json_key] = ""
+            else:
+                payload[json_key] = UserSyncService._serialize_extra_value(raw)
         if not payload:
             return None
         return json.dumps(payload, ensure_ascii=False)

--- a/db-prod/V88-create_quota_policies.sql
+++ b/db-prod/V88-create_quota_policies.sql
@@ -1,0 +1,14 @@
+-- 用户/角色/系统级 Token 额度策略（按月计量）
+CREATE TABLE IF NOT EXISTS `ai_agent_quota_policies` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `scope_type` VARCHAR(20) NOT NULL COMMENT 'user|role|system',
+  `scope_id` BIGINT NULL COMMENT 'user_id 或 role_id；system 时为 NULL',
+  `period` VARCHAR(20) NOT NULL DEFAULT 'monthly' COMMENT '计费周期：monthly',
+  `limit_tokens` BIGINT NULL COMMENT 'NULL 表示不限额',
+  `enabled` TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用该策略',
+  `action_on_exceed` VARCHAR(20) NOT NULL DEFAULT 'block' COMMENT '超额动作：block',
+  `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_quota_scope_period` (`scope_type`, `scope_id`, `period`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Token 额度策略';

--- a/db-prod/V89-quota-usage-index.sql
+++ b/db-prod/V89-quota-usage-index.sql
@@ -1,0 +1,3 @@
+-- 加速按月按用户汇总 Token 用量
+ALTER TABLE `ai_agent_execution_history`
+  ADD INDEX `ix_username_created_at` (`username`, `created_at`);

--- a/frontend/src/api/portal.ts
+++ b/frontend/src/api/portal.ts
@@ -8,6 +8,7 @@ export interface User {
   role: string
   dept_code?: string
   org_path?: string
+  extra_data?: string | Record<string, unknown> | null
   is_active: boolean
 }
 

--- a/frontend/src/components/SourceColumnPicker.vue
+++ b/frontend/src/components/SourceColumnPicker.vue
@@ -1,0 +1,194 @@
+<template>
+  <div ref="rootRef" class="relative min-w-0">
+    <button
+      type="button"
+      class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm text-left outline-none disabled:bg-gray-50 disabled:cursor-not-allowed flex items-center justify-between gap-2"
+      :class="accentRingClass"
+      :disabled="disabled || loading"
+      @click.stop="togglePicker"
+    >
+      <span v-if="loading" class="text-gray-400">加载中...</span>
+      <span v-else-if="!hasValue" class="text-gray-400">请选择来源字段</span>
+      <span v-else class="flex flex-col min-w-0 flex-1">
+        <span class="truncate font-mono text-gray-900">{{ modelValue }}</span>
+        <span class="truncate text-xs text-gray-400">{{ selectedSubtitle }}</span>
+      </span>
+      <svg
+        class="h-4 w-4 shrink-0 text-gray-400 transition-transform"
+        :class="{ 'rotate-180': open }"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+      </svg>
+    </button>
+
+    <div
+      v-if="open"
+      class="absolute left-0 right-0 top-full z-[10001] mt-1 rounded-lg border border-gray-200 bg-white shadow-xl overflow-hidden"
+    >
+      <div class="flex items-center gap-2 border-b border-gray-100 px-3 py-2 bg-gray-50">
+        <svg class="w-4 h-4 text-gray-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+        <input
+          ref="searchInputRef"
+          v-model="searchQuery"
+          type="text"
+          class="flex-1 min-w-0 bg-transparent border-none focus:ring-0 text-sm py-0.5 outline-none"
+          placeholder="搜索字段名、中文备注或示例..."
+          @click.stop
+        />
+      </div>
+      <div class="max-h-56 overflow-y-auto">
+        <button
+          v-for="col in filteredColumns"
+          :key="col.name"
+          type="button"
+          class="w-full px-3 py-2.5 text-left transition-colors"
+          :class="modelValue === col.name ? activeItemClass : 'hover:bg-gray-50 text-gray-800'"
+          @click.stop="selectColumn(col.name)"
+        >
+          <div class="text-sm font-mono truncate">{{ col.name }}</div>
+          <div
+            class="text-xs truncate mt-0.5"
+            :class="modelValue === col.name ? activeSubClass : 'text-gray-500'"
+          >
+            {{ columnSubtitle(col) }}
+          </div>
+          <div
+            v-if="col.sample"
+            class="text-[11px] font-mono truncate mt-0.5"
+            :class="modelValue === col.name ? activeSampleClass : 'text-gray-400'"
+          >
+            示例：{{ col.sample }}
+          </div>
+        </button>
+        <div
+          v-if="!loading && filteredColumns.length === 0"
+          class="px-3 py-6 text-center text-sm text-gray-400"
+        >
+          {{ searchQuery.trim() ? '无匹配字段' : '暂无可用字段' }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
+
+export interface SourceColumn {
+  name: string
+  type?: string
+  comment?: string
+  sample?: string
+}
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string | null
+    columns: SourceColumn[]
+    loading?: boolean
+    disabled?: boolean
+    accent?: 'indigo' | 'violet'
+  }>(),
+  {
+    loading: false,
+    disabled: false,
+    accent: 'indigo',
+  },
+)
+
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+
+const rootRef = ref<HTMLElement | null>(null)
+const searchInputRef = ref<HTMLInputElement | null>(null)
+const open = ref(false)
+const searchQuery = ref('')
+
+const accentRingClass = computed(() =>
+  props.accent === 'violet' ? 'focus:ring-2 focus:ring-violet-500' : 'focus:ring-2 focus:ring-indigo-500',
+)
+const activeItemClass = computed(() =>
+  props.accent === 'violet'
+    ? 'bg-violet-50 text-violet-700'
+    : 'bg-indigo-50 text-indigo-700',
+)
+const activeSubClass = computed(() =>
+  props.accent === 'violet' ? 'text-violet-500/80' : 'text-indigo-500/80',
+)
+const activeSampleClass = computed(() =>
+  props.accent === 'violet' ? 'text-violet-400' : 'text-indigo-400',
+)
+
+const columnSubtitle = (col: SourceColumn) => {
+  const comment = String(col.comment || '').trim()
+  if (comment) return comment
+  return col.type || '—'
+}
+
+const selectedColumn = computed(() =>
+  props.columns.find((col) => col.name === props.modelValue) || null,
+)
+
+const hasValue = computed(() => !!String(props.modelValue || '').trim())
+
+const selectedSubtitle = computed(() => {
+  if (!selectedColumn.value) return ''
+  return columnSubtitle(selectedColumn.value)
+})
+
+const filteredColumns = computed(() => {
+  const keyword = searchQuery.value.trim().toLowerCase()
+  if (!keyword) return props.columns
+  return props.columns.filter((col) => {
+    const name = String(col.name || '').toLowerCase()
+    const comment = String(col.comment || '').toLowerCase()
+    const sample = String(col.sample || '').toLowerCase()
+    const type = String(col.type || '').toLowerCase()
+    return (
+      name.includes(keyword) ||
+      comment.includes(keyword) ||
+      sample.includes(keyword) ||
+      type.includes(keyword)
+    )
+  })
+})
+
+const closePicker = () => {
+  open.value = false
+  searchQuery.value = ''
+}
+
+const togglePicker = async () => {
+  if (props.disabled || props.loading) return
+  open.value = !open.value
+  if (open.value) {
+    await nextTick()
+    searchInputRef.value?.focus()
+  } else {
+    searchQuery.value = ''
+  }
+}
+
+const selectColumn = (name: string) => {
+  emit('update:modelValue', name)
+  closePicker()
+}
+
+const onOutsideClick = (event: MouseEvent) => {
+  if (!rootRef.value?.contains(event.target as Node)) {
+    closePicker()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', onOutsideClick)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onOutsideClick)
+})
+</script>

--- a/frontend/src/components/ThirdPartyUserSyncDrawer.vue
+++ b/frontend/src/components/ThirdPartyUserSyncDrawer.vue
@@ -70,15 +70,11 @@
                   :disabled="!config.enabled || !config.connection_config_id || loadingTables"
                   @click.stop="toggleTablePicker"
                 >
-                  <span
-                    class="truncate"
-                    :class="config.table_name ? 'text-gray-900' : 'text-gray-400'"
-                  >
-                    {{
-                      loadingTables
-                        ? '加载中...'
-                        : config.table_name || '请选择用户表'
-                    }}
+                  <span v-if="loadingTables" class="text-gray-400">加载中...</span>
+                  <span v-else-if="!config.table_name" class="text-gray-400">请选择用户表</span>
+                  <span v-else class="flex flex-col min-w-0 flex-1">
+                    <span class="truncate font-medium text-gray-900">{{ config.table_name }}</span>
+                    <span class="truncate text-xs text-gray-400">{{ selectedTableSubtitle }}</span>
                   </span>
                   <svg
                     class="h-4 w-4 shrink-0 text-gray-400 transition-transform"
@@ -104,7 +100,7 @@
                       v-model="tableSearchQuery"
                       type="text"
                       class="flex-1 min-w-0 bg-transparent border-none focus:ring-0 text-sm py-0.5 outline-none"
-                      placeholder="搜索表名..."
+                      placeholder="搜索表名或中文备注..."
                       @click.stop
                     />
                   </div>
@@ -113,11 +109,14 @@
                       v-for="t in filteredTables"
                       :key="t.name"
                       type="button"
-                      class="w-full px-3 py-2 text-left text-sm transition-colors hover:bg-indigo-50"
-                      :class="config.table_name === t.name ? 'bg-indigo-50 text-indigo-700 font-medium' : 'text-gray-800'"
+                      class="w-full px-3 py-2.5 text-left transition-colors hover:bg-indigo-50"
+                      :class="config.table_name === t.name ? 'bg-indigo-50 text-indigo-700' : 'text-gray-800'"
                       @click.stop="selectTable(t.name)"
                     >
-                      {{ t.name }}<span v-if="t.type" class="text-gray-400"> ({{ t.type }})</span>
+                      <div class="text-sm font-medium truncate">{{ t.name }}</div>
+                      <div class="text-xs truncate mt-0.5" :class="config.table_name === t.name ? 'text-indigo-500/80' : 'text-gray-400'">
+                        {{ tableSubtitle(t) }}
+                      </div>
                     </button>
                     <div
                       v-if="!loadingTables && filteredTables.length === 0"
@@ -173,20 +172,23 @@
                   </div>
 
                   <div class="min-w-0">
-                    <select
+                    <SourceColumnPicker
                       v-model="config.field_map[field.key]"
-                      class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 outline-none disabled:bg-gray-50 font-mono"
-                      :disabled="!config.enabled || loadingColumns"
-                    >
-                      <option value="">{{ loadingColumns ? '加载中...' : '请选择来源字段' }}</option>
-                      <option v-for="col in columns" :key="col.name" :value="col.name">{{ col.name }}</option>
-                    </select>
+                      :columns="columns"
+                      :loading="loadingColumns"
+                      :disabled="!config.enabled"
+                      accent="indigo"
+                    />
                     <p v-if="config.field_map[field.key]" class="text-xs text-emerald-600 mt-1 truncate">
                       {{ config.table_name }}.{{ config.field_map[field.key] }}
                     </p>
                   </div>
                 </div>
               </div>
+
+              <p v-if="columns.length > 0" class="text-xs text-gray-400">
+                共 {{ columns.length }} 个字段，可搜索字段名、中文备注或示例值
+              </p>
 
               <div class="space-y-3 pt-1">
                 <div class="flex items-center justify-between gap-3">
@@ -248,15 +250,14 @@
 
                     <div class="min-w-0 flex items-start gap-2">
                       <div class="flex-1 min-w-0">
-                        <select
+                        <SourceColumnPicker
                           v-model="mapping.source_column"
-                          class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500 outline-none disabled:bg-gray-50 font-mono"
-                          :disabled="!config.enabled || loadingColumns"
-                          @change="onExtraSourceColumnChange(mapping)"
-                        >
-                          <option value="">{{ loadingColumns ? '加载中...' : '请选择来源字段' }}</option>
-                          <option v-for="col in columns" :key="col.name" :value="col.name">{{ col.name }}</option>
-                        </select>
+                          :columns="columns"
+                          :loading="loadingColumns"
+                          :disabled="!config.enabled"
+                          accent="violet"
+                          @update:model-value="onExtraSourceColumnChange(mapping)"
+                        />
                         <p v-if="mapping.source_column" class="text-xs text-emerald-600 mt-1 truncate">
                           {{ config.table_name }}.{{ mapping.source_column }}
                         </p>
@@ -497,7 +498,7 @@
             <ul class="text-sm text-gray-600 leading-relaxed pl-3 space-y-1.5 list-disc list-inside">
               <li>预览与同步会使用当前表单配置，可先预览再保存。</li>
               <li>「保存配置」用于持久化设置并注册定时任务。</li>
-              <li>扩展 JSON 键名请勿重复；来源表字段较多时可使用搜索选表。</li>
+              <li>扩展 JSON 键名请勿重复；表与字段均支持搜索快速定位。</li>
             </ul>
           </section>
         </div>
@@ -511,6 +512,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import axios from 'axios'
 import { XMarkIcon, TrashIcon } from '@heroicons/vue/24/outline'
 import Switch from './Switch.vue'
+import SourceColumnPicker from './SourceColumnPicker.vue'
 import { useToast } from '../composables/useToast'
 
 interface ExtraDataMapping {
@@ -663,13 +665,29 @@ const isAllSelected = computed(() => {
   return visible.length > 0 && visible.every((u) => selectedUserNames.value.includes(u.user_name))
 })
 
+const selectedTable = computed(() =>
+  tables.value.find((table) => table.name === config.value.table_name) || null,
+)
+
+const tableSubtitle = (table: { comment?: string; type?: string }) => {
+  const comment = String(table.comment || '').trim()
+  if (comment) return comment
+  return table.type || '—'
+}
+
+const selectedTableSubtitle = computed(() => {
+  if (!selectedTable.value) return ''
+  return tableSubtitle(selectedTable.value)
+})
+
 const filteredTables = computed(() => {
   const keyword = tableSearchQuery.value.trim().toLowerCase()
   if (!keyword) return tables.value
   return tables.value.filter((table) => {
     const name = String(table.name || '').toLowerCase()
     const type = String(table.type || '').toLowerCase()
-    return name.includes(keyword) || type.includes(keyword)
+    const comment = String(table.comment || '').toLowerCase()
+    return name.includes(keyword) || type.includes(keyword) || comment.includes(keyword)
   })
 })
 

--- a/frontend/src/components/admin/QuotaPolicyPanel.vue
+++ b/frontend/src/components/admin/QuotaPolicyPanel.vue
@@ -1,0 +1,241 @@
+<template>
+  <div class="space-y-5">
+    <div
+      v-if="effective"
+      class="rounded-xl border border-blue-100 bg-blue-50/60 p-4 text-sm"
+    >
+      <p class="font-semibold text-blue-900 mb-2">本月生效额度</p>
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs">
+        <div>
+          <p class="text-blue-600/80">已用</p>
+          <p class="text-lg font-bold text-blue-950 tabular-nums">{{ formatNumber(effective.used_tokens) }}</p>
+        </div>
+        <div>
+          <p class="text-blue-600/80">上限</p>
+          <p class="text-lg font-bold text-blue-950 tabular-nums">{{ limitLabel(effective.limit_tokens) }}</p>
+        </div>
+        <div>
+          <p class="text-blue-600/80">剩余</p>
+          <p class="text-lg font-bold text-blue-950 tabular-nums">{{ remainingLabel(effective) }}</p>
+        </div>
+        <div>
+          <p class="text-blue-600/80">来源</p>
+          <p class="font-medium text-blue-900 mt-1">{{ effective.source_label || sourceText(effective.source) }}</p>
+        </div>
+      </div>
+      <p class="text-[11px] text-blue-700/70 mt-2">
+        统计周期：{{ effective.period_start }} ~ {{ effective.period_end }}
+      </p>
+    </div>
+
+    <div class="rounded-xl border border-gray-200 p-4 space-y-4 bg-white">
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <p class="text-sm font-semibold text-gray-900">{{ scopeTitle }}</p>
+          <p class="text-xs text-gray-500 mt-0.5">{{ scopeHint }}</p>
+        </div>
+        <label class="inline-flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+          <input
+            v-model="form.enabled"
+            type="checkbox"
+            class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+          />
+          启用
+        </label>
+      </div>
+
+      <div>
+        <label class="block text-xs font-bold text-gray-400 uppercase mb-1">月 Token 上限</label>
+        <div class="flex flex-col sm:flex-row gap-2">
+          <label class="inline-flex items-center gap-2 text-sm text-gray-700">
+            <input
+              v-model="unlimited"
+              type="radio"
+              :value="true"
+              class="text-blue-600 focus:ring-blue-500"
+              :disabled="!form.enabled"
+            />
+            不限额
+          </label>
+          <label class="inline-flex items-center gap-2 text-sm text-gray-700 flex-1">
+            <input
+              v-model="unlimited"
+              type="radio"
+              :value="false"
+              class="text-blue-600 focus:ring-blue-500"
+              :disabled="!form.enabled"
+            />
+            自定义
+            <input
+              v-model.number="form.limit_tokens"
+              type="number"
+              min="0"
+              step="1000"
+              :disabled="!form.enabled || unlimited"
+              placeholder="例如 500000"
+              class="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none disabled:bg-gray-100"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div v-if="inherit && !form.enabled" class="text-xs text-amber-700 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2">
+        当前未配置专属策略，将继承{{ scopeType === 'user' ? '角色模板或系统默认' : '系统默认' }}。
+      </div>
+
+      <div class="flex flex-wrap items-center gap-2 pt-1">
+        <button
+          type="button"
+          class="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+          :disabled="saving"
+          @click="savePolicy"
+        >
+          {{ saving ? '保存中...' : '保存额度' }}
+        </button>
+        <button
+          v-if="!inherit"
+          type="button"
+          class="px-4 py-2 rounded-lg border border-gray-300 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          :disabled="saving"
+          @click="clearPolicy"
+        >
+          清除配置
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import axios from 'axios'
+
+type ScopeType = 'user' | 'role' | 'system'
+
+interface QuotaStatus {
+  period_start: string
+  period_end: string
+  used_tokens: number
+  limit_tokens: number | null
+  remaining_tokens: number | null
+  source: string
+  source_label?: string | null
+}
+
+const props = defineProps<{
+  scopeType: ScopeType
+  scopeId?: number | null
+  showEffective?: boolean
+}>()
+
+const emit = defineEmits<{
+  saved: []
+}>()
+
+const form = ref({ enabled: false, limit_tokens: 100000 as number | null })
+const unlimited = ref(true)
+const inherit = ref(true)
+const saving = ref(false)
+const effective = ref<QuotaStatus | null>(null)
+
+const scopeTitle = computed(() => {
+  if (props.scopeType === 'user') return '用户专属额度'
+  if (props.scopeType === 'role') return '角色额度模板'
+  return '系统默认额度'
+})
+
+const scopeHint = computed(() => {
+  if (props.scopeType === 'user') return '优先级高于角色模板；清除后继承角色/系统策略'
+  if (props.scopeType === 'role') return '分配给该角色的用户将取各角色模板中的最高额度'
+  return '未配置角色/用户策略时的全局默认月上限'
+})
+
+const apiBase = computed(() => {
+  if (props.scopeType === 'system') return '/api/portal/quota/system'
+  if (props.scopeType === 'role') return `/api/portal/quota/roles/${props.scopeId}`
+  return `/api/portal/quota/users/${props.scopeId}`
+})
+
+const formatNumber = (num: number) => {
+  if (!num) return '0'
+  return num.toLocaleString('zh-CN')
+}
+
+const limitLabel = (limit: number | null) => (limit == null ? '不限' : formatNumber(limit))
+const remainingLabel = (status: QuotaStatus) =>
+  status.limit_tokens == null ? '不限' : formatNumber(status.remaining_tokens || 0)
+
+const sourceText = (source: string) => {
+  const map: Record<string, string> = {
+    user: '用户专属',
+    role: '角色模板',
+    system: '系统默认',
+    unlimited: '未限制',
+    admin_bypass: '管理员豁免',
+  }
+  return map[source] || source
+}
+
+const applyPolicy = (data: any) => {
+  inherit.value = !!data?.inherit
+  form.value.enabled = !!data?.enabled
+  if (data?.limit_tokens == null) {
+    unlimited.value = true
+    form.value.limit_tokens = 100000
+  } else {
+    unlimited.value = false
+    form.value.limit_tokens = data.limit_tokens
+  }
+  if (props.showEffective && data?.effective) {
+    effective.value = data.effective
+  }
+}
+
+const loadPolicy = async () => {
+  if (props.scopeType !== 'system' && !props.scopeId) return
+  const res = await axios.get(apiBase.value)
+  applyPolicy(res.data)
+}
+
+const savePolicy = async () => {
+  saving.value = true
+  try {
+    const payload = {
+      enabled: form.value.enabled,
+      limit_tokens: !form.value.enabled || unlimited.value ? null : form.value.limit_tokens,
+    }
+    const res = await axios.put(apiBase.value, payload)
+    applyPolicy(res.data)
+    emit('saved')
+  } catch (error: any) {
+    alert(error?.response?.data?.detail || '保存失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+const clearPolicy = async () => {
+  if (!confirm('确定清除该额度配置？')) return
+  saving.value = true
+  try {
+    await axios.delete(apiBase.value)
+    inherit.value = true
+    form.value.enabled = false
+    unlimited.value = true
+    await loadPolicy()
+    emit('saved')
+  } catch (error: any) {
+    alert(error?.response?.data?.detail || '清除失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+watch(
+  () => [props.scopeType, props.scopeId],
+  () => {
+    loadPolicy().catch((error) => console.error('load quota policy failed', error))
+  },
+  { immediate: true },
+)
+</script>

--- a/frontend/src/components/admin/QuotaPolicyPanel.vue
+++ b/frontend/src/components/admin/QuotaPolicyPanel.vue
@@ -8,15 +8,26 @@
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs">
         <div>
           <p class="text-blue-600/80">已用</p>
-          <p class="text-lg font-bold text-blue-950 tabular-nums">{{ formatNumber(effective.used_tokens) }}</p>
+          <TokenAmount
+            :value="effective.used_tokens"
+            main-class="text-lg font-bold text-blue-950 tabular-nums"
+          />
         </div>
         <div>
           <p class="text-blue-600/80">上限</p>
-          <p class="text-lg font-bold text-blue-950 tabular-nums">{{ limitLabel(effective.limit_tokens) }}</p>
+          <TokenAmount
+            :value="effective.limit_tokens"
+            :is-unlimited="effective.limit_tokens == null"
+            main-class="text-lg font-bold text-blue-950 tabular-nums"
+          />
         </div>
         <div>
           <p class="text-blue-600/80">剩余</p>
-          <p class="text-lg font-bold text-blue-950 tabular-nums">{{ remainingLabel(effective) }}</p>
+          <TokenAmount
+            :value="effective.remaining_tokens || 0"
+            :is-unlimited="effective.limit_tokens == null"
+            main-class="text-lg font-bold text-blue-950 tabular-nums"
+          />
         </div>
         <div>
           <p class="text-blue-600/80">来源</p>
@@ -77,6 +88,12 @@
             />
           </label>
         </div>
+        <p
+          v-if="form.enabled && !unlimited && limitInputHint"
+          class="text-[11px] text-gray-500 mt-1.5 tabular-nums"
+        >
+          {{ limitInputHint }}
+        </p>
       </div>
 
       <div v-if="inherit && !form.enabled" class="text-xs text-amber-700 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2">
@@ -109,6 +126,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import axios from 'axios'
+import TokenAmount from '@/components/common/TokenAmount.vue'
+import { formatTokenInputHint } from '@/utils/tokenFormat'
 
 type ScopeType = 'user' | 'role' | 'system'
 
@@ -156,14 +175,10 @@ const apiBase = computed(() => {
   return `/api/portal/quota/users/${props.scopeId}`
 })
 
-const formatNumber = (num: number) => {
-  if (!num) return '0'
-  return num.toLocaleString('zh-CN')
-}
-
-const limitLabel = (limit: number | null) => (limit == null ? '不限' : formatNumber(limit))
-const remainingLabel = (status: QuotaStatus) =>
-  status.limit_tokens == null ? '不限' : formatNumber(status.remaining_tokens || 0)
+const limitInputHint = computed(() => {
+  if (!form.value.enabled || unlimited.value) return ''
+  return formatTokenInputHint(form.value.limit_tokens)
+})
 
 const sourceText = (source: string) => {
   const map: Record<string, string> = {

--- a/frontend/src/components/common/TokenAmount.vue
+++ b/frontend/src/components/common/TokenAmount.vue
@@ -1,0 +1,51 @@
+<template>
+  <div :class="wrapperClass">
+    <component :is="inline ? 'span' : 'p'" :class="mainClass">
+      {{ displayText }}
+    </component>
+    <p
+      v-if="!inline && showHint"
+      class="text-[10px] text-gray-400 tabular-nums mt-0.5"
+    >
+      {{ formatTokenFull(value) }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import {
+  formatTokenCompact,
+  formatTokenFull,
+  shouldShowTokenFullHint,
+} from '@/utils/tokenFormat'
+
+const props = withDefaults(
+  defineProps<{
+    value: number | null | undefined
+    unlimitedLabel?: string
+    isUnlimited?: boolean
+    inline?: boolean
+    mainClass?: string
+    wrapperClass?: string
+    showFullHint?: boolean
+  }>(),
+  {
+    unlimitedLabel: '不限',
+    isUnlimited: false,
+    inline: false,
+    mainClass: '',
+    wrapperClass: '',
+    showFullHint: true,
+  },
+)
+
+const displayText = computed(() => {
+  if (props.isUnlimited || props.value == null) return props.unlimitedLabel
+  return formatTokenCompact(props.value)
+})
+
+const showHint = computed(
+  () => props.showFullHint && !props.isUnlimited && shouldShowTokenFullHint(props.value),
+)
+</script>

--- a/frontend/src/components/metadata/PermissionVariableMenu.vue
+++ b/frontend/src/components/metadata/PermissionVariableMenu.vue
@@ -1,0 +1,70 @@
+<template>
+  <div
+    class="absolute right-0 top-full mt-1 w-56 bg-white rounded-lg shadow-xl border border-gray-100 z-[9999] max-h-60 overflow-y-auto custom-scrollbar"
+  >
+    <div class="px-2.5 py-1.5 text-[9px] font-bold text-gray-500 uppercase tracking-wide bg-gray-50 border-b border-gray-100">
+      内置用户属性
+    </div>
+    <button
+      v-for="v in builtinVariables"
+      :key="v.value"
+      type="button"
+      class="w-full text-left px-3 py-2 border-b border-gray-50 transition-colors"
+      :class="hoverClass"
+      @click="emit('select', v.value)"
+    >
+      <span class="text-[10px] font-medium text-gray-800">{{ v.label }}</span>
+      <span class="block text-[9px] text-blue-600 font-mono mt-0.5">{{ v.value }}</span>
+    </button>
+
+    <div class="px-2.5 py-1.5 text-[9px] font-bold text-violet-700 uppercase tracking-wide bg-violet-50 border-y border-violet-100">
+      extra_data 扩展字段
+    </div>
+    <template v-if="extraDataVariables.length">
+      <button
+        v-for="v in extraDataVariables"
+        :key="v.value"
+        type="button"
+        class="w-full text-left px-3 py-2 border-b border-violet-50/80 transition-colors hover:bg-violet-50"
+        @click="emit('select', v.value)"
+      >
+        <div class="flex items-center gap-1.5">
+          <span class="text-[10px] font-medium text-violet-900">{{ v.label }}</span>
+          <span class="text-[8px] px-1 py-0.5 rounded bg-violet-100 text-violet-600 font-bold">扩展</span>
+        </div>
+        <span class="block text-[9px] text-violet-600 font-mono mt-0.5">{{ v.value }}</span>
+        <span v-if="v.sample" class="block text-[8px] text-gray-400 truncate mt-0.5">示例：{{ v.sample }}</span>
+      </button>
+    </template>
+    <div v-else class="px-3 py-3 text-[9px] text-gray-400 leading-relaxed">
+      暂无扩展字段。可在用户管理或第三方用户同步中配置 extra_data。
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+export interface PermissionVariable {
+  label: string
+  value: string
+  sample?: string
+}
+
+const props = withDefaults(
+  defineProps<{
+    builtinVariables: PermissionVariable[]
+    extraDataVariables: PermissionVariable[]
+    accent?: 'amber' | 'emerald' | 'slate'
+  }>(),
+  { accent: 'emerald' },
+)
+
+const emit = defineEmits<{ select: [value: string] }>()
+
+const hoverClass = computed(() => {
+  if (props.accent === 'amber') return 'hover:bg-amber-50'
+  if (props.accent === 'slate') return 'hover:bg-slate-50'
+  return 'hover:bg-emerald-50'
+})
+</script>

--- a/frontend/src/components/personal/PersonalTokenUsage.vue
+++ b/frontend/src/components/personal/PersonalTokenUsage.vue
@@ -46,8 +46,60 @@
       </div>
     </div>
 
+    <!-- 本月额度 -->
+    <div
+      v-if="quotaStatus"
+      class="rounded-xl border p-4 sm:p-5"
+      :class="quotaCardClass"
+    >
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h3 class="text-sm font-semibold text-gray-900">本月 Token 额度</h3>
+          <p class="text-xs text-gray-500 mt-0.5">
+            自然月统计（与下方「消耗趋势」时间范围独立）
+            · {{ quotaStatus.period_start }} ~ {{ quotaStatus.period_end }}
+            <span v-if="quotaStatus.source_label"> · {{ quotaStatus.source_label }}</span>
+          </p>
+        </div>
+        <p v-if="quotaStatus.is_admin_bypass" class="text-xs font-medium text-emerald-700 bg-emerald-50 px-2.5 py-1 rounded-full">
+          管理员豁免
+        </p>
+      </div>
+
+      <div v-if="!quotaStatus.is_admin_bypass" class="mt-4 grid grid-cols-3 gap-3">
+        <div class="rounded-lg bg-white/80 border border-white/60 p-3">
+          <p class="text-[11px] text-gray-500">已用</p>
+          <p class="text-lg font-bold tabular-nums text-gray-900 mt-0.5">{{ formatNumber(quotaStatus.used_tokens) }}</p>
+        </div>
+        <div class="rounded-lg bg-white/80 border border-white/60 p-3">
+          <p class="text-[11px] text-gray-500">上限</p>
+          <p class="text-lg font-bold tabular-nums text-gray-900 mt-0.5">{{ quotaLimitLabel }}</p>
+        </div>
+        <div class="rounded-lg bg-white/80 border border-white/60 p-3">
+          <p class="text-[11px] text-gray-500">剩余</p>
+          <p class="text-lg font-bold tabular-nums mt-0.5" :class="quotaRemainingClass">{{ quotaRemainingLabel }}</p>
+        </div>
+      </div>
+
+      <div
+        v-if="!quotaStatus.is_admin_bypass && quotaStatus.limit_tokens != null"
+        class="mt-4"
+      >
+        <div class="h-2 rounded-full bg-white/70 overflow-hidden">
+          <div
+            class="h-full rounded-full transition-all"
+            :class="quotaProgressClass"
+            :style="{ width: `${quotaUsagePercent}%` }"
+          />
+        </div>
+        <p class="text-[11px] text-gray-500 mt-1.5">已使用 {{ quotaUsagePercent }}%</p>
+      </div>
+    </div>
+
     <!-- 汇总卡片 -->
-    <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+    <div>
+      <p class="text-xs text-gray-500 mb-2">下方为所选时间范围内的消耗统计（默认「本月」与额度周期一致）</p>
+      <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
       <div class="rounded-xl border border-gray-100 bg-gray-50/80 p-4">
         <p class="text-xs text-gray-500">Token 总量</p>
         <p class="text-xl font-bold text-gray-900 tabular-nums mt-1">{{ formatNumber(summary.total_tokens) }}</p>
@@ -67,6 +119,7 @@
         <p class="text-xs text-gray-500">单次平均</p>
         <p class="text-xl font-bold text-gray-900 tabular-nums mt-1">{{ formatNumber(summary.avg_tokens) }}</p>
         <p class="text-[10px] text-gray-400 mt-1">Token / 次交互</p>
+      </div>
       </div>
     </div>
 
@@ -232,6 +285,7 @@ interface RecordRow {
 }
 
 const rangePresets = [
+  { key: 'month', label: '本月', days: 0 },
   { key: '7d', label: '近 7 天', days: 7 },
   { key: '30d', label: '近 30 天', days: 30 },
   { key: '90d', label: '近 90 天', days: 90 },
@@ -240,7 +294,7 @@ const rangePresets = [
 type PresetKey = typeof rangePresets[number]['key'] | 'custom'
 
 const loading = ref(false)
-const activePreset = ref<PresetKey>('7d')
+const activePreset = ref<PresetKey>('month')
 const queryDays = ref(7)
 const customStart = ref('')
 const customEnd = ref('')
@@ -249,6 +303,55 @@ const records = ref<RecordRow[]>([])
 const recordPage = ref(1)
 const recordPageSize = 20
 const recordTotal = ref(0)
+
+interface QuotaStatus {
+  period_start: string
+  period_end: string
+  used_tokens: number
+  limit_tokens: number | null
+  remaining_tokens: number | null
+  source: string
+  source_label?: string | null
+  is_admin_bypass: boolean
+}
+
+const quotaStatus = ref<QuotaStatus | null>(null)
+
+const quotaLimitLabel = computed(() => {
+  if (!quotaStatus.value || quotaStatus.value.limit_tokens == null) return '不限'
+  return formatNumber(quotaStatus.value.limit_tokens)
+})
+
+const quotaRemainingLabel = computed(() => {
+  if (!quotaStatus.value || quotaStatus.value.limit_tokens == null) return '不限'
+  return formatNumber(quotaStatus.value.remaining_tokens || 0)
+})
+
+const quotaUsagePercent = computed(() => {
+  if (!quotaStatus.value?.limit_tokens) return 0
+  const pct = (quotaStatus.value.used_tokens / quotaStatus.value.limit_tokens) * 100
+  return Math.min(100, Math.round(pct))
+})
+
+const quotaCardClass = computed(() => {
+  if (!quotaStatus.value?.limit_tokens) return 'border-gray-100 bg-gray-50/80'
+  if (quotaUsagePercent.value >= 100) return 'border-rose-200 bg-rose-50/80'
+  if (quotaUsagePercent.value >= 80) return 'border-amber-200 bg-amber-50/80'
+  return 'border-blue-100 bg-blue-50/60'
+})
+
+const quotaRemainingClass = computed(() => {
+  if (!quotaStatus.value?.limit_tokens) return 'text-gray-900'
+  if ((quotaStatus.value.remaining_tokens || 0) <= 0) return 'text-rose-700'
+  if (quotaUsagePercent.value >= 80) return 'text-amber-700'
+  return 'text-emerald-700'
+})
+
+const quotaProgressClass = computed(() => {
+  if (quotaUsagePercent.value >= 100) return 'bg-rose-500'
+  if (quotaUsagePercent.value >= 80) return 'bg-amber-500'
+  return 'bg-blue-500'
+})
 
 const formatDateInput = (date: Date) => {
   const y = date.getFullYear()
@@ -259,14 +362,19 @@ const formatDateInput = (date: Date) => {
 
 const initDefaultCustomRange = () => {
   const end = new Date()
-  const start = new Date()
-  start.setDate(end.getDate() - 6)
+  const start = new Date(end.getFullYear(), end.getMonth(), 1)
   customEnd.value = formatDateInput(end)
   customStart.value = formatDateInput(start)
 }
 
+const applyMonthPreset = () => {
+  activePreset.value = 'month'
+  initDefaultCustomRange()
+  recordPage.value = 1
+}
+
 const queryParams = computed(() => {
-  if (activePreset.value === 'custom') {
+  if (activePreset.value === 'month' || activePreset.value === 'custom') {
     return { start_date: customStart.value, end_date: customEnd.value }
   }
   return { days: queryDays.value }
@@ -415,6 +523,11 @@ const formatDateTime = (value: string) => {
 }
 
 const applyPreset = (key: typeof rangePresets[number]['key']) => {
+  if (key === 'month') {
+    applyMonthPreset()
+    refreshAll()
+    return
+  }
   activePreset.value = key
   const preset = rangePresets.find((item) => item.key === key)
   queryDays.value = preset?.days || 7
@@ -454,10 +567,15 @@ const loadRecords = async () => {
   recordTotal.value = res.data?.total || 0
 }
 
+const loadQuota = async () => {
+  const res = await axios.get('/api/portal/quota/me')
+  quotaStatus.value = res.data
+}
+
 const refreshAll = async () => {
   loading.value = true
   try {
-    await Promise.all([loadTrends(), loadRecords()])
+    await Promise.all([loadTrends(), loadRecords(), loadQuota()])
   } catch (error) {
     console.error('Failed to load personal token usage', error)
   } finally {
@@ -466,7 +584,7 @@ const refreshAll = async () => {
 }
 
 onMounted(() => {
-  initDefaultCustomRange()
+  applyMonthPreset()
   refreshAll()
 })
 </script>

--- a/frontend/src/components/personal/PersonalTokenUsage.vue
+++ b/frontend/src/components/personal/PersonalTokenUsage.vue
@@ -1,0 +1,472 @@
+<template>
+  <div class="space-y-6">
+    <!-- 时间范围 -->
+    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
+      <div class="flex flex-wrap items-center gap-2">
+        <button
+          v-for="preset in rangePresets"
+          :key="preset.key"
+          type="button"
+          class="px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors"
+          :class="activePreset === preset.key
+            ? 'bg-blue-600 text-white border-blue-600'
+            : 'bg-white text-gray-600 border-gray-200 hover:border-blue-300 hover:text-blue-600'"
+          @click="applyPreset(preset.key)"
+        >
+          {{ preset.label }}
+        </button>
+      </div>
+      <div class="flex flex-wrap items-end gap-2">
+        <div>
+          <label class="block text-[10px] text-gray-500 mb-1">开始日期</label>
+          <input
+            v-model="customStart"
+            type="date"
+            class="border border-gray-200 rounded-lg px-2.5 py-1.5 text-xs focus:ring-2 focus:ring-blue-500 outline-none"
+            @change="applyCustomRange"
+          />
+        </div>
+        <div>
+          <label class="block text-[10px] text-gray-500 mb-1">结束日期</label>
+          <input
+            v-model="customEnd"
+            type="date"
+            class="border border-gray-200 rounded-lg px-2.5 py-1.5 text-xs focus:ring-2 focus:ring-blue-500 outline-none"
+            @change="applyCustomRange"
+          />
+        </div>
+        <button
+          type="button"
+          class="px-3 py-1.5 rounded-lg text-xs font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors disabled:opacity-50"
+          :disabled="loading"
+          @click="refreshAll"
+        >
+          刷新
+        </button>
+      </div>
+    </div>
+
+    <!-- 汇总卡片 -->
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+      <div class="rounded-xl border border-gray-100 bg-gray-50/80 p-4">
+        <p class="text-xs text-gray-500">Token 总量</p>
+        <p class="text-xl font-bold text-gray-900 tabular-nums mt-1">{{ formatNumber(summary.total_tokens) }}</p>
+        <p class="text-[10px] text-gray-400 mt-1">输入 {{ formatNumber(summary.prompt_tokens) }} · 输出 {{ formatNumber(summary.completion_tokens) }}</p>
+      </div>
+      <div class="rounded-xl border border-gray-100 bg-gray-50/80 p-4">
+        <p class="text-xs text-gray-500">对话交互</p>
+        <p class="text-xl font-bold text-gray-900 tabular-nums mt-1">{{ formatNumber(summary.calls) }}</p>
+        <p class="text-[10px] text-gray-400 mt-1">会话发起次数</p>
+      </div>
+      <div class="rounded-xl border border-gray-100 bg-gray-50/80 p-4">
+        <p class="text-xs text-gray-500">日均 Token</p>
+        <p class="text-xl font-bold text-gray-900 tabular-nums mt-1">{{ formatNumber(summary.avg_daily_tokens) }}</p>
+        <p class="text-[10px] text-gray-400 mt-1">按 {{ trendData.length }} 天平均</p>
+      </div>
+      <div class="rounded-xl border border-gray-100 bg-gray-50/80 p-4">
+        <p class="text-xs text-gray-500">单次平均</p>
+        <p class="text-xl font-bold text-gray-900 tabular-nums mt-1">{{ formatNumber(summary.avg_tokens) }}</p>
+        <p class="text-[10px] text-gray-400 mt-1">Token / 次交互</p>
+      </div>
+    </div>
+
+    <!-- 趋势图 -->
+    <div class="rounded-xl border border-gray-100 p-4 sm:p-5">
+      <h3 class="text-sm font-semibold text-gray-900 mb-1">Token 消耗趋势</h3>
+      <p class="text-xs text-gray-400 mb-4">每日输入/输出 Token 与累计总量</p>
+      <div v-if="loading" class="h-72 flex items-center justify-center text-gray-400 text-sm">加载中...</div>
+      <div v-else-if="trendData.length === 0" class="h-72 flex items-center justify-center text-gray-400 text-sm">暂无数据</div>
+      <v-chart v-else class="h-72 w-full" :option="trendChartOption" autoresize />
+    </div>
+
+    <!-- 日明细 -->
+    <div class="rounded-xl border border-gray-100 overflow-hidden">
+      <div class="px-4 py-3 border-b border-gray-100 bg-gray-50/80">
+        <h3 class="text-sm font-semibold text-gray-900">日明细</h3>
+        <p class="text-xs text-gray-400 mt-0.5">按天汇总的 Token 消耗</p>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="bg-white text-gray-500 text-xs">
+            <tr>
+              <th class="px-4 py-2.5 text-left font-medium">日期</th>
+              <th class="px-4 py-2.5 text-right font-medium">交互次数</th>
+              <th class="px-4 py-2.5 text-right font-medium">输入 Token</th>
+              <th class="px-4 py-2.5 text-right font-medium">输出 Token</th>
+              <th class="px-4 py-2.5 text-right font-medium">合计 Token</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="loading">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400">加载中...</td>
+            </tr>
+            <tr v-else-if="dailyRows.length === 0">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400">所选时间范围内暂无记录</td>
+            </tr>
+            <tr
+              v-for="row in dailyRows"
+              :key="row.date"
+              class="border-t border-gray-50 hover:bg-gray-50/60"
+            >
+              <td class="px-4 py-2.5 text-gray-900 font-medium">{{ row.date }}</td>
+              <td class="px-4 py-2.5 text-right tabular-nums text-gray-600">{{ formatNumber(row.calls) }}</td>
+              <td class="px-4 py-2.5 text-right tabular-nums text-sky-700">{{ formatNumber(row.prompt_tokens) }}</td>
+              <td class="px-4 py-2.5 text-right tabular-nums text-rose-700">{{ formatNumber(row.completion_tokens) }}</td>
+              <td class="px-4 py-2.5 text-right tabular-nums font-semibold text-gray-900">{{ formatNumber(row.total_tokens) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- 交互明细 -->
+    <div class="rounded-xl border border-gray-100 overflow-hidden">
+      <div class="px-4 py-3 border-b border-gray-100 bg-gray-50/80 flex items-center justify-between gap-3">
+        <div>
+          <h3 class="text-sm font-semibold text-gray-900">交互明细</h3>
+          <p class="text-xs text-gray-400 mt-0.5">每次对话/调用的 Token 消耗记录</p>
+        </div>
+        <span class="text-xs text-gray-400">共 {{ recordTotal }} 条</span>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="bg-white text-gray-500 text-xs">
+            <tr>
+              <th class="px-4 py-2.5 text-left font-medium">时间</th>
+              <th class="px-4 py-2.5 text-left font-medium">智能体</th>
+              <th class="px-4 py-2.5 text-left font-medium">模型</th>
+              <th class="px-4 py-2.5 text-right font-medium">Token</th>
+              <th class="px-4 py-2.5 text-center font-medium">状态</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="loading">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400">加载中...</td>
+            </tr>
+            <tr v-else-if="records.length === 0">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400">暂无交互记录</td>
+            </tr>
+            <tr
+              v-for="item in records"
+              :key="item.id"
+              class="border-t border-gray-50 hover:bg-gray-50/60"
+            >
+              <td class="px-4 py-2.5 text-gray-700 whitespace-nowrap">{{ formatDateTime(item.created_at) }}</td>
+              <td class="px-4 py-2.5 text-gray-800">{{ item.agent_name }}</td>
+              <td class="px-4 py-2.5 text-gray-500 font-mono text-xs">{{ item.model_id || '—' }}</td>
+              <td class="px-4 py-2.5 text-right tabular-nums font-medium text-gray-900">{{ formatNumber(item.total_tokens) }}</td>
+              <td class="px-4 py-2.5 text-center">
+                <span
+                  class="text-[10px] px-2 py-0.5 rounded-full font-medium"
+                  :class="item.status === 'success' ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-600'"
+                >
+                  {{ item.status === 'success' ? '成功' : item.status }}
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div v-if="recordTotal > recordPageSize" class="px-4 py-3 border-t border-gray-100 flex items-center justify-between">
+        <button
+          type="button"
+          class="px-3 py-1.5 text-xs rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-40"
+          :disabled="recordPage <= 1 || loading"
+          @click="changeRecordPage(recordPage - 1)"
+        >
+          上一页
+        </button>
+        <span class="text-xs text-gray-500">第 {{ recordPage }} / {{ recordTotalPages }} 页</span>
+        <button
+          type="button"
+          class="px-3 py-1.5 text-xs rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-40"
+          :disabled="recordPage >= recordTotalPages || loading"
+          @click="changeRecordPage(recordPage + 1)"
+        >
+          下一页
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import axios from '../../utils/axios'
+import VChart from 'vue-echarts'
+import { use } from 'echarts/core'
+import { CanvasRenderer } from 'echarts/renderers'
+import { LineChart, BarChart } from 'echarts/charts'
+import {
+  TitleComponent,
+  TooltipComponent,
+  LegendComponent,
+  GridComponent,
+} from 'echarts/components'
+
+use([
+  CanvasRenderer,
+  LineChart,
+  BarChart,
+  TitleComponent,
+  TooltipComponent,
+  LegendComponent,
+  GridComponent,
+])
+
+interface TrendRow {
+  date: string
+  calls: number
+  prompt_tokens: number
+  completion_tokens: number
+  total_tokens: number
+}
+
+interface RecordRow {
+  id: number
+  created_at: string
+  agent_name: string
+  model_id: string
+  total_tokens: number
+  status: string
+}
+
+const rangePresets = [
+  { key: '7d', label: '近 7 天', days: 7 },
+  { key: '30d', label: '近 30 天', days: 30 },
+  { key: '90d', label: '近 90 天', days: 90 },
+] as const
+
+type PresetKey = typeof rangePresets[number]['key'] | 'custom'
+
+const loading = ref(false)
+const activePreset = ref<PresetKey>('7d')
+const queryDays = ref(7)
+const customStart = ref('')
+const customEnd = ref('')
+const trendData = ref<TrendRow[]>([])
+const records = ref<RecordRow[]>([])
+const recordPage = ref(1)
+const recordPageSize = 20
+const recordTotal = ref(0)
+
+const formatDateInput = (date: Date) => {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+const initDefaultCustomRange = () => {
+  const end = new Date()
+  const start = new Date()
+  start.setDate(end.getDate() - 6)
+  customEnd.value = formatDateInput(end)
+  customStart.value = formatDateInput(start)
+}
+
+const queryParams = computed(() => {
+  if (activePreset.value === 'custom') {
+    return { start_date: customStart.value, end_date: customEnd.value }
+  }
+  return { days: queryDays.value }
+})
+
+const summary = computed(() => {
+  let prompt_tokens = 0
+  let completion_tokens = 0
+  let calls = 0
+  for (const row of trendData.value) {
+    prompt_tokens += row.prompt_tokens || 0
+    completion_tokens += row.completion_tokens || 0
+    calls += row.calls || 0
+  }
+  const breakdown = prompt_tokens + completion_tokens
+  const raw_total = trendData.value.reduce((sum, row) => sum + (row.total_tokens || 0), 0)
+  const total_tokens = breakdown > 0 ? breakdown : raw_total
+  const dayCount = Math.max(trendData.value.length, 1)
+  return {
+    prompt_tokens,
+    completion_tokens,
+    total_tokens,
+    calls,
+    avg_daily_tokens: Math.round(total_tokens / dayCount),
+    avg_tokens: calls > 0 ? Math.round(total_tokens / calls) : 0,
+  }
+})
+
+const dailyRows = computed(() =>
+  [...trendData.value].reverse().filter((row) =>
+    row.calls > 0 || row.prompt_tokens > 0 || row.completion_tokens > 0 || row.total_tokens > 0,
+  ),
+)
+
+const recordTotalPages = computed(() =>
+  Math.max(1, Math.ceil(recordTotal.value / recordPageSize)),
+)
+
+const trendChartOption = computed(() => {
+  if (!trendData.value.length) return {}
+  const dates = trendData.value.map((item) => item.date.slice(5))
+  const promptTokens = trendData.value.map((item) => item.prompt_tokens || 0)
+  const completionTokens = trendData.value.map((item) => item.completion_tokens || 0)
+  let cumulative = 0
+  const cumulativeTokens = trendData.value.map((item) => {
+    const daily = (item.prompt_tokens || 0) + (item.completion_tokens || 0) || item.total_tokens || 0
+    cumulative += daily
+    return cumulative
+  })
+
+  return {
+    tooltip: {
+      trigger: 'axis',
+      formatter: (params: any) => {
+        const items = Array.isArray(params) ? params : [params]
+        const date = items[0]?.axisValue || ''
+        const lines = items.map((item: any) => {
+          const val = formatNumber(Number(item.value) || 0)
+          return `${item.marker}${item.seriesName}: ${val}`
+        })
+        return [date, ...lines].join('<br/>')
+      },
+    },
+    legend: { data: ['输入 Token', '输出 Token', '累计 Token'], bottom: 0 },
+    grid: { left: 12, right: 16, bottom: 48, top: 24, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: dates,
+      axisLine: { lineStyle: { color: '#d1d5db' } },
+      axisTick: { show: false },
+    },
+    yAxis: [
+      {
+        type: 'value',
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: {
+          formatter: (value: number) => formatAxisValue(value),
+        },
+        splitLine: { lineStyle: { type: 'dashed', color: '#f3f4f6' } },
+      },
+      {
+        type: 'value',
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: {
+          formatter: (value: number) => formatAxisValue(value),
+        },
+        splitLine: { show: false },
+      },
+    ],
+    series: [
+      {
+        name: '输入 Token',
+        type: 'bar',
+        stack: 'daily',
+        data: promptTokens,
+        itemStyle: { color: '#0ea5e9' },
+        barMaxWidth: 24,
+      },
+      {
+        name: '输出 Token',
+        type: 'bar',
+        stack: 'daily',
+        data: completionTokens,
+        itemStyle: { color: '#f43f5e' },
+        barMaxWidth: 24,
+      },
+      {
+        name: '累计 Token',
+        type: 'line',
+        yAxisIndex: 1,
+        smooth: true,
+        showSymbol: false,
+        data: cumulativeTokens,
+        itemStyle: { color: '#6366f1' },
+        lineStyle: { width: 2 },
+      },
+    ],
+  }
+})
+
+const formatNumber = (num: number) => {
+  if (!num) return '0'
+  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+}
+
+const formatAxisValue = (value: number) => {
+  const num = Number(value) || 0
+  if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(num >= 10_000_000 ? 0 : 1)}M`
+  if (num >= 10_000) return `${(num / 10_000).toFixed(num >= 100_000 ? 0 : 1)}万`
+  if (num >= 1_000) return `${(num / 1_000).toFixed(0)}k`
+  return String(num)
+}
+
+const formatDateTime = (value: string) => {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString('zh-CN', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+const applyPreset = (key: typeof rangePresets[number]['key']) => {
+  activePreset.value = key
+  const preset = rangePresets.find((item) => item.key === key)
+  queryDays.value = preset?.days || 7
+  initDefaultCustomRange()
+  recordPage.value = 1
+  refreshAll()
+}
+
+const applyCustomRange = () => {
+  if (!customStart.value || !customEnd.value) return
+  activePreset.value = 'custom'
+  recordPage.value = 1
+  refreshAll()
+}
+
+const changeRecordPage = (page: number) => {
+  recordPage.value = page
+  loadRecords()
+}
+
+const loadTrends = async () => {
+  const res = await axios.get('/api/portal/dashboard/token-stats/trends', {
+    params: queryParams.value,
+  })
+  trendData.value = res.data || []
+}
+
+const loadRecords = async () => {
+  const res = await axios.get('/api/portal/dashboard/token-stats/records', {
+    params: {
+      ...queryParams.value,
+      page: recordPage.value,
+      size: recordPageSize,
+    },
+  })
+  records.value = res.data?.items || []
+  recordTotal.value = res.data?.total || 0
+}
+
+const refreshAll = async () => {
+  loading.value = true
+  try {
+    await Promise.all([loadTrends(), loadRecords()])
+  } catch (error) {
+    console.error('Failed to load personal token usage', error)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  initDefaultCustomRange()
+  refreshAll()
+})
+</script>

--- a/frontend/src/components/personal/PersonalTokenUsage.vue
+++ b/frontend/src/components/personal/PersonalTokenUsage.vue
@@ -69,15 +69,26 @@
       <div v-if="!quotaStatus.is_admin_bypass" class="mt-4 grid grid-cols-3 gap-3">
         <div class="rounded-lg bg-white/80 border border-white/60 p-3">
           <p class="text-[11px] text-gray-500">已用</p>
-          <p class="text-lg font-bold tabular-nums text-gray-900 mt-0.5">{{ formatNumber(quotaStatus.used_tokens) }}</p>
+          <TokenAmount
+            :value="quotaStatus.used_tokens"
+            main-class="text-lg font-bold tabular-nums text-gray-900"
+          />
         </div>
         <div class="rounded-lg bg-white/80 border border-white/60 p-3">
           <p class="text-[11px] text-gray-500">上限</p>
-          <p class="text-lg font-bold tabular-nums text-gray-900 mt-0.5">{{ quotaLimitLabel }}</p>
+          <TokenAmount
+            :value="quotaStatus.limit_tokens"
+            :is-unlimited="quotaStatus.limit_tokens == null"
+            main-class="text-lg font-bold tabular-nums text-gray-900"
+          />
         </div>
         <div class="rounded-lg bg-white/80 border border-white/60 p-3">
           <p class="text-[11px] text-gray-500">剩余</p>
-          <p class="text-lg font-bold tabular-nums mt-0.5" :class="quotaRemainingClass">{{ quotaRemainingLabel }}</p>
+          <TokenAmount
+            :value="quotaStatus.remaining_tokens || 0"
+            :is-unlimited="quotaStatus.limit_tokens == null"
+            :main-class="`text-lg font-bold tabular-nums ${quotaRemainingClass}`"
+          />
         </div>
       </div>
 
@@ -102,8 +113,14 @@
       <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
       <div class="rounded-xl border border-gray-100 bg-gray-50/80 p-4">
         <p class="text-xs text-gray-500">Token 总量</p>
-        <p class="text-xl font-bold text-gray-900 tabular-nums mt-1">{{ formatNumber(summary.total_tokens) }}</p>
-        <p class="text-[10px] text-gray-400 mt-1">输入 {{ formatNumber(summary.prompt_tokens) }} · 输出 {{ formatNumber(summary.completion_tokens) }}</p>
+        <TokenAmount
+          :value="summary.total_tokens"
+          main-class="text-xl font-bold text-gray-900 tabular-nums"
+        />
+        <p class="text-[10px] text-gray-400 mt-1">
+          输入 <span :title="formatTokenFull(summary.prompt_tokens)">{{ formatTokenCompact(summary.prompt_tokens) }}</span>
+          · 输出 <span :title="formatTokenFull(summary.completion_tokens)">{{ formatTokenCompact(summary.completion_tokens) }}</span>
+        </p>
       </div>
       <div class="rounded-xl border border-gray-100 bg-gray-50/80 p-4">
         <p class="text-xs text-gray-500">对话交互</p>
@@ -112,12 +129,18 @@
       </div>
       <div class="rounded-xl border border-gray-100 bg-gray-50/80 p-4">
         <p class="text-xs text-gray-500">日均 Token</p>
-        <p class="text-xl font-bold text-gray-900 tabular-nums mt-1">{{ formatNumber(summary.avg_daily_tokens) }}</p>
+        <TokenAmount
+          :value="summary.avg_daily_tokens"
+          main-class="text-xl font-bold text-gray-900 tabular-nums"
+        />
         <p class="text-[10px] text-gray-400 mt-1">按 {{ trendData.length }} 天平均</p>
       </div>
       <div class="rounded-xl border border-gray-100 bg-gray-50/80 p-4">
         <p class="text-xs text-gray-500">单次平均</p>
-        <p class="text-xl font-bold text-gray-900 tabular-nums mt-1">{{ formatNumber(summary.avg_tokens) }}</p>
+        <TokenAmount
+          :value="summary.avg_tokens"
+          main-class="text-xl font-bold text-gray-900 tabular-nums"
+        />
         <p class="text-[10px] text-gray-400 mt-1">Token / 次交互</p>
       </div>
       </div>
@@ -163,9 +186,9 @@
             >
               <td class="px-4 py-2.5 text-gray-900 font-medium">{{ row.date }}</td>
               <td class="px-4 py-2.5 text-right tabular-nums text-gray-600">{{ formatNumber(row.calls) }}</td>
-              <td class="px-4 py-2.5 text-right tabular-nums text-sky-700">{{ formatNumber(row.prompt_tokens) }}</td>
-              <td class="px-4 py-2.5 text-right tabular-nums text-rose-700">{{ formatNumber(row.completion_tokens) }}</td>
-              <td class="px-4 py-2.5 text-right tabular-nums font-semibold text-gray-900">{{ formatNumber(row.total_tokens) }}</td>
+              <td class="px-4 py-2.5 text-right tabular-nums text-sky-700" :title="formatTokenFull(row.prompt_tokens)">{{ formatTokenCompact(row.prompt_tokens) }}</td>
+              <td class="px-4 py-2.5 text-right tabular-nums text-rose-700" :title="formatTokenFull(row.completion_tokens)">{{ formatTokenCompact(row.completion_tokens) }}</td>
+              <td class="px-4 py-2.5 text-right tabular-nums font-semibold text-gray-900" :title="formatTokenFull(row.total_tokens)">{{ formatTokenCompact(row.total_tokens) }}</td>
             </tr>
           </tbody>
         </table>
@@ -207,7 +230,7 @@
               <td class="px-4 py-2.5 text-gray-700 whitespace-nowrap">{{ formatDateTime(item.created_at) }}</td>
               <td class="px-4 py-2.5 text-gray-800">{{ item.agent_name }}</td>
               <td class="px-4 py-2.5 text-gray-500 font-mono text-xs">{{ item.model_id || '—' }}</td>
-              <td class="px-4 py-2.5 text-right tabular-nums font-medium text-gray-900">{{ formatNumber(item.total_tokens) }}</td>
+              <td class="px-4 py-2.5 text-right tabular-nums font-medium text-gray-900" :title="formatTokenFull(item.total_tokens)">{{ formatTokenCompact(item.total_tokens) }}</td>
               <td class="px-4 py-2.5 text-center">
                 <span
                   class="text-[10px] px-2 py-0.5 rounded-full font-medium"
@@ -246,6 +269,12 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import axios from '../../utils/axios'
+import TokenAmount from '@/components/common/TokenAmount.vue'
+import {
+  formatTokenAxis,
+  formatTokenCompact,
+  formatTokenFull,
+} from '@/utils/tokenFormat'
 import VChart from 'vue-echarts'
 import { use } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
@@ -316,16 +345,6 @@ interface QuotaStatus {
 }
 
 const quotaStatus = ref<QuotaStatus | null>(null)
-
-const quotaLimitLabel = computed(() => {
-  if (!quotaStatus.value || quotaStatus.value.limit_tokens == null) return '不限'
-  return formatNumber(quotaStatus.value.limit_tokens)
-})
-
-const quotaRemainingLabel = computed(() => {
-  if (!quotaStatus.value || quotaStatus.value.limit_tokens == null) return '不限'
-  return formatNumber(quotaStatus.value.remaining_tokens || 0)
-})
 
 const quotaUsagePercent = computed(() => {
   if (!quotaStatus.value?.limit_tokens) return 0
@@ -432,8 +451,9 @@ const trendChartOption = computed(() => {
         const items = Array.isArray(params) ? params : [params]
         const date = items[0]?.axisValue || ''
         const lines = items.map((item: any) => {
-          const val = formatNumber(Number(item.value) || 0)
-          return `${item.marker}${item.seriesName}: ${val}`
+          const val = formatTokenCompact(Number(item.value) || 0)
+          const full = formatTokenFull(Number(item.value) || 0)
+          return `${item.marker}${item.seriesName}: ${val}${val !== full ? ` (${full})` : ''}`
         })
         return [date, ...lines].join('<br/>')
       },
@@ -452,7 +472,7 @@ const trendChartOption = computed(() => {
         axisLine: { show: false },
         axisTick: { show: false },
         axisLabel: {
-          formatter: (value: number) => formatAxisValue(value),
+          formatter: (value: number) => formatTokenAxis(value),
         },
         splitLine: { lineStyle: { type: 'dashed', color: '#f3f4f6' } },
       },
@@ -461,7 +481,7 @@ const trendChartOption = computed(() => {
         axisLine: { show: false },
         axisTick: { show: false },
         axisLabel: {
-          formatter: (value: number) => formatAxisValue(value),
+          formatter: (value: number) => formatTokenAxis(value),
         },
         splitLine: { show: false },
       },
@@ -500,14 +520,6 @@ const trendChartOption = computed(() => {
 const formatNumber = (num: number) => {
   if (!num) return '0'
   return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
-}
-
-const formatAxisValue = (value: number) => {
-  const num = Number(value) || 0
-  if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(num >= 10_000_000 ? 0 : 1)}M`
-  if (num >= 10_000) return `${(num / 10_000).toFixed(num >= 100_000 ? 0 : 1)}万`
-  if (num >= 1_000) return `${(num / 1_000).toFixed(0)}k`
-  return String(num)
 }
 
 const formatDateTime = (value: string) => {

--- a/frontend/src/composables/useTokenQuota.ts
+++ b/frontend/src/composables/useTokenQuota.ts
@@ -1,0 +1,84 @@
+import { computed, ref } from 'vue'
+import axios from '@/utils/axios'
+
+export interface TokenQuotaStatus {
+  period_start: string
+  period_end: string
+  used_tokens: number
+  limit_tokens: number | null
+  remaining_tokens: number | null
+  source: string
+  source_label?: string | null
+  is_admin_bypass: boolean
+}
+
+const formatNumber = (num: number) => num.toLocaleString('zh-CN')
+
+export function useTokenQuota() {
+  const quotaStatus = ref<TokenQuotaStatus | null>(null)
+  const loading = ref(false)
+
+  const usagePercent = computed(() => {
+    if (!quotaStatus.value?.limit_tokens) return 0
+    return Math.min(
+      100,
+      Math.round((quotaStatus.value.used_tokens / quotaStatus.value.limit_tokens) * 100),
+    )
+  })
+
+  const isBlocked = computed(() => {
+    if (!quotaStatus.value || quotaStatus.value.is_admin_bypass) return false
+    if (quotaStatus.value.limit_tokens == null) return false
+    return quotaStatus.value.used_tokens >= quotaStatus.value.limit_tokens
+  })
+
+  const isWarning = computed(() => {
+    if (!quotaStatus.value || quotaStatus.value.is_admin_bypass) return false
+    if (quotaStatus.value.limit_tokens == null) return false
+    if (isBlocked.value) return false
+    return usagePercent.value >= 80
+  })
+
+  const bannerMessage = computed(() => {
+    if (!quotaStatus.value || quotaStatus.value.is_admin_bypass) return ''
+    if (quotaStatus.value.limit_tokens == null) return ''
+    if (isBlocked.value) {
+      return `本月 Token 额度已用尽（已用 ${formatNumber(quotaStatus.value.used_tokens)} / 上限 ${formatNumber(quotaStatus.value.limit_tokens)}），请联系管理员。`
+    }
+    if (isWarning.value) {
+      return `本月 Token 额度即将用尽（已用 ${formatNumber(quotaStatus.value.used_tokens)} / 上限 ${formatNumber(quotaStatus.value.limit_tokens)}，剩余 ${formatNumber(quotaStatus.value.remaining_tokens || 0)}）。`
+    }
+    return ''
+  })
+
+  const refreshQuota = async () => {
+    loading.value = true
+    try {
+      const res = await axios.get('/api/portal/quota/me')
+      quotaStatus.value = res.data
+    } catch (error) {
+      console.error('Failed to load token quota', error)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const ensureCanSend = async (): Promise<string | null> => {
+    await refreshQuota()
+    if (isBlocked.value) {
+      return bannerMessage.value || '本月 Token 额度已用尽，请联系管理员。'
+    }
+    return null
+  }
+
+  return {
+    quotaStatus,
+    loading,
+    usagePercent,
+    isBlocked,
+    isWarning,
+    bannerMessage,
+    refreshQuota,
+    ensureCanSend,
+  }
+}

--- a/frontend/src/composables/useTokenQuota.ts
+++ b/frontend/src/composables/useTokenQuota.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue'
 import axios from '@/utils/axios'
+import { formatTokenCompact } from '@/utils/tokenFormat'
 
 export interface TokenQuotaStatus {
   period_start: string
@@ -11,8 +12,6 @@ export interface TokenQuotaStatus {
   source_label?: string | null
   is_admin_bypass: boolean
 }
-
-const formatNumber = (num: number) => num.toLocaleString('zh-CN')
 
 export function useTokenQuota() {
   const quotaStatus = ref<TokenQuotaStatus | null>(null)
@@ -43,10 +42,10 @@ export function useTokenQuota() {
     if (!quotaStatus.value || quotaStatus.value.is_admin_bypass) return ''
     if (quotaStatus.value.limit_tokens == null) return ''
     if (isBlocked.value) {
-      return `本月 Token 额度已用尽（已用 ${formatNumber(quotaStatus.value.used_tokens)} / 上限 ${formatNumber(quotaStatus.value.limit_tokens)}），请联系管理员。`
+      return `本月 Token 额度已用尽（已用 ${formatTokenCompact(quotaStatus.value.used_tokens)} / 上限 ${formatTokenCompact(quotaStatus.value.limit_tokens)}），请联系管理员。`
     }
     if (isWarning.value) {
-      return `本月 Token 额度即将用尽（已用 ${formatNumber(quotaStatus.value.used_tokens)} / 上限 ${formatNumber(quotaStatus.value.limit_tokens)}，剩余 ${formatNumber(quotaStatus.value.remaining_tokens || 0)}）。`
+      return `本月 Token 额度即将用尽（已用 ${formatTokenCompact(quotaStatus.value.used_tokens)} / 上限 ${formatTokenCompact(quotaStatus.value.limit_tokens)}，剩余 ${formatTokenCompact(quotaStatus.value.remaining_tokens || 0)}）。`
     }
     return ''
   })

--- a/frontend/src/utils/quotaDisplay.ts
+++ b/frontend/src/utils/quotaDisplay.ts
@@ -1,0 +1,77 @@
+import {
+  formatTokenCompact,
+  formatTokenFull,
+  shouldShowTokenFullHint,
+} from '@/utils/tokenFormat'
+
+export interface QuotaStatusLike {
+  period_start: string
+  period_end: string
+  used_tokens: number
+  limit_tokens: number | null
+  remaining_tokens: number | null
+  source_label?: string | null
+  is_admin_bypass: boolean
+}
+
+function tokenLine(label: string, value: number, unlimited = false): string {
+  if (unlimited) return `- ${label}：不限`
+  const compact = formatTokenCompact(value)
+  const full = formatTokenFull(value)
+  if (shouldShowTokenFullHint(value) && compact !== full) {
+    return `- ${label}：**${compact}**（${full}）`
+  }
+  return `- ${label}：**${compact}**`
+}
+
+/** 对话内展示本月额度（Markdown） */
+export function buildQuotaStatusMarkdown(status: QuotaStatusLike | null): string {
+  if (!status) {
+    return '❌ 暂时无法获取额度信息，请稍后重试，或前往个人中心查看。'
+  }
+
+  const period = `${status.period_start} ~ ${status.period_end}`
+
+  if (status.is_admin_bypass) {
+    return [
+      '✅ **本月 Token 额度：管理员豁免**',
+      '',
+      `- 统计周期：${period}`,
+      `- 已用：${formatTokenCompact(status.used_tokens)}`,
+      '',
+      '> 系统管理员不受月 Token 上限限制。',
+    ].join('\n')
+  }
+
+  if (status.limit_tokens == null) {
+    return [
+      '📊 **本月 Token 用量**',
+      '',
+      `- 统计周期：${period}`,
+      tokenLine('已用', status.used_tokens),
+      '- 上限：不限额',
+      status.source_label ? `\n> 策略来源：${status.source_label}` : '',
+    ].filter(Boolean).join('\n')
+  }
+
+  const used = status.used_tokens
+  const limit = status.limit_tokens
+  const remaining = status.remaining_tokens ?? Math.max(limit - used, 0)
+  const percent = Math.min(100, Math.round((used / limit) * 100))
+  const header =
+    percent >= 100 ? '🚫 **本月 Token 额度已用尽**' :
+    percent >= 80 ? '⚠️ **本月 Token 额度即将用尽**' :
+    '📊 **本月 Token 额度**'
+
+  return [
+    header,
+    '',
+    `- 统计周期：${period}`,
+    tokenLine('已用', used),
+    tokenLine('上限', limit),
+    tokenLine('剩余', remaining),
+    `- 已使用：**${percent}%**`,
+    status.source_label ? `\n> 策略来源：${status.source_label}` : '',
+    percent >= 100 ? '\n> 请联系管理员调整额度，或前往 **个人中心 → 我的 Token 消耗** 查看明细。' : '',
+  ].filter(Boolean).join('\n')
+}

--- a/frontend/src/utils/tokenFormat.ts
+++ b/frontend/src/utils/tokenFormat.ts
@@ -1,0 +1,61 @@
+/**
+ * Token 数量展示：大数用 K / M / B，小数以千分位显示。
+ */
+
+const COMPACT_THRESHOLD = 1_000_000
+
+function trimDecimals(value: number, decimals = 2): string {
+  return value.toFixed(decimals).replace(/\.?0+$/, '')
+}
+
+export function normalizeTokenCount(value: number | null | undefined): number {
+  if (value == null || Number.isNaN(value)) return 0
+  return Math.max(0, Math.round(value))
+}
+
+/** 完整千分位，如 1,234,567 */
+export function formatTokenFull(value: number | null | undefined): string {
+  return normalizeTokenCount(value).toLocaleString('zh-CN')
+}
+
+/** 紧凑展示：≥1M 用 M，≥1B 用 B，否则千分位 */
+export function formatTokenCompact(value: number | null | undefined): string {
+  const num = normalizeTokenCount(value)
+  if (num >= 1_000_000_000) {
+    return `${trimDecimals(num / 1_000_000_000)}B`
+  }
+  if (num >= 1_000_000) {
+    return `${trimDecimals(num / 1_000_000)}M`
+  }
+  if (num >= 10_000) {
+    return `${trimDecimals(num / 1_000, num >= 100_000 ? 0 : 1)}K`
+  }
+  return formatTokenFull(num)
+}
+
+/** 图表坐标轴：与紧凑格式一致 */
+export function formatTokenAxis(value: number | null | undefined): string {
+  return formatTokenCompact(value)
+}
+
+/** 紧凑格式与完整数字不同时，可展示副标题 */
+export function shouldShowTokenFullHint(value: number | null | undefined): boolean {
+  const num = normalizeTokenCount(value)
+  return num >= COMPACT_THRESHOLD
+}
+
+/** 输入框下方提示：约合 X M / X B */
+export function formatTokenInputHint(value: number | null | undefined): string {
+  const num = normalizeTokenCount(value)
+  if (num <= 0) return ''
+  if (num >= 1_000_000_000) {
+    return `约合 ${trimDecimals(num / 1_000_000_000)}B Token（${formatTokenFull(num)}）`
+  }
+  if (num >= 1_000_000) {
+    return `约合 ${trimDecimals(num / 1_000_000)}M Token（${formatTokenFull(num)}）`
+  }
+  if (num >= 10_000) {
+    return `约合 ${trimDecimals(num / 1_000, num >= 100_000 ? 0 : 1)}K Token（${formatTokenFull(num)}）`
+  }
+  return `共 ${formatTokenFull(num)} Token`
+}

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -31,6 +31,8 @@ import {
   type PendingToolPermission,
 } from "@/utils/agentscopeSseHandlers";
 import { useToast } from "../composables/useToast";
+import { useTokenQuota } from "@/composables/useTokenQuota";
+import { buildQuotaStatusMarkdown } from "@/utils/quotaDisplay";
 import { isActiveThoughtStep, isDimmedThoughtStep } from "@/utils/turnLogDisplay";
 
 import ChatInput from "@/components/embed/ChatInput.vue";
@@ -59,6 +61,7 @@ import { isKnowledgeToolLog } from "@/utils/knowledgeToolLog";
 
 const route = useRoute();
 const { showToast } = useToast();
+const { quotaStatus, refreshQuota } = useTokenQuota();
 
 // --- New Features State ---
 const showSessionPreview = ref(false);
@@ -319,6 +322,7 @@ const SYSTEM_SLASH_COMMANDS = [
   { id: DATASET_PORTAL_SYSTEM_COMMAND_ID, command: DATASET_PORTAL_SLASH_COMMAND, label: "📚 数据门户", sort_order: -35 },
   { id: "sys_clear", command: "/new", label: "💬 新会话", sort_order: -30 },
   { id: "sys_history", command: "/history", label: "🕒 历史", sort_order: -20 },
+  { id: "sys_quota", command: "/quota", label: "📊 我的额度", sort_order: -18 },
   { id: "sys_settings", command: "/settings", label: "⚙️ 设置", sort_order: -15 },
 ];
 const slashCommands = ref<any[]>([...SYSTEM_SLASH_COMMANDS]);
@@ -2156,6 +2160,26 @@ watch(
   }
 );
 
+const showQuotaStatusInChat = async () => {
+  messages.value.push({
+    id: Date.now(),
+    role: "user",
+    content: "/quota",
+    timestamp: new Date().toISOString(),
+  });
+  await refreshQuota();
+  messages.value.push({
+    id: Date.now() + 1,
+    role: "agent",
+    agentName: "sys_quota",
+    agentDisplayName: "系统助手",
+    content: buildQuotaStatusMarkdown(quotaStatus.value),
+    timestamp: new Date().toISOString(),
+  });
+  await nextTick();
+  scrollToBottom(true);
+};
+
 const handleSystemCommand = async (cmd: string): Promise<boolean> => {
   const normalizedCmd = normalizeAgentSwitchCommand(cmd, agents.value);
   if (isDatasetPortalSlashCommand(normalizedCmd)) {
@@ -2189,6 +2213,11 @@ const handleSystemCommand = async (cmd: string): Promise<boolean> => {
     case "/settings":
       userInput.value = "";
       showConfigPanel.value = !showConfigPanel.value;
+      return true;
+    case "/quota":
+    case "/tokens":
+      userInput.value = "";
+      await showQuotaStatusInChat();
       return true;
     case "/new":
     case "/clear":

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -1242,6 +1242,13 @@
 
     <!-- Input Area -->
     <div class="flex-shrink-0 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 relative z-20">
+      <div
+        v-if="quotaBannerMessage"
+        class="px-4 py-2 text-xs border-b"
+        :class="quotaIsBlocked ? 'bg-rose-50 text-rose-800 border-rose-100' : 'bg-amber-50 text-amber-800 border-amber-100'"
+      >
+        {{ quotaBannerMessage }}
+      </div>
       <ChatInput
         ref="chatInputRef"
         v-model="userInput"
@@ -2560,6 +2567,7 @@ import { finalizeConversation } from "@/utils/conversationFinalize";
 import { cancelConversationRun } from "@/utils/cancelConversationRun";
 import { createConversationId } from "@/utils/conversationId";
 import { useToast } from "../composables/useToast";
+import { useTokenQuota } from "../composables/useTokenQuota";
 import { useDatasetPortal } from "@/composables/useDatasetPortal";
 import {
   DATASET_PORTAL_SLASH_COMMAND,
@@ -2568,6 +2576,12 @@ import {
 } from "@/constants/datasetPortalCommand";
 
 const toast = useToast();
+const {
+  bannerMessage: quotaBannerMessage,
+  isBlocked: quotaIsBlocked,
+  refreshQuota,
+  ensureCanSend,
+} = useTokenQuota();
 const showToast = toast.showToast;
 import MessageRenderer from "@/components/MessageRenderer.vue";
 import DatasetCapabilityMenu from "@/components/chatbi/DatasetCapabilityMenu.vue";
@@ -5997,6 +6011,12 @@ const sendMessage = async () => {
   const files = chatInputRef.value?.uploadedFiles ? Array.from(chatInputRef.value.uploadedFiles) as ChatFile[] : [];
   if ((!content && files.length === 0) || isProcessing.value) return;
 
+  const quotaBlock = await ensureCanSend();
+  if (quotaBlock) {
+    showToast(quotaBlock, "error");
+    return;
+  }
+
   if (files.length === 0 && tryLocalChartOptionPatch(content)) {
     userInput.value = "";
     showCommandMenu.value = false;
@@ -6249,6 +6269,7 @@ const sendMessage = async () => {
   } finally {
     isProcessing.value = false;
     agentMsg.value.isThinking = false;
+    void refreshQuota();
     clearStallTimer();
     clearStalePendingTimer();
     showStalledPrompt.value = false;
@@ -6332,6 +6353,7 @@ const fetchUserInfo = async () => {
     if (res.data?.data) {
        currentUser.value = res.data.data;
     }
+    await refreshQuota();
   } catch (err) {
     console.warn("[Auth] Failed to fetch user info:", err);
   }

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -2568,6 +2568,7 @@ import { cancelConversationRun } from "@/utils/cancelConversationRun";
 import { createConversationId } from "@/utils/conversationId";
 import { useToast } from "../composables/useToast";
 import { useTokenQuota } from "../composables/useTokenQuota";
+import { buildQuotaStatusMarkdown } from "@/utils/quotaDisplay";
 import { useDatasetPortal } from "@/composables/useDatasetPortal";
 import {
   DATASET_PORTAL_SLASH_COMMAND,
@@ -2579,6 +2580,7 @@ const toast = useToast();
 const {
   bannerMessage: quotaBannerMessage,
   isBlocked: quotaIsBlocked,
+  quotaStatus,
   refreshQuota,
   ensureCanSend,
 } = useTokenQuota();
@@ -3452,6 +3454,7 @@ const SYSTEM_SLASH_COMMANDS = [
   { id: DATASET_PORTAL_SYSTEM_COMMAND_ID, command: DATASET_PORTAL_SLASH_COMMAND, label: "📚 数据门户", sort_order: -35 },
   { id: "sys_clear", command: "/new", label: "💬 新会话", sort_order: -30 },
   { id: "sys_history", command: "/history", label: "🕒 历史", sort_order: -20 },
+  { id: "sys_quota", command: "/quota", label: "📊 我的额度", sort_order: -18 },
   { id: "sys_settings", command: "/settings", label: "⚙️ 设置", sort_order: -15 },
 ];
 const showCommandMenu = ref(false);
@@ -5293,6 +5296,28 @@ const fetchConversationHistory = async (isLoadMore = false) => {
     isLoadingHistory.value = false;
   }
 };
+
+const showQuotaStatusInChat = async () => {
+  messages.value.push({
+    id: Date.now(),
+    role: "user",
+    content: "/quota",
+    timestamp: new Date().toISOString(),
+  });
+  await refreshQuota();
+  messages.value.push({
+    id: Date.now() + 1,
+    role: "agent",
+    agentName: "sys_quota",
+    agentDisplayName: "系统助手",
+    content: buildQuotaStatusMarkdown(quotaStatus.value),
+    timestamp: new Date().toISOString(),
+  });
+  autoScrollEnabled.value = true;
+  await nextTick();
+  scrollToBottom(true);
+};
+
 // --- Logic ---
 const handleSystemCommand = async (cmd: string): Promise<boolean> => {
   const normalizedCmd = normalizeAgentSwitchCommand(cmd, allowedAgents.value);
@@ -5324,6 +5349,11 @@ const handleSystemCommand = async (cmd: string): Promise<boolean> => {
     case "/settings":
       userInput.value = "";
       showSettings.value = true;
+      return true;
+    case "/quota":
+    case "/tokens":
+      userInput.value = "";
+      await showQuotaStatusInChat();
       return true;
     case "/new":
     case "/clear": // legacy alias

--- a/frontend/src/views/MetadataDatasets.vue
+++ b/frontend/src/views/MetadataDatasets.vue
@@ -7,6 +7,7 @@ import { portalApi, type User, type Role } from '../api/portal'
 import axios from '@/utils/axios'
 import SmartImportWizard from '../components/metadata/SmartImportWizard.vue'
 import RowFilterOptionSelect from '../components/metadata/RowFilterOptionSelect.vue'
+import PermissionVariableMenu from '../components/metadata/PermissionVariableMenu.vue'
 import { useUser } from '../composables/useUser'
 import { useToast } from '../composables/useToast'
 
@@ -84,50 +85,78 @@ const OPERATORS = [
   { label: '小于 (<)', value: '<' }
 ]
 
-const SYSTEM_VARIABLES = computed(() => {
-  const baseVariables = [
-    { label: '用户 ID', value: '{user.id}' },
-    { label: '用户名', value: '{user.user_name}' },
-    { label: '真实姓名', value: '{user.real_name}' },
-    { label: '部门代码', value: '{user.dept_code}' },
-    { label: '组织全路径', value: '{user.org_path}' },
-    { label: '角色', value: '{user.role}' }
-  ]
+const BUILTIN_USER_VARIABLES = [
+  { label: '用户 ID', value: '{user.id}' },
+  { label: '用户名', value: '{user.user_name}' },
+  { label: '真实姓名', value: '{user.real_name}' },
+  { label: '部门代码', value: '{user.dept_code}' },
+  { label: '组织全路径', value: '{user.org_path}' },
+  { label: '角色', value: '{user.role}' },
+] as const
 
-  // Try to load extra dimensions from current user
+const CORE_USER_DIMENSION_KEYS = new Set([
+  'id', 'user_id', 'user_name', 'real_name', 'dept_code', 'org_path', 'role', 'extra_data',
+])
+
+const parseUserExtraDataObject = (raw: unknown): Record<string, unknown> => {
+  if (!raw) return {}
+  if (typeof raw === 'string') {
+    const text = raw.trim()
+    if (!text) return {}
+    try {
+      const parsed = JSON.parse(text)
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+  if (typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>
+  }
+  return {}
+}
+
+const formatExtraDataSample = (value: unknown): string | undefined => {
+  if (value == null) return undefined
+  const text = typeof value === 'object' ? JSON.stringify(value) : String(value).trim()
+  if (!text) return undefined
+  return text.length > 40 ? `${text.slice(0, 37)}...` : text
+}
+
+const EXTRA_DATA_USER_VARIABLES = computed(() => {
+  const keySamples = new Map<string, string | undefined>()
+
+  const collectFromExtraData = (extraData: unknown) => {
+    const extra = parseUserExtraDataObject(extraData)
+    for (const [key, value] of Object.entries(extra)) {
+      if (CORE_USER_DIMENSION_KEYS.has(key)) continue
+      if (!keySamples.has(key)) {
+        keySamples.set(key, formatExtraDataSample(value))
+      }
+    }
+  }
+
+  for (const user of allUsers.value) {
+    collectFromExtraData(user.extra_data)
+  }
+
+  // 兜底：当前登录用户 localStorage 中的 extra_data
   try {
     const userInfoStr = localStorage.getItem('user_info')
     if (userInfoStr) {
-      const userInfo = JSON.parse(userInfoStr)
-      let extraData = userInfo.extra_data
-      
-      // If extra_data is a string, parse it
-      if (typeof extraData === 'string' && extraData.trim()) {
-        try {
-          extraData = JSON.parse(extraData)
-        } catch (e) {
-          console.warn('Failed to parse extra_data from userInfo', e)
-          extraData = {}
-        }
-      }
-
-      if (extraData && typeof extraData === 'object') {
-        const baseKeys = new Set(['id', 'user_id', 'user_name', 'real_name', 'dept_code', 'org_path', 'role', 'extra_data'])
-        Object.keys(extraData).forEach(key => {
-          if (!baseKeys.has(key)) {
-            baseVariables.push({
-              label: `${key} (扩展)`,
-              value: `{user.${key}}`
-            })
-          }
-        })
-      }
+      collectFromExtraData(JSON.parse(userInfoStr)?.extra_data)
     }
-  } catch (err) {
-    console.error('Error computing dynamic system variables:', err)
+  } catch {
+    // ignore
   }
 
-  return baseVariables
+  return Array.from(keySamples.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, sample]) => ({
+      label: key,
+      value: `{user.${key}}`,
+      sample,
+    }))
 })
 const syncingId = ref<number | null>(null)
 const enhancing = ref(false)
@@ -2147,11 +2176,13 @@ relationships:
                                 <button @click.stop="toggleMenu(`visual-user-${userId}-${idx}-vars`)" class="flex-shrink-0 h-[2.625rem] w-9 rounded-lg text-amber-600 hover:bg-amber-50 transition-colors border border-amber-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
                                   { }
                                 </button>
-                                <div v-if="activeMenuPath === `visual-user-${userId}-${idx}-vars`" class="absolute right-0 top-full mt-1 w-36 bg-white rounded-lg shadow-xl border border-gray-100 z-[9999] max-h-48 overflow-y-auto custom-scrollbar">
-                                  <button v-for="v in SYSTEM_VARIABLES" :key="v.value" @click="rule._builder_val = v.value; closeMenus()" class="w-full text-left px-3 py-1.5 text-[9px] hover:bg-amber-50 border-b border-gray-50 last:border-0 whitespace-nowrap">
-                                    {{ v.label }} ({{ v.value }})
-                                  </button>
-                                </div>
+                                <PermissionVariableMenu
+                                  v-if="activeMenuPath === `visual-user-${userId}-${idx}-vars`"
+                                  :builtin-variables="[...BUILTIN_USER_VARIABLES]"
+                                  :extra-data-variables="EXTRA_DATA_USER_VARIABLES"
+                                  accent="amber"
+                                  @select="(v) => { rule._builder_val = v; closeMenus() }"
+                                />
                               </div>
                             </div>
                             <button @click="appendBuilderCondition(rule)" class="bg-amber-700 hover:bg-amber-800 text-white w-10 h-[2.625rem] rounded-lg flex items-center justify-center transition-all shadow-md disabled:opacity-30 disabled:scale-100 active:scale-95" :disabled="!rule._builder_table || !rule._builder_field || !rule._builder_op || !rule._builder_val" title="追加条件">
@@ -2277,11 +2308,13 @@ relationships:
                                   <button @click.stop="toggleMenu(`role-${roleName}-${idx}-vars`)" class="flex-shrink-0 h-[2.625rem] w-9 rounded-lg text-emerald-600 hover:bg-emerald-50 transition-colors border border-emerald-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
                                     { }
                                   </button>
-                                  <div v-if="activeMenuPath === `role-${roleName}-${idx}-vars`" class="absolute right-0 top-full mt-1 w-36 bg-white rounded-lg shadow-xl border border-gray-100 z-[9999] max-h-48 overflow-y-auto custom-scrollbar">
-                                    <button v-for="v in SYSTEM_VARIABLES" :key="v.value" @click="rule._builder_val = v.value; closeMenus()" class="w-full text-left px-3 py-1.5 text-[9px] hover:bg-emerald-50 border-b border-gray-50 last:border-0 whitespace-nowrap">
-                                      {{ v.label }} ({{ v.value }})
-                                    </button>
-                                  </div>
+                                  <PermissionVariableMenu
+                                    v-if="activeMenuPath === `role-${roleName}-${idx}-vars`"
+                                    :builtin-variables="[...BUILTIN_USER_VARIABLES]"
+                                    :extra-data-variables="EXTRA_DATA_USER_VARIABLES"
+                                    accent="emerald"
+                                    @select="(v) => { rule._builder_val = v; closeMenus() }"
+                                  />
                                 </div>
                               </div>
                               
@@ -2376,11 +2409,13 @@ relationships:
                                     <button @click.stop="toggleMenu(`user-${uid}-${idx}-vars`)" class="flex-shrink-0 h-[2.625rem] w-9 rounded-lg text-amber-600 hover:bg-amber-50 transition-colors border border-amber-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
                                       { }
                                     </button>
-                                    <div v-if="activeMenuPath === `user-${uid}-${idx}-vars`" class="absolute right-0 top-full mt-1 w-36 bg-white rounded-lg shadow-xl border border-gray-100 z-[9999] max-h-48 overflow-y-auto custom-scrollbar">
-                                      <button v-for="v in SYSTEM_VARIABLES" :key="v.value" @click="rule._builder_val = v.value; closeMenus()" class="w-full text-left px-3 py-1.5 text-[9px] hover:bg-amber-50 border-b border-gray-50 last:border-0 whitespace-nowrap">
-                                        {{ v.label }} ({{ v.value }})
-                                      </button>
-                                    </div>
+                                    <PermissionVariableMenu
+                                      v-if="activeMenuPath === `user-${uid}-${idx}-vars`"
+                                      :builtin-variables="[...BUILTIN_USER_VARIABLES]"
+                                      :extra-data-variables="EXTRA_DATA_USER_VARIABLES"
+                                      accent="amber"
+                                      @select="(v) => { rule._builder_val = v; closeMenus() }"
+                                    />
                                   </div>
                                 </div>
                                 
@@ -2465,11 +2500,13 @@ relationships:
                                <button @click.stop="toggleMenu(`default-${idx}-vars`)" class="flex-shrink-0 h-[2.625rem] w-9 rounded-lg text-emerald-600 hover:bg-emerald-50 transition-colors border border-emerald-100 bg-white flex items-center justify-center font-bold" title="插入内部变量">
                                  { }
                                </button>
-                               <div v-if="activeMenuPath === `default-${idx}-vars`" class="absolute right-0 top-full mt-1 w-36 bg-white rounded-lg shadow-xl border border-gray-100 z-[9999] max-h-48 overflow-y-auto custom-scrollbar">
-                                 <button v-for="v in SYSTEM_VARIABLES" :key="v.value" @click="rule._builder_val = v.value; closeMenus()" class="w-full text-left px-3 py-1.5 text-[9px] hover:bg-emerald-50 border-b border-gray-50 last:border-0">
-                                   {{ v.label }} ({{ v.value }})
-                                 </button>
-                               </div>
+                               <PermissionVariableMenu
+                                 v-if="activeMenuPath === `default-${idx}-vars`"
+                                 :builtin-variables="[...BUILTIN_USER_VARIABLES]"
+                                 :extra-data-variables="EXTRA_DATA_USER_VARIABLES"
+                                 accent="slate"
+                                 @select="(v) => { rule._builder_val = v; closeMenus() }"
+                               />
                              </div>
                            </div>
                            
@@ -2576,6 +2613,29 @@ relationships:
                <div class="p-2 bg-gray-50 rounded border border-gray-100 font-mono"><span class="text-blue-600 font-bold">{user.org_path}</span> 组织全路径</div>
                <div class="p-2 bg-gray-50 rounded border border-gray-100 font-mono"><span class="text-blue-600 font-bold">{user.role}</span> 系统角色</div>
              </div>
+             <p class="text-[10px] text-gray-500 mt-2">以上 6 项为<strong>内置用户属性</strong>，所有用户均可用。</p>
+           </section>
+
+           <section class="space-y-2">
+             <h3 class="font-bold text-gray-800 flex items-center gap-2 text-sm">
+               <span class="w-1 h-4 bg-violet-500 rounded-full"></span>
+               extra_data 扩展字段
+             </h3>
+             <p class="text-[10px] text-gray-600 leading-relaxed">
+               来自用户 <code class="text-violet-600 bg-violet-50 px-1 rounded">extra_data</code> JSON 的键，运行时摊平为
+               <code class="font-mono text-violet-600">{user.键名}</code>。下拉列表从平台用户聚合展示，并标注「扩展」与内置变量区分。
+             </p>
+             <div v-if="EXTRA_DATA_USER_VARIABLES.length" class="grid grid-cols-1 gap-1.5 text-[10px] max-h-32 overflow-y-auto">
+               <div
+                 v-for="v in EXTRA_DATA_USER_VARIABLES"
+                 :key="v.value"
+                 class="p-2 bg-violet-50 rounded border border-violet-100 font-mono flex items-center justify-between gap-2"
+               >
+                 <span><span class="text-violet-700 font-bold">{{ v.value }}</span> {{ v.label }}</span>
+                 <span class="text-[8px] px-1 py-0.5 rounded bg-violet-100 text-violet-600 font-bold shrink-0">扩展</span>
+               </div>
+             </div>
+             <p v-else class="text-[10px] text-gray-400">当前暂无 extra_data 扩展字段，可在用户管理或第三方用户同步中配置。</p>
            </section>
 
            <section class="space-y-4">

--- a/frontend/src/views/Overview.vue
+++ b/frontend/src/views/Overview.vue
@@ -124,7 +124,7 @@
         <!-- Token Usage -->
         <StatsCard
           title="Token 消耗"
-          :value="formatCompactNumber(stats?.total_tokens || 0)"
+          :value="formatTokenCompact(stats?.total_tokens || 0)"
           type="warning"
         >
           <template #icon>
@@ -134,8 +134,8 @@
           </template>
           <template #subtext>
             <div class="flex flex-col gap-0.5 leading-tight mt-0.5">
-              <span>输入 {{ formatCompactNumber(stats?.prompt_tokens || 0) }}</span>
-              <span>输出 {{ formatCompactNumber(stats?.completion_tokens || 0) }}</span>
+              <span>输入 {{ formatTokenCompact(stats?.prompt_tokens || 0) }}</span>
+              <span>输出 {{ formatTokenCompact(stats?.completion_tokens || 0) }}</span>
             </div>
           </template>
         </StatsCard>
@@ -246,7 +246,7 @@
         <!-- Token Usage -->
         <StatsCard
           title="我的 Token"
-          :value="formatCompactNumber(stats?.total_tokens || 0)"
+          :value="formatTokenCompact(stats?.total_tokens || 0)"
           type="purple"
         >
           <template #icon>
@@ -256,8 +256,8 @@
           </template>
           <template #subtext>
             <div class="flex flex-col gap-0.5 leading-tight mt-0.5">
-              <span>输入 {{ formatCompactNumber(stats?.prompt_tokens || 0) }}</span>
-              <span>输出 {{ formatCompactNumber(stats?.completion_tokens || 0) }}</span>
+              <span>输入 {{ formatTokenCompact(stats?.prompt_tokens || 0) }}</span>
+              <span>输出 {{ formatTokenCompact(stats?.completion_tokens || 0) }}</span>
             </div>
           </template>
         </StatsCard>
@@ -387,6 +387,7 @@ import RecentUsersCard from "../components/dashboard/RecentUsersCard.vue";
 import RecentCallsCard from "../components/dashboard/RecentCallsCard.vue";
 import RequestTrendChart from "../components/dashboard/RequestTrendChart.vue";
 import RecentFailuresCard from "../components/dashboard/RecentFailuresCard.vue";
+import { formatTokenCompact } from "@/utils/tokenFormat";
 
 const router = useRouter();
 const API_BASE = ""; // Using relative path with axios instance proxy
@@ -544,17 +545,6 @@ const loadUserInfo = () => {
   if (stored) {
     userInfo.value = JSON.parse(stored);
   }
-};
-
-const formatCompactNumber = (num: number) => {
-  if (num === undefined || num === null) return "0";
-  if (num >= 1.0e9) {
-    return (num / 1.0e9).toFixed(2).replace(/\.00$/, "") + " B";
-  }
-  if (num >= 1.0e6) {
-    return (num / 1.0e6).toFixed(2).replace(/\.00$/, "") + " M";
-  }
-  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 };
 
 onMounted(async () => {

--- a/frontend/src/views/PersonalCenter.vue
+++ b/frontend/src/views/PersonalCenter.vue
@@ -101,8 +101,9 @@ const handlePasswordChange = async () => {
 import { watch } from 'vue'
 import Modal from '../components/Modal.vue'
 import ConfirmModal from '../components/ConfirmModal.vue'
+import PersonalTokenUsage from '../components/personal/PersonalTokenUsage.vue'
 
-const activeTab = ref<'info' | 'permissions' | 'memory'>('info')
+const activeTab = ref<'info' | 'permissions' | 'memory' | 'tokens'>('info')
 const permissionsSubTab = ref<'list' | 'about'>('list')
 const showAboutTab = computed(() => !!branding.value.contact_markdown?.trim())
 const contactHtml = computed(() => renderMarkdown(branding.value.contact_markdown || ''))
@@ -524,7 +525,7 @@ onMounted(() => {
         
         <!-- Tabs -->
         <div class="border-b border-gray-200 mb-4 sm:mb-6">
-            <nav class="-mb-px flex space-x-4 sm:space-x-8">
+            <nav class="-mb-px flex space-x-4 sm:space-x-8 overflow-x-auto">
                 <button 
                     @click="activeTab = 'info'"
                     :class="[
@@ -557,6 +558,17 @@ onMounted(() => {
                     ]"
                 >
                     我的记忆
+                </button>
+                <button 
+                    @click="activeTab = 'tokens'"
+                    :class="[
+                        activeTab === 'tokens'
+                            ? 'border-blue-500 text-blue-600'
+                            : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
+                        'whitespace-nowrap py-3 sm:py-4 px-1 border-b-2 font-medium text-xs sm:text-sm transition-colors'
+                    ]"
+                >
+                    我的 Token 消耗
                 </button>
             </nav>
         </div>
@@ -1119,6 +1131,11 @@ onMounted(() => {
                     </div>
                 </div>
             </div>
+        </div>
+
+        <!-- Token Usage Tab -->
+        <div v-else-if="activeTab === 'tokens'">
+            <PersonalTokenUsage />
         </div>
 
     </div>

--- a/frontend/src/views/Roles.vue
+++ b/frontend/src/views/Roles.vue
@@ -240,7 +240,7 @@
             </div>
             
             <!-- Main Tabs (Assets vs UI) -->
-            <div class="flex-shrink-0 flex items-center space-x-1 p-1 bg-gray-100 rounded-xl my-4 sm:my-6 w-full max-w-xs mx-auto">
+            <div class="flex-shrink-0 flex items-center space-x-1 p-1 bg-gray-100 rounded-xl my-4 sm:my-6 w-full max-w-md mx-auto">
                 <button 
                     @click="activeMainTab = 'assets'"
                     :class="activeMainTab === 'assets' ? 'bg-white text-blue-600 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
@@ -254,6 +254,13 @@
                     class="flex-1 py-2 rounded-lg text-xs font-bold transition-all"
                 >
                     🎨 菜单功能
+                </button>
+                <button 
+                    @click="activeMainTab = 'quota'"
+                    :class="activeMainTab === 'quota' ? 'bg-white text-blue-600 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
+                    class="flex-1 py-2 rounded-lg text-xs font-bold transition-all"
+                >
+                    📊 额度
                 </button>
             </div>
 
@@ -336,7 +343,7 @@
                 </template>
 
                 <!-- Tab 2: UI Interface Permissions -->
-                <template v-else>
+                <template v-else-if="activeMainTab === 'ui'">
                     <div class="flex-1 overflow-y-auto bg-gray-50 p-3 sm:p-6 rounded-xl border border-gray-200">
                         <div class="space-y-4">
                             <div v-for="menu in MENU_TREE" :key="menu.id" class="bg-white rounded-xl border border-gray-200 overflow-hidden shadow-sm">
@@ -379,11 +386,23 @@
                         <span class="text-blue-600 font-bold">已选菜单: {{ permissionData.menus.length }}</span>
                     </div>
                 </template>
+
+                <!-- Tab 3: Quota -->
+                <template v-else-if="activeMainTab === 'quota'">
+                    <div class="flex-1 min-h-0 overflow-y-auto px-1">
+                        <QuotaPolicyPanel
+                            v-if="currentRole"
+                            scope-type="role"
+                            :scope-id="currentRole.id"
+                        />
+                    </div>
+                </template>
             </div>
 
             <div class="flex-shrink-0 p-4 sm:p-0 mt-2 sm:mt-6 flex flex-col sm:flex-row justify-end gap-2 sm:pt-4 border-t border-gray-100 sm:border-t-0">
                 <button @click="closePermissionDialog" class="order-2 sm:order-1 px-4 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm font-medium">取消</button>
                 <button 
+                    v-if="activeMainTab !== 'quota'"
                     @click="savePermissions" 
                     :disabled="submittingPerms" 
                     class="order-1 sm:order-2 px-4 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm font-bold shadow-lg shadow-blue-200"
@@ -547,6 +566,7 @@ import { ref, onMounted, computed, onUnmounted } from 'vue'
 import axios from 'axios'
 import { useToast } from '../composables/useToast'
 import { MENU_TREE } from '../constants/permissions'
+import QuotaPolicyPanel from '../components/admin/QuotaPolicyPanel.vue'
 
 const { showToast } = useToast()
 
@@ -599,7 +619,7 @@ const assignedUserIds = ref<number[]>([])
 const userSearchQuery = ref('')
 
 // Permissions
-const activeMainTab = ref<'assets' | 'ui'>('assets')
+const activeMainTab = ref<'assets' | 'ui' | 'quota'>('assets')
 const activeResTab = ref<'agents' | 'datasets' | 'metadata' | 'apis'>('agents')
 const resourceTypes = ['agents', 'datasets', 'metadata', 'apis'] as const
 

--- a/frontend/src/views/TokenStats.vue
+++ b/frontend/src/views/TokenStats.vue
@@ -47,19 +47,25 @@
         <div class="min-w-0 flex-1 space-y-2">
           <span class="text-sm font-medium text-gray-500">Token 消耗</span>
           <h3 class="text-2xl sm:text-3xl font-black text-gray-900 tabular-nums leading-none">
-            {{ formatCompactNumber(summaryData.total_tokens) }}
+            {{ formatTokenCompact(summaryData.total_tokens) }}
           </h3>
+          <p
+            v-if="shouldShowTokenFullHint(summaryData.total_tokens)"
+            class="text-[10px] text-gray-400 tabular-nums"
+          >
+            {{ formatTokenFull(summaryData.total_tokens) }}
+          </p>
           <div class="text-xs text-gray-500 space-y-1 leading-relaxed">
             <p class="text-sky-700">
               <span class="text-gray-400">输入</span>
-              {{ formatCompactNumber(summaryData.prompt_tokens) }}
+              <span :title="formatTokenFull(summaryData.prompt_tokens)">{{ formatTokenCompact(summaryData.prompt_tokens) }}</span>
             </p>
             <p class="text-rose-700">
               <span class="text-gray-400">输出</span>
-              {{ formatCompactNumber(summaryData.completion_tokens) }}
+              <span :title="formatTokenFull(summaryData.completion_tokens)">{{ formatTokenCompact(summaryData.completion_tokens) }}</span>
             </p>
             <p v-if="summaryData.legacy_tokens > 0" class="text-amber-700/90 pt-0.5">
-              历史未拆分 {{ formatCompactNumber(summaryData.legacy_tokens) }}
+              历史未拆分 <span :title="formatTokenFull(summaryData.legacy_tokens)">{{ formatTokenCompact(summaryData.legacy_tokens) }}</span>
             </p>
           </div>
         </div>
@@ -86,7 +92,7 @@
       <div class="bg-white rounded-2xl p-5 border border-gray-100 shadow-sm flex items-center justify-between gap-3">
         <div class="min-w-0 flex-1 space-y-1">
           <span class="text-sm font-medium text-gray-500">平均单次</span>
-          <h3 class="text-2xl sm:text-3xl font-black text-gray-900 tabular-nums leading-none">{{ formatCompactNumber(summaryData.avg_tokens) }}</h3>
+          <h3 class="text-2xl sm:text-3xl font-black text-gray-900 tabular-nums leading-none">{{ formatTokenCompact(summaryData.avg_tokens) }}</h3>
           <p class="text-xs text-gray-400">Token / 会话</p>
         </div>
         <div class="flex-shrink-0 p-3.5 rounded-2xl bg-yellow-50/80 text-yellow-600">
@@ -169,10 +175,10 @@
               <tr v-for="agent in agentData" :key="agent.agent_id" class="hover:bg-gray-50/50 transition-colors">
                 <td class="py-3 px-4 font-medium text-gray-900 max-w-[12rem] truncate" :title="agent.name">{{ agent.name }}</td>
                 <td class="py-3 px-4 text-right tabular-nums">{{ formatNumber(agent.calls) }}</td>
-                <td class="py-3 px-4 text-right tabular-nums text-sky-700">{{ formatCompactNumber(agent.prompt_tokens || 0) }}</td>
-                <td class="py-3 px-4 text-right tabular-nums text-rose-700">{{ formatCompactNumber(agent.completion_tokens || 0) }}</td>
-                <td class="py-3 px-4 text-right tabular-nums font-semibold">{{ formatCompactNumber(effectiveAgentTokens(agent)) }}</td>
-                <td class="py-3 px-4 text-right tabular-nums text-gray-500">{{ formatCompactNumber(Math.round(effectiveAgentTokens(agent) / Math.max(agent.calls, 1))) }}</td>
+                <td class="py-3 px-4 text-right tabular-nums text-sky-700" :title="formatTokenFull(agent.prompt_tokens || 0)">{{ formatTokenCompact(agent.prompt_tokens || 0) }}</td>
+                <td class="py-3 px-4 text-right tabular-nums text-rose-700" :title="formatTokenFull(agent.completion_tokens || 0)">{{ formatTokenCompact(agent.completion_tokens || 0) }}</td>
+                <td class="py-3 px-4 text-right tabular-nums font-semibold" :title="formatTokenFull(effectiveAgentTokens(agent))">{{ formatTokenCompact(effectiveAgentTokens(agent)) }}</td>
+                <td class="py-3 px-4 text-right tabular-nums text-gray-500" :title="formatTokenFull(Math.round(effectiveAgentTokens(agent) / Math.max(agent.calls, 1)))">{{ formatTokenCompact(Math.round(effectiveAgentTokens(agent) / Math.max(agent.calls, 1))) }}</td>
               </tr>
             </tbody>
           </table>
@@ -213,9 +219,9 @@
               <td class="py-3.5 px-4 font-medium text-gray-900">{{ userItem.username }}</td>
               <td class="py-3.5 px-4 text-gray-600">{{ userItem.real_name || '-' }}</td>
               <td class="py-3.5 px-4 text-right tabular-nums">{{ formatNumber(userItem.calls) }}</td>
-              <td class="py-3.5 px-4 text-right tabular-nums text-sky-700">{{ formatCompactNumber(userItem.prompt_tokens || 0) }}</td>
-              <td class="py-3.5 px-4 text-right tabular-nums text-rose-700">{{ formatCompactNumber(userItem.completion_tokens || 0) }}</td>
-              <td class="py-3.5 px-4 text-right tabular-nums font-semibold text-gray-900">{{ formatCompactNumber(effectiveAgentTokens(userItem)) }}</td>
+              <td class="py-3.5 px-4 text-right tabular-nums text-sky-700" :title="formatTokenFull(userItem.prompt_tokens || 0)">{{ formatTokenCompact(userItem.prompt_tokens || 0) }}</td>
+              <td class="py-3.5 px-4 text-right tabular-nums text-rose-700" :title="formatTokenFull(userItem.completion_tokens || 0)">{{ formatTokenCompact(userItem.completion_tokens || 0) }}</td>
+              <td class="py-3.5 px-4 text-right tabular-nums font-semibold text-gray-900" :title="formatTokenFull(effectiveAgentTokens(userItem))">{{ formatTokenCompact(effectiveAgentTokens(userItem)) }}</td>
               <td class="py-3.5 px-4">
                 <div class="flex items-center gap-3 w-48">
                   <div class="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
@@ -238,6 +244,11 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from "vue";
 import axios from "../utils/axios";
+import {
+  formatTokenCompact,
+  formatTokenFull,
+  shouldShowTokenFullHint,
+} from "@/utils/tokenFormat";
 import VChart from "vue-echarts";
 import { use } from "echarts/core";
 import { CanvasRenderer } from "echarts/renderers";
@@ -317,17 +328,6 @@ const summaryData = computed(() => {
 
 const formatNumber = (num: number) => {
   if (num === undefined || num === null) return "0";
-  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-};
-
-const formatCompactNumber = (num: number) => {
-  if (num === undefined || num === null) return "0";
-  if (num >= 1.0e9) {
-    return (num / 1.0e9).toFixed(2).replace(/\.00$/, "") + " B";
-  }
-  if (num >= 1.0e6) {
-    return (num / 1.0e6).toFixed(2).replace(/\.00$/, "") + " M";
-  }
   return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 };
 

--- a/frontend/src/views/Users.vue
+++ b/frontend/src/views/Users.vue
@@ -30,6 +30,15 @@
           同步第三方用户
         </button>
         <button
+          @click="showSystemQuotaModal = true"
+          class="bg-amber-600 text-white px-4 py-2 rounded-lg hover:bg-amber-700 transition flex items-center gap-2 shadow-sm"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+          </svg>
+          系统默认额度
+        </button>
+        <button
           @click="openCreateDialog"
           class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition flex items-center gap-2"
         >
@@ -435,6 +444,17 @@
               class="px-4 py-2.5 border-b-2 font-medium text-sm transition-colors flex-1 sm:flex-none text-center"
             >
               权限配置
+            </button>
+            <button
+              @click="activeTab = 'quota'"
+              :class="
+                activeTab === 'quota'
+                  ? 'border-blue-500 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              "
+              class="px-4 py-2.5 border-b-2 font-medium text-sm transition-colors flex-1 sm:flex-none text-center"
+            >
+              额度
             </button>
           </nav>
         </div>
@@ -882,6 +902,16 @@
               </div>
             </div>
           </div>
+
+          <!-- QUOTA TAB -->
+          <div v-show="activeTab === 'quota'" class="space-y-4 py-2">
+            <QuotaPolicyPanel
+              v-if="editingUserId"
+              scope-type="user"
+              :scope-id="editingUserId"
+              show-effective
+            />
+          </div>
         </div>
 
         <div
@@ -894,7 +924,7 @@
             取消
           </button>
           <button
-            v-if="!createdApiKey"
+            v-if="!createdApiKey && activeTab !== 'quota'"
             @click="saveUser"
             :disabled="submitting"
             class="order-1 sm:order-2 px-4 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm font-bold shadow-md shadow-blue-100"
@@ -1268,6 +1298,31 @@
     </div>
   </div>
 
+  <!-- System Default Quota Modal -->
+  <div
+    v-if="showSystemQuotaModal"
+    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[9990] p-4"
+    @click.self="showSystemQuotaModal = false"
+  >
+    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto p-6">
+      <div class="flex items-center justify-between mb-4">
+        <div>
+          <h2 class="text-xl font-bold text-gray-900">系统默认额度</h2>
+          <p class="text-xs text-gray-500 mt-1">未配置用户/角色策略时的全局月 Token 上限</p>
+        </div>
+        <button
+          @click="showSystemQuotaModal = false"
+          class="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      <QuotaPolicyPanel scope-type="system" />
+    </div>
+  </div>
+
   <ThirdPartyUserSyncDrawer
     :visible="showThirdPartyDrawer"
     @close="showThirdPartyDrawer = false"
@@ -1284,6 +1339,7 @@ import { MENU_TREE } from "../constants/permissions";
 import Switch from "../components/Switch.vue";
 import RoleList from "../components/RoleList.vue";
 import ThirdPartyUserSyncDrawer from "../components/ThirdPartyUserSyncDrawer.vue";
+import QuotaPolicyPanel from "../components/admin/QuotaPolicyPanel.vue";
 import {
   KeyIcon,
   ArrowPathIcon,
@@ -1336,6 +1392,7 @@ const showRegenerateDialog = ref(false);
 const showViewKeyDialog = ref(false);
 const showSsoModal = ref(false);
 const showThirdPartyDrawer = ref(false);
+const showSystemQuotaModal = ref(false);
 const userToDelete = ref<any>(null);
 const userToRegenerate = ref<any>(null);
 const userToViewKey = ref<any>(null);
@@ -1510,7 +1567,7 @@ const createdApiKey = ref("");
 const regeneratedApiKey = ref("");
 
 // Permission State
-const activeTab = ref<"info" | "permissions">("info");
+const activeTab = ref<"info" | "permissions" | "quota">("info");
 const activePermissionSubTab = ref<"assets" | "ui">("assets");
 const activeResTab = ref<"agents" | "datasets" | "metadata" | "apis">("agents");
 const resourceTypes = ["agents", "datasets", "metadata", "apis"] as const;

--- a/tests/services/test_quota_service.py
+++ b/tests/services/test_quota_service.py
@@ -1,0 +1,113 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.quota_service import QuotaService
+
+
+def _policy(enabled=True, limit_tokens=1000):
+    policy = MagicMock()
+    policy.enabled = enabled
+    policy.limit_tokens = limit_tokens
+    policy.action_on_exceed = "block"
+    return policy
+
+
+@pytest.mark.asyncio
+async def test_check_before_call_blocks_when_exceeded():
+    db = AsyncMock()
+    service = QuotaService(db)
+    service.get_user_quota_status = AsyncMock(
+        return_value=MagicMock(
+            is_admin_bypass=False,
+            limit_tokens=1000,
+            used_tokens=1200,
+        )
+    )
+
+    message = await service.check_before_call({"user_id": 1, "user_name": "alice"})
+    assert message is not None
+    assert "额度已用尽" in message
+
+
+@pytest.mark.asyncio
+async def test_check_before_call_allows_unlimited():
+    db = AsyncMock()
+    service = QuotaService(db)
+    service.get_user_quota_status = AsyncMock(
+        return_value=MagicMock(
+            is_admin_bypass=False,
+            limit_tokens=None,
+            used_tokens=999999,
+        )
+    )
+
+    message = await service.check_before_call({"user_id": 1, "user_name": "alice"})
+    assert message is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_limit_prefers_user_override():
+    db = AsyncMock()
+    service = QuotaService(db)
+
+    user = MagicMock()
+    user.role = "user"
+    db.get = AsyncMock(return_value=user)
+
+    async def fake_get_policy(scope_type, scope_id):
+        if scope_type == "user":
+            return _policy(enabled=True, limit_tokens=5000)
+        return None
+
+    service._get_policy = fake_get_policy  # type: ignore[method-assign]
+    db.execute = AsyncMock(return_value=MagicMock(all=lambda: []))
+
+    limit, source, _ = await service._resolve_effective_limit(1, "alice")
+    assert limit == 5000
+    assert source == "user"
+
+
+@pytest.mark.asyncio
+async def test_build_warning_message_near_limit():
+    db = AsyncMock()
+    service = QuotaService(db)
+    status = service._build_status(
+        used_tokens=850_000,
+        limit_tokens=1_000_000,
+        source="role",
+        source_label="角色：分析师",
+        is_admin_bypass=False,
+    )
+    message = service.build_warning_message(status)
+    assert message is not None
+    assert "即将用尽" in message
+
+
+@pytest.mark.asyncio
+async def test_resolve_effective_limit_batches_role_policies():
+    db = AsyncMock()
+    service = QuotaService(db)
+
+    user = MagicMock()
+    user.role = "user"
+    db.get = AsyncMock(return_value=user)
+    db.execute = AsyncMock(
+        return_value=MagicMock(all=lambda: [(1, "分析师"), (2, "运营")])
+    )
+
+    async def fake_batch(scope_type, scope_ids):
+        assert scope_type == "role"
+        assert scope_ids == [1, 2]
+        p1 = _policy(enabled=True, limit_tokens=200000)
+        p1.scope_id = 1
+        p2 = _policy(enabled=True, limit_tokens=500000)
+        p2.scope_id = 2
+        return {1: p1, 2: p2}
+
+    service._get_policies_for_scope_ids = fake_batch  # type: ignore[method-assign]
+
+    limit, source, label = await service._resolve_effective_limit(1, "alice")
+    assert limit == 500000
+    assert source == "role"
+    assert label == "角色：运营"

--- a/tests/services/test_user_sync_service.py
+++ b/tests/services/test_user_sync_service.py
@@ -46,6 +46,20 @@ def test_build_extra_data_json():
     assert payload == '{"id": 100, "dept": "RD"}'
 
 
+def test_build_extra_data_json_null_as_empty_string():
+    row = {
+        "user_name": "alice",
+        "__extra__id": 100,
+        "__extra__dept": None,
+    }
+    mappings = [
+        ThirdPartyUserSyncExtraDataMapping(json_key="id", source_column="user_id"),
+        ThirdPartyUserSyncExtraDataMapping(json_key="dept", source_column="dept_code"),
+    ]
+    payload = UserSyncService._build_extra_data_json(row, mappings)
+    assert payload == '{"id": 100, "dept": ""}'
+
+
 def test_normalize_external_user():
     row = {"user_name": " alice ", "real_name": "Bob", "remark": None}
     result = UserSyncService._normalize_external_user(row)


### PR DESCRIPTION

## 概要 (Overview)

本 PR 在 `d429e7f` 之后引入**用户级月 Token 配额**全链路能力（策略配置 → 用量计量 → 超额拦截 → 多端展示），并完善个人中心 Token 消耗看板、对话内快捷查询与数字可读性优化。同时包含数据权限过滤变量分组展示、第三方用户同步 `extra_data` NULL 处理修复等配套改动。

**生效规则：** 用户专属 > 角色模板（取最高）> 系统默认 > 不限；管理员豁免。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)

- [x] **Token 额度管理体系**：新增 `ai_agent_quota_policies` 表（V88）、`QuotaService` 与 `/api/portal/quota` API，支持用户 / 角色 / 系统三级月额度策略
- [x] **调用前拦截**：`agent_service` 主对话流及 Resume（工具确认、外部执行恢复）路径超额拦截，返回 `quota_exceeded`
- [x] **管理端配置**：用户管理「额度」Tab、角色管理权限弹窗「额度」Tab、用户管理页「系统默认额度」入口
- [x] **个人中心「我的 Token 消耗」**：时间范围（默认本月）、汇总卡片、趋势图、日明细、交互记录分页；扩展 `token-stats/trends` 自定义日期与 `token-stats/records` 接口
- [x] **对话侧额度感知**：EmbedChat 输入框上方 80% 预警 / 超额红条；发送前校验；对话结束自动刷新额度
- [x] **快捷指令 `/quota`**：EmbedChat / AgentDebug 内置「📊 我的额度」，对话内展示已用 / 上限 / 剩余及策略来源
- [x] **数据权限过滤变量**：`PermissionVariableMenu` 内置变量与 `extra_data` 扩展字段分组展示；`MetadataDatasets` 聚合用户 `extra_data` 键名
- [x] **性能优化**：角色额度策略批量查询（消除 N+1）；V89 增加 `(username, created_at)` 索引加速按月汇总

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)

- [x] **Token 数字紧凑展示**：统一 `tokenFormat` 工具（K / M / B）与 `TokenAmount` 组件，应用于配额配置、个人消耗、Token 统计、Overview、对话预警文案
- [x] **额度输入折算提示**：`QuotaPolicyPanel` 自定义上限输入框下方显示「约合 X M Token（完整数字）」
- [x] **口径说明**：个人中心额度卡片标注「自然月统计」，趋势区默认「本月」并与额度周期对齐
- [x] **表格悬停**：Token 相关表格单元格 `title` 显示完整千分位数值

### 3. 🐞 关键修复 (Bug Fixes)

- [x] **第三方用户同步 `extra_data`**：来源字段为 NULL 时仍写入 JSON 键且值为 `""`，避免映射字段被静默跳过（`test_user_sync_service` 覆盖）

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `5b1f11a` | fix: 第三方用户同步 extra_data 将 NULL 写入为空字符串 |
| `21f311a` | feat: 数据权限过滤变量区分内置与 extra_data 扩展 |
| `deccf7e` | feat: 个人中心新增我的 Token 消耗 Tab |
| `47326e4` | feat: Token 额度管理体系（策略配置、调用拦截与用量展示） |
| `c32daae` | feat: Token 数量统一 K/M/B 紧凑展示 |
| `68f8343` | feat: 对话快捷指令 /quota 查看本月 Token 额度 |

**变更规模：** 28 files, +2312 / -122 lines

---

## 测试覆盖 (Testing)

- [x] **UI 兼容性**: 已验证不同浏览器下的展示效果。
- [x] **核心功能**: 关键业务流程已通过手动或自动化测试。
- [x] **回归测试**: 确认未引入已知回归错误。

**建议手动验证：**

1. 执行 DB 迁移 `V88-create_quota_policies.sql`、`V89-quota-usage-index.sql`
2. 角色管理 → 额度 Tab 配置角色模板；用户管理 → 系统默认额度 / 用户额度 Tab
3. 普通用户对话至接近 / 超过上限，确认黄条、红条、发送拦截及 `/quota` 指令回复一致
4. 工具确认 Resume、外部执行 Resume 在超额时同样被拦截
5. 个人中心「我的 Token 消耗」：本月默认、额度卡片与趋势数据
6. 数据权限配置页：内置变量与 `extra_data` 变量分组展示
7. 第三方用户同步：NULL 字段写入 `extra_data` 为 `""`

**自动化测试：**

- `tests/services/test_quota_service.py` — 超额拦截、用户覆盖、角色取 max、80% 预警
- `tests/services/test_user_sync_service.py` — extra_data NULL → `""`

> [!IMPORTANT]
> 提交前请务必确认已更新 `tests/CHECKLIST.md` 中的自动化测试清单。（本 PR 尚未更新 CHECKLIST，合并前建议补充 Token 额度相关条目。）

---

## 其他备注 (Notes)

### 数据库迁移（必须）

```sql
-- 已执行 V88 的环境仅需补 V89
db-prod/V88-create_quota_policies.sql
db-prod/V89-quota-usage-index.sql
```

### 新增 API

| 路径 | 说明 |
|------|------|
| `GET /api/portal/quota/me` | 当前用户本月额度状态 |
| `GET/PUT/DELETE /api/portal/quota/users/{id}` | 用户专属额度 |
| `GET/PUT/DELETE /api/portal/quota/roles/{id}` | 角色额度模板 |
| `GET/PUT/DELETE /api/portal/quota/system` | 系统默认额度 |
| `GET /api/portal/dashboard/token-stats/records` | 个人交互明细分页 |
| `GET /api/portal/dashboard/token-stats/trends` | 支持 `start_date` / `end_date` |

### 部署后

- 重启服务：`./dev.sh`
- 无新增环境变量或第三方依赖

