### PR TITLE
Pull Request: 工作空间浏览全面升级（Redis 隔离、会话目录重构与 UI 增强）

### DIFF
--- a/app/api/v1/endpoints/fs.py
+++ b/app/api/v1/endpoints/fs.py
@@ -35,6 +35,22 @@ logger = logging.getLogger(__name__)
 TRASH_DIR_NAME = ".trash"
 WORKSPACE_RECENT_FILES_MAX = 20
 WORKSPACE_RECENT_REDIS_PREFIX = "agent:workspace_recent_files:"
+WORKSPACE_BROWSER_PREFS_REDIS_PREFIX = "agent:workspace_browser_prefs:"
+WORKSPACE_BROWSER_TYPE_FILTERS = frozenset({
+    "all",
+    "folder",
+    "image",
+    "markdown",
+    "document",
+    "html",
+    "code",
+    "spreadsheet",
+    "presentation",
+    "archive",
+    "video",
+    "audio",
+    "data",
+})
 
 IMAGE_PREVIEW_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 IMAGE_MEDIA_TYPES = {
@@ -1018,3 +1034,111 @@ async def save_workspace_recent_files(
         raise HTTPException(status_code=500, detail="保存最近文件记录失败")
 
     return StandardResponse(data=payload, message="最近文件记录已保存")
+
+
+class WorkspaceBrowserPrefs(BaseModel):
+    include_subdirs: bool = Field(True, description="搜索时是否包含子目录")
+    type_filter: str = Field("all", description="文件类型筛选")
+
+
+class WorkspaceBrowserPrefsPayload(BaseModel):
+    include_subdirs: Optional[bool] = Field(None, description="搜索时是否包含子目录")
+    type_filter: Optional[str] = Field(None, description="文件类型筛选")
+
+
+def _workspace_browser_prefs_redis_key(user_id: int) -> str:
+    return f"{WORKSPACE_BROWSER_PREFS_REDIS_PREFIX}{user_id}"
+
+
+def _sanitize_workspace_browser_prefs(
+    raw: WorkspaceBrowserPrefsPayload | WorkspaceBrowserPrefs | Dict[str, Any] | None,
+) -> WorkspaceBrowserPrefs:
+    include_subdirs = True
+    type_filter = "all"
+    if raw is not None:
+        if isinstance(raw, dict):
+            include_subdirs = raw.get("include_subdirs", True)
+            type_filter = raw.get("type_filter", "all")
+        else:
+            include_subdirs = getattr(raw, "include_subdirs", True)
+            type_filter = getattr(raw, "type_filter", "all")
+    if not isinstance(include_subdirs, bool):
+        include_subdirs = True
+    type_filter = str(type_filter or "all").strip().lower()
+    if type_filter not in WORKSPACE_BROWSER_TYPE_FILTERS:
+        type_filter = "all"
+    return WorkspaceBrowserPrefs(include_subdirs=include_subdirs, type_filter=type_filter)
+
+
+@router.get(
+    "/browser-prefs",
+    response_model=StandardResponse[WorkspaceBrowserPrefs],
+    summary="获取当前用户的工作空间浏览偏好",
+)
+async def get_workspace_browser_prefs(
+    user_info: Dict[str, Any] = Depends(require_api_key),
+):
+    redis = await get_redis()
+    if not redis:
+        return StandardResponse(data=WorkspaceBrowserPrefs())
+
+    user_id = int(user_info["user_id"])
+    key = _workspace_browser_prefs_redis_key(user_id)
+    try:
+        raw = await redis.get(key)
+    except Exception as e:
+        logger.error("Failed to get workspace browser prefs from Redis: %s", e)
+        return StandardResponse(data=WorkspaceBrowserPrefs())
+
+    if not raw:
+        return StandardResponse(data=WorkspaceBrowserPrefs())
+
+    try:
+        decoded = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+        parsed = json.loads(decoded)
+        prefs = _sanitize_workspace_browser_prefs(parsed)
+    except Exception as e:
+        logger.warning("Failed to parse workspace browser prefs JSON: %s", e)
+        prefs = WorkspaceBrowserPrefs()
+
+    return StandardResponse(data=prefs)
+
+
+@router.put(
+    "/browser-prefs",
+    response_model=StandardResponse[WorkspaceBrowserPrefs],
+    summary="保存当前用户的工作空间浏览偏好",
+)
+async def save_workspace_browser_prefs(
+    body: WorkspaceBrowserPrefsPayload,
+    user_info: Dict[str, Any] = Depends(require_api_key),
+):
+    redis = await get_redis()
+    if not redis:
+        raise HTTPException(status_code=503, detail="Redis 服务不可用")
+
+    user_id = int(user_info["user_id"])
+    key = _workspace_browser_prefs_redis_key(user_id)
+
+    existing = WorkspaceBrowserPrefs()
+    try:
+        raw = await redis.get(key)
+        if raw:
+            decoded = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+            existing = _sanitize_workspace_browser_prefs(json.loads(decoded))
+    except Exception as e:
+        logger.warning("Failed to read existing workspace browser prefs: %s", e)
+
+    merged = WorkspaceBrowserPrefs(
+        include_subdirs=body.include_subdirs if body.include_subdirs is not None else existing.include_subdirs,
+        type_filter=body.type_filter if body.type_filter is not None else existing.type_filter,
+    )
+    prefs = _sanitize_workspace_browser_prefs(merged)
+
+    try:
+        await redis.set(key, prefs.model_dump_json())
+    except Exception as e:
+        logger.error("Failed to save workspace browser prefs to Redis: %s", e)
+        raise HTTPException(status_code=500, detail="保存浏览偏好失败")
+
+    return StandardResponse(data=prefs, message="浏览偏好已保存")

--- a/app/api/v1/endpoints/fs.py
+++ b/app/api/v1/endpoints/fs.py
@@ -20,8 +20,9 @@ from app.utils.fs_access import (
     get_allowed_fs_roots,
     get_user_docs_dir,
     get_user_private_workspace_root,
+    get_user_sessions_dir,
     get_user_uploads_dir,
-    is_session_dir_name,
+    is_session_workdir_path,
     is_fs_admin,
     is_fs_virtual_root,
     is_path_allowed,
@@ -281,13 +282,12 @@ async def list_files(
     docs_path = get_user_docs_dir(user_info)
     if docs_path and os.path.normpath(target_path) == os.path.normpath(docs_path):
         os.makedirs(docs_path, mode=0o700, exist_ok=True)
+    sessions_path = get_user_sessions_dir(user_info)
+    if sessions_path and os.path.normpath(target_path) == os.path.normpath(sessions_path):
+        os.makedirs(sessions_path, mode=0o700, exist_ok=True)
     if not os.path.exists(target_path) and private_root:
-        norm_target = os.path.normpath(target_path)
-        norm_root = os.path.normpath(private_root)
-        if norm_target.startswith(norm_root + os.sep):
-            rel = os.path.relpath(norm_target, norm_root)
-            if "/" not in rel and is_session_dir_name(rel):
-                os.makedirs(norm_target, mode=0o700, exist_ok=True)
+        if is_session_workdir_path(private_root, target_path):
+            os.makedirs(target_path, mode=0o700, exist_ok=True)
     if not os.path.exists(target_path):
         raise HTTPException(status_code=404, detail="请求的路径不存在。")
     if not os.path.isdir(target_path):
@@ -364,6 +364,7 @@ def _resolve_fs_file_path(
     must_exist: bool = True,
 ) -> str:
     from app.services.ai.runtime.agentscope.workspace import (
+        resolve_legacy_session_workdir,
         resolve_session_workdir,
         resolve_user_docs_dir,
         resolve_user_workspace_root,
@@ -394,6 +395,19 @@ def _resolve_fs_file_path(
             )
             if os.path.isdir(session_workdir):
                 candidate = normalize_under_base(path, session_workdir)
+                if candidate and (not must_exist or os.path.isfile(candidate)) and is_path_allowed(candidate, user_info):
+                    safe_path = candidate
+
+        if not safe_path:
+            legacy_session_workdir = resolve_legacy_session_workdir(
+                root=root,
+                user_id=user_info.get("user_id") or user_info.get("id"),
+                user_name=user_info.get("user_name") or user_info.get("username"),
+                user_info=user_info,
+                conversation_id=conversation_id,
+            )
+            if legacy_session_workdir != session_workdir and os.path.isdir(legacy_session_workdir):
+                candidate = normalize_under_base(path, legacy_session_workdir)
                 if candidate and (not must_exist or os.path.isfile(candidate)) and is_path_allowed(candidate, user_info):
                     safe_path = candidate
 

--- a/app/api/v1/endpoints/fs.py
+++ b/app/api/v1/endpoints/fs.py
@@ -1,4 +1,6 @@
 import fnmatch
+import json
+import logging
 import os
 import re
 import shutil
@@ -10,6 +12,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from app.schemas.response import StandardResponse
 from app.core.dependencies import require_api_key
+from app.core.redis import get_redis
 from app.utils.fs_paths import get_data_base_dir, normalize_under_base
 from app.utils.fs_access import (
     assert_path_allowed,
@@ -27,7 +30,11 @@ from app.utils.fs_access import (
 
 router = APIRouter()
 
+logger = logging.getLogger(__name__)
+
 TRASH_DIR_NAME = ".trash"
+WORKSPACE_RECENT_FILES_MAX = 20
+WORKSPACE_RECENT_REDIS_PREFIX = "agent:workspace_recent_files:"
 
 IMAGE_PREVIEW_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 IMAGE_MEDIA_TYPES = {
@@ -888,3 +895,126 @@ async def search_files(
             truncated=truncated,
         )
     )
+
+
+class WorkspaceRecentFileItem(BaseModel):
+    path: str = Field(..., description="文件绝对路径")
+    name: str = Field(..., description="展示用文件名")
+    mtime: float = Field(..., description="最后访问时间戳（秒）")
+
+
+class WorkspaceRecentFilesPayload(BaseModel):
+    items: List[WorkspaceRecentFileItem] = Field(default_factory=list)
+
+
+class WorkspaceRecentFilesResponse(BaseModel):
+    items: List[WorkspaceRecentFileItem] = Field(default_factory=list)
+
+
+def _workspace_recent_redis_key(user_id: int) -> str:
+    return f"{WORKSPACE_RECENT_REDIS_PREFIX}{user_id}"
+
+
+def _is_trash_path_segment(path: str) -> bool:
+    norm = os.path.normpath(path)
+    return f"/{TRASH_DIR_NAME}/" in f"{norm}/" or norm.endswith(f"/{TRASH_DIR_NAME}")
+
+
+def _sanitize_workspace_recent_files(
+    items: List[WorkspaceRecentFileItem],
+    user_info: Dict[str, Any],
+) -> List[WorkspaceRecentFileItem]:
+    seen: set[str] = set()
+    cleaned: List[WorkspaceRecentFileItem] = []
+    for raw in items:
+        path = str(raw.path or "").strip()
+        if not path or _is_trash_path_segment(path):
+            continue
+        normalized = normalize_fs_path(path)
+        if not normalized or not is_path_allowed(normalized, user_info):
+            continue
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        name = str(raw.name or os.path.basename(normalized) or normalized).strip()
+        if not name:
+            name = os.path.basename(normalized)
+        if len(name) > 255:
+            name = name[:255]
+        try:
+            mtime = float(raw.mtime)
+        except (TypeError, ValueError):
+            mtime = time.time()
+        if mtime <= 0:
+            mtime = time.time()
+        cleaned.append(WorkspaceRecentFileItem(path=normalized, name=name, mtime=mtime))
+        if len(cleaned) >= WORKSPACE_RECENT_FILES_MAX:
+            break
+    return cleaned
+
+
+@router.get(
+    "/recent-files",
+    response_model=StandardResponse[WorkspaceRecentFilesResponse],
+    summary="获取当前用户的工作空间最近访问文件",
+)
+async def get_workspace_recent_files(
+    user_info: Dict[str, Any] = Depends(require_api_key),
+):
+    redis = await get_redis()
+    if not redis:
+        return StandardResponse(data=WorkspaceRecentFilesResponse(items=[]))
+
+    user_id = int(user_info["user_id"])
+    key = _workspace_recent_redis_key(user_id)
+    try:
+        raw = await redis.get(key)
+    except Exception as e:
+        logger.error("Failed to get workspace recent files from Redis: %s", e)
+        return StandardResponse(data=WorkspaceRecentFilesResponse(items=[]))
+
+    if not raw:
+        return StandardResponse(data=WorkspaceRecentFilesResponse(items=[]))
+
+    try:
+        decoded = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+        parsed = json.loads(decoded)
+        raw_items = parsed.get("items") if isinstance(parsed, dict) else parsed
+        if not isinstance(raw_items, list):
+            raw_items = []
+        items = _sanitize_workspace_recent_files(
+            [WorkspaceRecentFileItem.model_validate(item) for item in raw_items],
+            user_info,
+        )
+    except Exception as e:
+        logger.warning("Failed to parse workspace recent files JSON: %s", e)
+        items = []
+
+    return StandardResponse(data=WorkspaceRecentFilesResponse(items=items))
+
+
+@router.put(
+    "/recent-files",
+    response_model=StandardResponse[WorkspaceRecentFilesResponse],
+    summary="保存当前用户的工作空间最近访问文件",
+)
+async def save_workspace_recent_files(
+    body: WorkspaceRecentFilesPayload,
+    user_info: Dict[str, Any] = Depends(require_api_key),
+):
+    redis = await get_redis()
+    if not redis:
+        raise HTTPException(status_code=503, detail="Redis 服务不可用")
+
+    user_id = int(user_info["user_id"])
+    key = _workspace_recent_redis_key(user_id)
+    items = _sanitize_workspace_recent_files(body.items, user_info)
+    payload = WorkspaceRecentFilesResponse(items=items)
+
+    try:
+        await redis.set(key, payload.model_dump_json())
+    except Exception as e:
+        logger.error("Failed to save workspace recent files to Redis: %s", e)
+        raise HTTPException(status_code=500, detail="保存最近文件记录失败")
+
+    return StandardResponse(data=payload, message="最近文件记录已保存")

--- a/app/api/v1/endpoints/fs.py
+++ b/app/api/v1/endpoints/fs.py
@@ -18,8 +18,10 @@ from app.utils.fs_access import (
     assert_path_allowed,
     assert_path_writable,
     get_allowed_fs_roots,
+    get_user_docs_dir,
     get_user_private_workspace_root,
     get_user_uploads_dir,
+    is_session_dir_name,
     is_fs_admin,
     is_fs_virtual_root,
     is_path_allowed,
@@ -276,6 +278,16 @@ async def list_files(
     uploads_path = get_user_uploads_dir(user_info)
     if uploads_path and os.path.normpath(target_path) == os.path.normpath(uploads_path):
         os.makedirs(uploads_path, mode=0o700, exist_ok=True)
+    docs_path = get_user_docs_dir(user_info)
+    if docs_path and os.path.normpath(target_path) == os.path.normpath(docs_path):
+        os.makedirs(docs_path, mode=0o700, exist_ok=True)
+    if not os.path.exists(target_path) and private_root:
+        norm_target = os.path.normpath(target_path)
+        norm_root = os.path.normpath(private_root)
+        if norm_target.startswith(norm_root + os.sep):
+            rel = os.path.relpath(norm_target, norm_root)
+            if "/" not in rel and is_session_dir_name(rel):
+                os.makedirs(norm_target, mode=0o700, exist_ok=True)
     if not os.path.exists(target_path):
         raise HTTPException(status_code=404, detail="请求的路径不存在。")
     if not os.path.isdir(target_path):
@@ -353,6 +365,7 @@ def _resolve_fs_file_path(
 ) -> str:
     from app.services.ai.runtime.agentscope.workspace import (
         resolve_session_workdir,
+        resolve_user_docs_dir,
         resolve_user_workspace_root,
     )
 
@@ -360,17 +373,29 @@ def _resolve_fs_file_path(
 
     if conversation_id and not path.startswith("/") and not path.startswith("/app/data"):
         root = workspace_root
-        session_workdir = resolve_session_workdir(
+        docs_workdir = resolve_user_docs_dir(
             root=root,
             user_id=user_info.get("user_id") or user_info.get("id"),
             user_name=user_info.get("user_name") or user_info.get("username"),
             user_info=user_info,
-            conversation_id=conversation_id,
         )
-        if os.path.isdir(session_workdir):
-            candidate = normalize_under_base(path, session_workdir)
+        if os.path.isdir(docs_workdir) or not must_exist:
+            candidate = normalize_under_base(path, docs_workdir)
             if candidate and (not must_exist or os.path.isfile(candidate)) and is_path_allowed(candidate, user_info):
                 safe_path = candidate
+
+        if not safe_path:
+            session_workdir = resolve_session_workdir(
+                root=root,
+                user_id=user_info.get("user_id") or user_info.get("id"),
+                user_name=user_info.get("user_name") or user_info.get("username"),
+                user_info=user_info,
+                conversation_id=conversation_id,
+            )
+            if os.path.isdir(session_workdir):
+                candidate = normalize_under_base(path, session_workdir)
+                if candidate and (not must_exist or os.path.isfile(candidate)) and is_path_allowed(candidate, user_info):
+                    safe_path = candidate
 
         if not safe_path:
             user_workspaces_root = resolve_user_workspace_root(

--- a/app/services/ai/agent_prompts.py
+++ b/app/services/ai/agent_prompts.py
@@ -540,17 +540,23 @@ class AgentServicePrompts:
         )
 
     @staticmethod
-    def session_workspace_sandbox_block(*, workdir: str, file_tool_names: List[str]) -> str:
+    def session_workspace_sandbox_block(
+        *,
+        session_workdir: str,
+        docs_dir: str,
+        file_tool_names: List[str],
+    ) -> str:
         """本会话 AgentScope workspace 与路径沙箱说明（仅在有文件/Shell 工具时注入）。"""
         tools_text = "、".join(file_tool_names) if file_tool_names else "Read/Write/Grep/Glob/Bash"
         return (
             "[Session Workspace & Path Sandbox]\n"
-            f"- **会话工作目录**：`{workdir}`（位于 `/app/data/agent_workspaces/...`，仅供本会话读写落盘文件）\n"
+            f"- **会话工作目录**：`{session_workdir}`（本会话自动创建；Read/Write/Edit/Grep/Glob/Bash 的相对路径默认相对此目录，会话过程临时文件、工具落盘优先放这里）\n"
+            f"- **默认文档目录**：`{docs_dir}`（跨会话集中存放；用户要求「保存到文档/报告/文件」且**未指定路径**时，写入此目录，如 `{docs_dir}/report.md` 或相对路径 `../docs/report.md`）\n"
             f"- **本轮文件/Shell 工具**：{tools_text}\n"
-            "- Read/Write/Edit/Grep/Glob 的路径默认相对**会话工作目录**；本会话内新生成/落盘文件优先用相对路径（如 `./notes.md`）。\n"
             "- **平台共享目录仍在 `/app/data` 沙箱内、可访问**：用户上传附件在本人工作目录 `.../uploads/`；SQLite 临时演算库在 `.../sandbox/sess_<id>.db`；技能文件在 `/app/data/skills/...`。"
-            " 用户消息 `---` 之后或附件块中给出的**绝对路径**可直接用于 Read/Grep，无需先复制到会话工作目录。\n"
-            "- 文件与命令工具仅能在平台允许的路径范围内生效（含上述会话目录与 `/app/data` 下授权子目录）；越界会被工具层拒绝。\n"
+            " 用户消息 `---` 之后或附件块中给出的**绝对路径**可直接用于 Read/Grep。\n"
+            "- 用户明确要求保存到其他路径时，按其指示写入；未说明且属于交付给用户的文档时，一律使用默认文档目录。\n"
+            "- 文件与命令工具仅能在平台允许的路径范围内生效（含上述目录与 `/app/data` 下授权子目录）；越界会被工具层拒绝。\n"
             "- 禁止访问其他用户或其他会话的 agent_workspaces 目录；不得臆造路径。\n"
             "- 有 Grep/Glob 时优先于 Bash 做文本/文件搜索；Bash 用于 Grep/Glob 无法完成的管道或系统诊断。\n"
             "- 写文件、执行命令等高风险操作可能触发平台确认；挂起时不得声称已完成。"

--- a/app/services/ai/runtime/agentscope/workspace.py
+++ b/app/services/ai/runtime/agentscope/workspace.py
@@ -29,6 +29,7 @@ _workspace_cache: dict[str, Any] = {}
 
 WORKSPACE_USER_KEY_SEP = "__"
 USER_DOCS_DIR_NAME = "docs"
+USER_SESSIONS_DIR_NAME = "sessions"
 
 
 def _clean_key_part(value: str | None, fallback_prefix: str) -> str:
@@ -127,6 +128,48 @@ async def resolve_workspace_root() -> str:
     return root
 
 
+def resolve_user_sessions_dir(
+    *,
+    root: str,
+    user_id: str | int | None,
+    user_name: str | None = None,
+    user_info: dict[str, Any] | None = None,
+) -> str:
+    """用户级会话目录容器：agent_workspaces/{user_key}/sessions。"""
+    resolved_user_id, resolved_user_name = extract_workspace_identity(
+        user_id=user_id,
+        user_name=user_name,
+        user_info=user_info,
+    )
+    uid = resolve_workspace_user_key(
+        user_id=resolved_user_id,
+        user_name=resolved_user_name,
+    )
+    return os.path.join(os.path.abspath(root), uid, USER_SESSIONS_DIR_NAME)
+
+
+def resolve_legacy_session_workdir(
+    *,
+    root: str,
+    user_id: str | int | None,
+    conversation_id: str,
+    user_name: str | None = None,
+    user_info: dict[str, Any] | None = None,
+) -> str:
+    """旧版会话目录：agent_workspaces/{user_key}/{conversation_id}（兼容历史数据）。"""
+    resolved_user_id, resolved_user_name = extract_workspace_identity(
+        user_id=user_id,
+        user_name=user_name,
+        user_info=user_info,
+    )
+    uid = resolve_workspace_user_key(
+        user_id=resolved_user_id,
+        user_name=resolved_user_name,
+    )
+    cid = _clean_key_part(conversation_id, "conversation")
+    return os.path.join(os.path.abspath(root), uid, cid)
+
+
 def resolve_session_workdir(
     *,
     root: str,
@@ -145,7 +188,7 @@ def resolve_session_workdir(
         user_name=resolved_user_name,
     )
     cid = _clean_key_part(conversation_id, "conversation")
-    return os.path.join(os.path.abspath(root), uid, cid)
+    return os.path.join(os.path.abspath(root), uid, USER_SESSIONS_DIR_NAME, cid)
 
 
 def resolve_user_docs_dir(

--- a/app/services/ai/runtime/agentscope/workspace.py
+++ b/app/services/ai/runtime/agentscope/workspace.py
@@ -28,6 +28,7 @@ _workspace_cache: dict[str, Any] = {}
 
 
 WORKSPACE_USER_KEY_SEP = "__"
+USER_DOCS_DIR_NAME = "docs"
 
 
 def _clean_key_part(value: str | None, fallback_prefix: str) -> str:
@@ -147,6 +148,26 @@ def resolve_session_workdir(
     return os.path.join(os.path.abspath(root), uid, cid)
 
 
+def resolve_user_docs_dir(
+    *,
+    root: str,
+    user_id: str | int | None,
+    user_name: str | None = None,
+    user_info: dict[str, Any] | None = None,
+) -> str:
+    """用户级文档目录：agent_workspaces/{user_key}/docs（跨会话集中存放 AI 落盘文件）。"""
+    resolved_user_id, resolved_user_name = extract_workspace_identity(
+        user_id=user_id,
+        user_name=user_name,
+        user_info=user_info,
+    )
+    uid = resolve_workspace_user_key(
+        user_id=resolved_user_id,
+        user_name=resolved_user_name,
+    )
+    return os.path.join(os.path.abspath(root), uid, USER_DOCS_DIR_NAME)
+
+
 def resolve_user_workspace_root(
     *,
     root: str,
@@ -189,6 +210,7 @@ async def get_local_workspace(
         user_info=user_info,
         conversation_id=conversation_id,
     )
+    os.makedirs(workdir, exist_ok=True)
     cached = _workspace_cache.get(workdir)
     if cached is not None:
         return cached
@@ -303,15 +325,22 @@ async def append_session_workspace_sandbox_to_system_prompt(
     from app.services.ai.agent_prompts import AgentServicePrompts
 
     root = await resolve_workspace_root()
-    workdir = resolve_session_workdir(
+    session_workdir = resolve_session_workdir(
         root=root,
         user_id=user_id,
         user_name=user_name,
         user_info=user_info,
         conversation_id=conversation_id,
     )
+    docs_dir = resolve_user_docs_dir(
+        root=root,
+        user_id=user_id,
+        user_name=user_name,
+        user_info=user_info,
+    )
     block = AgentServicePrompts.session_workspace_sandbox_block(
-        workdir=workdir,
+        session_workdir=session_workdir,
+        docs_dir=docs_dir,
         file_tool_names=sorted(file_tools),
     )
     base = (system_content or "").strip()

--- a/app/services/ai/tools/document_paths.py
+++ b/app/services/ai/tools/document_paths.py
@@ -134,9 +134,21 @@ async def resolve_document_input_path(
             user_name=user_name,
         )
     ).resolve()
-    if not _path_under(candidate, session_workdir):
-        raise DocumentPathError("文件不在当前会话允许访问的目录中")
-    return candidate
+    if _path_under(candidate, session_workdir):
+        return candidate
+    from app.services.ai.runtime.agentscope.workspace import resolve_legacy_session_workdir
+
+    legacy_workdir = Path(
+        resolve_legacy_session_workdir(
+            root=str(workspace_root),
+            user_id=user_id,
+            conversation_id=conversation_id,
+            user_name=user_name,
+        )
+    ).resolve()
+    if legacy_workdir != session_workdir and _path_under(candidate, legacy_workdir):
+        return candidate
+    raise DocumentPathError("文件不在当前会话允许访问的目录中")
 
 
 def sanitize_output_filename(filename: str, allowed_extensions: Iterable[str]) -> str:

--- a/app/services/ai/tools/document_paths.py
+++ b/app/services/ai/tools/document_paths.py
@@ -40,6 +40,23 @@ def resolve_session_workdir(
     )
 
 
+def resolve_user_docs_dir(
+    *,
+    root: str,
+    user_id: int | str | None,
+    user_name: str | None = None,
+    user_info: dict | None = None,
+) -> str:
+    from app.services.ai.runtime.agentscope.workspace import resolve_user_docs_dir as resolver
+
+    return resolver(
+        root=root,
+        user_id=user_id,
+        user_name=user_name,
+        user_info=user_info,
+    )
+
+
 def _path_under(path: Path, parent: Path) -> bool:
     try:
         path.relative_to(parent)
@@ -100,6 +117,15 @@ async def resolve_document_input_path(
     if not conversation_id:
         raise DocumentPathError("当前会话缺少工作目录，无法访问该文件")
     workspace_root = Path(await resolve_workspace_root()).resolve()
+    user_docs_dir = Path(
+        resolve_user_docs_dir(
+            root=str(workspace_root),
+            user_id=user_id,
+            user_name=user_name,
+        )
+    ).resolve()
+    if _path_under(candidate, user_docs_dir):
+        return candidate
     session_workdir = Path(
         resolve_session_workdir(
             root=str(workspace_root),
@@ -134,16 +160,15 @@ async def resolve_document_output_path(
         raise DocumentPathError("当前会话缺少工作目录，无法生成文件")
     clean_name = sanitize_output_filename(filename, allowed_extensions)
     workspace_root = Path(await resolve_workspace_root()).resolve()
-    session_workdir = Path(
-        resolve_session_workdir(
+    docs_dir = Path(
+        resolve_user_docs_dir(
             root=str(workspace_root),
             user_id=user_id,
-            conversation_id=conversation_id,
             user_name=user_name,
         )
     ).resolve()
-    session_workdir.mkdir(parents=True, exist_ok=True)
-    output_path = (session_workdir / clean_name).resolve()
-    if not _path_under(output_path, session_workdir):
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    output_path = (docs_dir / clean_name).resolve()
+    if not _path_under(output_path, docs_dir):
         raise DocumentPathError("输出文件路径不安全")
     return output_path

--- a/app/utils/fs_access.py
+++ b/app/utils/fs_access.py
@@ -10,7 +10,7 @@ from fastapi import HTTPException
 from app.utils.fs_paths import get_data_base_dir, normalize_under_base
 
 PUBLIC_DATA_SUBDIRS: tuple[str, ...] = ("branding", "skills")
-USER_WORKSPACE_RESERVED_DIR_NAMES = frozenset({"docs", "uploads", "sandbox", ".trash", "skills"})
+USER_WORKSPACE_RESERVED_DIR_NAMES = frozenset({"docs", "uploads", "sandbox", ".trash", "skills", "sessions"})
 SESSION_DIR_NAME_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,
@@ -90,12 +90,35 @@ def get_user_docs_dir(user_info: dict[str, Any] | None) -> str | None:
     return os.path.normpath(os.path.join(private_root, "docs"))
 
 
+def get_user_sessions_dir(user_info: dict[str, Any] | None) -> str | None:
+    """用户会话目录容器：agent_workspaces/{user_key}/sessions。"""
+    private_root = get_user_private_workspace_root(user_info)
+    if not private_root:
+        return None
+    return os.path.normpath(os.path.join(private_root, "sessions"))
+
+
 def is_session_dir_name(name: str) -> bool:
-    """判断用户工作区下的直接子目录名是否为会话目录。"""
+    """判断目录名是否为会话 ID（sessions/ 下或旧版用户根下的直接子目录）。"""
     cleaned = str(name or "").strip()
     if not cleaned or cleaned in USER_WORKSPACE_RESERVED_DIR_NAMES:
         return False
     return bool(SESSION_DIR_NAME_RE.match(cleaned)) or cleaned.startswith("conv_")
+
+
+def is_session_workdir_path(user_root: str, target_path: str) -> bool:
+    """判断目标路径是否为可自动创建的会话工作目录（含旧版平铺路径）。"""
+    norm_target = os.path.normpath(target_path)
+    norm_root = os.path.normpath(user_root)
+    if not norm_target.startswith(norm_root + os.sep):
+        return False
+    rel = os.path.relpath(norm_target, norm_root)
+    parts = rel.split(os.sep)
+    if len(parts) == 2 and parts[0] == "sessions" and is_session_dir_name(parts[1]):
+        return True
+    if len(parts) == 1 and is_session_dir_name(parts[0]):
+        return True
+    return False
 
 
 def get_user_sandbox_dir(user_info: dict[str, Any] | None) -> str | None:

--- a/app/utils/fs_access.py
+++ b/app/utils/fs_access.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
 
 from fastapi import HTTPException
@@ -9,6 +10,11 @@ from fastapi import HTTPException
 from app.utils.fs_paths import get_data_base_dir, normalize_under_base
 
 PUBLIC_DATA_SUBDIRS: tuple[str, ...] = ("branding", "skills")
+USER_WORKSPACE_RESERVED_DIR_NAMES = frozenset({"docs", "uploads", "sandbox", ".trash", "skills"})
+SESSION_DIR_NAME_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
 
 
 def get_platform_skills_root() -> str | None:
@@ -74,6 +80,22 @@ def get_user_uploads_dir(user_info: dict[str, Any] | None) -> str | None:
     if not private_root:
         return None
     return os.path.normpath(os.path.join(private_root, "uploads"))
+
+
+def get_user_docs_dir(user_info: dict[str, Any] | None) -> str | None:
+    """用户文档目录：agent_workspaces/{user_key}/docs（AI 默认落盘，跨会话共享）。"""
+    private_root = get_user_private_workspace_root(user_info)
+    if not private_root:
+        return None
+    return os.path.normpath(os.path.join(private_root, "docs"))
+
+
+def is_session_dir_name(name: str) -> bool:
+    """判断用户工作区下的直接子目录名是否为会话目录。"""
+    cleaned = str(name or "").strip()
+    if not cleaned or cleaned in USER_WORKSPACE_RESERVED_DIR_NAMES:
+        return False
+    return bool(SESSION_DIR_NAME_RE.match(cleaned)) or cleaned.startswith("conv_")
 
 
 def get_user_sandbox_dir(user_info: dict[str, Any] | None) -> str | None:

--- a/frontend/scripts/workspaceFilePreview.test.ts
+++ b/frontend/scripts/workspaceFilePreview.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import {
+  isDirectRenderableUrl,
+  resolveFsPreviewUrl,
+} from '../src/utils/workspaceFilePreview.ts';
+
+const blobUrl = 'blob:http://localhost:5173/abc-123';
+
+assert.equal(isDirectRenderableUrl(blobUrl), true);
+assert.equal(resolveFsPreviewUrl(blobUrl), blobUrl);
+assert.equal(
+  resolveFsPreviewUrl('/data/agent_workspaces/user__1/uploads/photo.jpg'),
+  '/api/v1/chat/fs/preview?path=%2Fdata%2Fagent_workspaces%2Fuser__1%2Fuploads%2Fphoto.jpg',
+);
+
+console.log('workspaceFilePreview.test.ts passed');

--- a/frontend/scripts/workspaceFilePreview.test.ts
+++ b/frontend/scripts/workspaceFilePreview.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {
   isDirectRenderableUrl,
+  isSameWorkspacePreviewPath,
   resolveFsPreviewUrl,
 } from '../src/utils/workspaceFilePreview.ts';
 
@@ -8,6 +9,8 @@ const blobUrl = 'blob:http://localhost:5173/abc-123';
 
 assert.equal(isDirectRenderableUrl(blobUrl), true);
 assert.equal(resolveFsPreviewUrl(blobUrl), blobUrl);
+assert.equal(isSameWorkspacePreviewPath('/a/b.md', '/a/b.md'), true);
+assert.equal(isSameWorkspacePreviewPath('/a/b.md', '/a/c.md'), false);
 assert.equal(
   resolveFsPreviewUrl('/data/agent_workspaces/user__1/uploads/photo.jpg'),
   '/api/v1/chat/fs/preview?path=%2Fdata%2Fagent_workspaces%2Fuser__1%2Fuploads%2Fphoto.jpg',

--- a/frontend/src/components/embed/ChatCanvas.vue
+++ b/frontend/src/components/embed/ChatCanvas.vue
@@ -6,7 +6,7 @@ import MermaidRenderer from '@/components/MermaidRenderer.vue';
 import { renderMarkdownPreview } from '@/utils/markdown';
 import PivotTable from '@/components/embed/PivotTable.vue';
 import { useToast } from '@/composables/useToast';
-import { canWriteWorkspaceFile, resolvePublicUploadsPreviewUrl, saveWorkspaceFileContent } from '@/utils/workspaceFilePreview';
+import { canWriteWorkspaceFile, isDirectRenderableUrl, resolvePublicUploadsPreviewUrl, saveWorkspaceFileContent } from '@/utils/workspaceFilePreview';
 
 const props = withDefaults(
   defineProps<{
@@ -442,7 +442,7 @@ const saveWorkspaceFile = async () => {
 
 const resolveUrlPath = (val: string): string => {
   if (!val) return '';
-  if (val.startsWith('http://') || val.startsWith('https://') || val.startsWith('data:') || val.startsWith('quick:') || val.startsWith('canvas:')) {
+  if (isDirectRenderableUrl(val)) {
     return val;
   }
   const publicUploadUrl = resolvePublicUploadsPreviewUrl(val);

--- a/frontend/src/components/embed/WorkspaceBrowserDrawer.vue
+++ b/frontend/src/components/embed/WorkspaceBrowserDrawer.vue
@@ -591,9 +591,10 @@ const formatTrashItemName = (name: string) => {
   return match?.[1] || name
 }
 
-const resolveItemDisplayName = (item: { name: string; path: string; is_dir: boolean }) => (
-  isTrashView.value ? formatTrashItemName(item.name) : displayItemName(item)
-)
+const resolveItemDisplayName = (item: { name: string; path: string; is_dir: boolean }) => {
+  if (isUserSessionsContainerItem(item)) return '会话目录'
+  return isTrashView.value ? formatTrashItemName(item.name) : displayItemName(item)
+}
 
 const isTrashRootItem = (item: { path: string; name: string; is_dir: boolean }) => {
   if (!item.is_dir || !trashDirPath.value) return false
@@ -604,23 +605,41 @@ const isTrashListItem = (item: { path: string; name: string; is_dir: boolean }) 
   isTrashPath(item.path) && !isTrashRootItem(item)
 )
 
-const USER_WORKSPACE_RESERVED_DIRS = new Set(['docs', 'uploads', 'sandbox', '.trash', 'skills'])
+const USER_WORKSPACE_RESERVED_DIRS = new Set(['docs', 'uploads', 'sandbox', '.trash', 'skills', 'sessions'])
 const SESSION_DIR_NAME_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
-const isDirectChildOfUserWorkspace = (itemPath: string) => {
+const isSessionDirName = (name: string) => (
+  SESSION_DIR_NAME_RE.test(name) || name.startsWith('conv_')
+)
+
+const isUserSessionsContainerItem = (item: { name: string; path: string; is_dir: boolean }) => {
+  if (!item.is_dir || item.name !== 'sessions') return false
   const root = userWorkspaceRoot.value
-  if (!root || !itemPath) return false
-  const norm = normalizeFsPathForCompare(itemPath)
+  if (!root || !item.path) return false
+  const norm = normalizeFsPathForCompare(item.path)
   const rootNorm = normalizeFsPathForCompare(root)
   if (!norm.startsWith(`${rootNorm}/`)) return false
   const relative = norm.slice(rootNorm.length + 1)
-  return relative.length > 0 && !relative.includes('/')
+  return relative === 'sessions'
 }
 
 const isSessionDirItem = (item: { name: string; path: string; is_dir: boolean }) => {
-  if (!item.is_dir || USER_WORKSPACE_RESERVED_DIRS.has(item.name)) return false
-  if (!isDirectChildOfUserWorkspace(item.path)) return false
-  return SESSION_DIR_NAME_RE.test(item.name) || item.name.startsWith('conv_')
+  if (!item.is_dir) return false
+  if (isUserSessionsContainerItem(item)) return true
+  const root = userWorkspaceRoot.value
+  if (!root || !item.path) return false
+  const norm = normalizeFsPathForCompare(item.path)
+  const rootNorm = normalizeFsPathForCompare(root)
+  if (!norm.startsWith(`${rootNorm}/`)) return false
+  const relative = norm.slice(rootNorm.length + 1)
+  const parts = relative.split('/')
+  if (parts.length === 2 && parts[0] === 'sessions' && isSessionDirName(parts[1])) {
+    return true
+  }
+  if (parts.length === 1 && !USER_WORKSPACE_RESERVED_DIRS.has(item.name)) {
+    return isSessionDirName(item.name)
+  }
+  return false
 }
 
 const isPathInUserWorkspace = (path: string) => {
@@ -1115,7 +1134,7 @@ const quickNavLinks = computed(() => {
       links.push({
         key: 'session',
         label: '本会话目录',
-        path: `${userWorkspaceRoot.value}/${props.conversationId}`,
+        path: `${userWorkspaceRoot.value}/sessions/${props.conversationId}`,
         icon: '💬',
         disabled: !props.sessionStarted,
         disabledTitle: '发送首条消息后会话目录才会创建',

--- a/frontend/src/components/embed/WorkspaceBrowserDrawer.vue
+++ b/frontend/src/components/embed/WorkspaceBrowserDrawer.vue
@@ -9,7 +9,7 @@ import {
 import { canPreviewWorkspaceFile, downloadWorkspaceFile, createWorkspaceEntry, renameWorkspaceEntry, deleteWorkspaceEntry, uploadToWorkspaceDir, copyTextToClipboard, restoreWorkspaceEntry, purgeWorkspaceEntry, emptyWorkspaceTrash } from '@/utils/workspaceFilePreview'
 
 const LEGACY_RECENT_FILES_KEY = 'workspace_recent_files_v1'
-const BROWSER_PREFS_KEY = 'workspace_browser_prefs_v1'
+const LEGACY_BROWSER_PREFS_KEY = 'workspace_browser_prefs_v1'
 const MAX_RECENT = 20
 const LIST_PAGE_SIZE = 200
 
@@ -107,23 +107,55 @@ const TYPE_SCAN_PATTERNS: Partial<Record<TypeFilterKey, string[]>> = {
   data: ['*.db', '*.sqlite', '*.parquet'],
 }
 
-const loadBrowserPrefs = () => {
+const loadBrowserPrefs = async () => {
   try {
-    const raw = localStorage.getItem(BROWSER_PREFS_KEY)
-    if (!raw) return
-    const prefs = JSON.parse(raw)
-    if (typeof prefs.includeSubdirs === 'boolean') includeSubdirs.value = prefs.includeSubdirs
-    if (prefs.typeFilter) typeFilter.value = prefs.typeFilter
+    const res = await axios.get('/api/v1/chat/fs/browser-prefs')
+    const prefs = res.data?.data
+    if (prefs && typeof prefs.include_subdirs === 'boolean') {
+      includeSubdirs.value = prefs.include_subdirs
+    }
+    if (prefs?.type_filter) typeFilter.value = prefs.type_filter as TypeFilterKey
+    await migrateLegacyBrowserPrefsIfNeeded()
   } catch { /* ignore */ }
 }
 
-const saveBrowserPrefs = () => {
+let browserPrefsPersistTimer: ReturnType<typeof setTimeout> | null = null
+
+const persistBrowserPrefsNow = async () => {
   try {
-    localStorage.setItem(BROWSER_PREFS_KEY, JSON.stringify({
-      includeSubdirs: includeSubdirs.value,
-      typeFilter: typeFilter.value,
-    }))
-  } catch { /* ignore */ }
+    await axios.put('/api/v1/chat/fs/browser-prefs', {
+      include_subdirs: includeSubdirs.value,
+      type_filter: typeFilter.value,
+    })
+  } catch {
+    /* ignore */
+  }
+}
+
+const saveBrowserPrefs = () => {
+  if (browserPrefsPersistTimer) clearTimeout(browserPrefsPersistTimer)
+  browserPrefsPersistTimer = setTimeout(() => {
+    browserPrefsPersistTimer = null
+    void persistBrowserPrefsNow()
+  }, 300)
+}
+
+const migrateLegacyBrowserPrefsIfNeeded = async () => {
+  try {
+    const raw = localStorage.getItem(LEGACY_BROWSER_PREFS_KEY)
+    if (!raw) return
+    const legacy = JSON.parse(raw) as { includeSubdirs?: boolean; typeFilter?: string }
+    localStorage.removeItem(LEGACY_BROWSER_PREFS_KEY)
+    if (typeof legacy.includeSubdirs === 'boolean') {
+      includeSubdirs.value = legacy.includeSubdirs
+    }
+    if (legacy.typeFilter) {
+      typeFilter.value = legacy.typeFilter as TypeFilterKey
+    }
+    await persistBrowserPrefsNow()
+  } catch {
+    localStorage.removeItem(LEGACY_BROWSER_PREFS_KEY)
+  }
 }
 
 const loadRecentFiles = async () => {
@@ -247,7 +279,7 @@ const openRecentFile = async (recent: { path: string; name: string; mtime: numbe
   setTimeout(() => { highlightedPath.value = '' }, 3000)
 }
 
-loadBrowserPrefs()
+void loadBrowserPrefs()
 void loadRecentFiles()
 
 let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -758,6 +790,11 @@ onUnmounted(() => {
     clearTimeout(recentFilesPersistTimer)
     recentFilesPersistTimer = null
     void persistRecentFilesNow()
+  }
+  if (browserPrefsPersistTimer) {
+    clearTimeout(browserPrefsPersistTimer)
+    browserPrefsPersistTimer = null
+    void persistBrowserPrefsNow()
   }
   mobileMq?.removeEventListener('change', syncMobile)
   document.removeEventListener('click', onDocumentClick)

--- a/frontend/src/components/embed/WorkspaceBrowserDrawer.vue
+++ b/frontend/src/components/embed/WorkspaceBrowserDrawer.vue
@@ -8,7 +8,7 @@ import {
 } from '@/utils/fileTypeVisual'
 import { canPreviewWorkspaceFile, downloadWorkspaceFile, createWorkspaceEntry, renameWorkspaceEntry, deleteWorkspaceEntry, uploadToWorkspaceDir, copyTextToClipboard, restoreWorkspaceEntry, purgeWorkspaceEntry, emptyWorkspaceTrash } from '@/utils/workspaceFilePreview'
 
-const RECENT_FILES_KEY = 'workspace_recent_files_v1'
+const LEGACY_RECENT_FILES_KEY = 'workspace_recent_files_v1'
 const BROWSER_PREFS_KEY = 'workspace_browser_prefs_v1'
 const MAX_RECENT = 20
 const LIST_PAGE_SIZE = 200
@@ -126,19 +126,47 @@ const saveBrowserPrefs = () => {
   } catch { /* ignore */ }
 }
 
-const loadRecentFiles = () => {
+const loadRecentFiles = async () => {
   try {
-    const raw = localStorage.getItem(RECENT_FILES_KEY)
-    recentFiles.value = raw ? JSON.parse(raw) : []
+    const res = await axios.get('/api/v1/chat/fs/recent-files')
+    recentFiles.value = res.data?.data?.items || []
+    await migrateLegacyRecentFilesIfNeeded()
   } catch {
     recentFiles.value = []
   }
 }
 
-const persistRecentFiles = () => {
+let recentFilesPersistTimer: ReturnType<typeof setTimeout> | null = null
+
+const persistRecentFilesNow = async () => {
   try {
-    localStorage.setItem(RECENT_FILES_KEY, JSON.stringify(recentFiles.value))
-  } catch { /* ignore */ }
+    await axios.put('/api/v1/chat/fs/recent-files', { items: recentFiles.value })
+  } catch {
+    /* ignore */
+  }
+}
+
+const persistRecentFiles = () => {
+  if (recentFilesPersistTimer) clearTimeout(recentFilesPersistTimer)
+  recentFilesPersistTimer = setTimeout(() => {
+    recentFilesPersistTimer = null
+    void persistRecentFilesNow()
+  }, 300)
+}
+
+const migrateLegacyRecentFilesIfNeeded = async () => {
+  try {
+    const raw = localStorage.getItem(LEGACY_RECENT_FILES_KEY)
+    if (!raw) return
+    const legacy = JSON.parse(raw) as Array<{ path: string; name: string; mtime?: number }>
+    localStorage.removeItem(LEGACY_RECENT_FILES_KEY)
+    if (!Array.isArray(legacy) || legacy.length === 0) return
+    if (recentFiles.value.length > 0) return
+    recentFiles.value = legacy.slice(0, MAX_RECENT)
+    await persistRecentFilesNow()
+  } catch {
+    localStorage.removeItem(LEGACY_RECENT_FILES_KEY)
+  }
 }
 
 const trackRecentFile = (item: { path: string; name: string; mtime?: number }) => {
@@ -155,7 +183,7 @@ const removeRecentFile = (path: string) => {
 
 const clearRecentFiles = () => {
   recentFiles.value = []
-  persistRecentFiles()
+  void persistRecentFilesNow()
   showToast('已清空最近记录', 'success')
 }
 
@@ -178,7 +206,7 @@ const toggleRecentFilesMenu = () => {
     closeRecentFilesMenu()
     return
   }
-  loadRecentFiles()
+  void loadRecentFiles()
   recentFilesOpen.value = true
   nextTick(updateRecentFilesMenuPosition)
 }
@@ -220,7 +248,7 @@ const openRecentFile = async (recent: { path: string; name: string; mtime: numbe
 }
 
 loadBrowserPrefs()
-loadRecentFiles()
+void loadRecentFiles()
 
 let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -726,6 +754,11 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  if (recentFilesPersistTimer) {
+    clearTimeout(recentFilesPersistTimer)
+    recentFilesPersistTimer = null
+    void persistRecentFilesNow()
+  }
   mobileMq?.removeEventListener('change', syncMobile)
   document.removeEventListener('click', onDocumentClick)
   document.removeEventListener('keydown', onGlobalKeydown)

--- a/frontend/src/components/embed/WorkspaceBrowserDrawer.vue
+++ b/frontend/src/components/embed/WorkspaceBrowserDrawer.vue
@@ -604,6 +604,25 @@ const isTrashListItem = (item: { path: string; name: string; is_dir: boolean }) 
   isTrashPath(item.path) && !isTrashRootItem(item)
 )
 
+const USER_WORKSPACE_RESERVED_DIRS = new Set(['docs', 'uploads', 'sandbox', '.trash', 'skills'])
+const SESSION_DIR_NAME_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+const isDirectChildOfUserWorkspace = (itemPath: string) => {
+  const root = userWorkspaceRoot.value
+  if (!root || !itemPath) return false
+  const norm = normalizeFsPathForCompare(itemPath)
+  const rootNorm = normalizeFsPathForCompare(root)
+  if (!norm.startsWith(`${rootNorm}/`)) return false
+  const relative = norm.slice(rootNorm.length + 1)
+  return relative.length > 0 && !relative.includes('/')
+}
+
+const isSessionDirItem = (item: { name: string; path: string; is_dir: boolean }) => {
+  if (!item.is_dir || USER_WORKSPACE_RESERVED_DIRS.has(item.name)) return false
+  if (!isDirectChildOfUserWorkspace(item.path)) return false
+  return SESSION_DIR_NAME_RE.test(item.name) || item.name.startsWith('conv_')
+}
+
 const isPathInUserWorkspace = (path: string) => {
   const root = userWorkspaceRoot.value
   if (!root || !path) return false
@@ -742,12 +761,35 @@ watch(
       baseDir.value = ''
       loadRecentFiles()
       fetchDirectory()
+      nextTick(syncQuickNavScrollHints)
     } else {
       closeRecentFilesMenu()
     }
   },
   { immediate: true },
 )
+
+const quickNavScrollRef = ref<HTMLElement | null>(null)
+const quickNavScrollRight = ref(false)
+const quickNavScrollLeft = ref(false)
+
+const syncQuickNavScrollHints = () => {
+  const el = quickNavScrollRef.value
+  if (!el) {
+    quickNavScrollRight.value = false
+    quickNavScrollLeft.value = false
+    return
+  }
+  const maxScroll = el.scrollWidth - el.clientWidth
+  quickNavScrollLeft.value = el.scrollLeft > 4
+  quickNavScrollRight.value = maxScroll > 4 && el.scrollLeft < maxScroll - 4
+}
+
+const scrollQuickNav = (direction: 'left' | 'right') => {
+  const el = quickNavScrollRef.value
+  if (!el) return
+  el.scrollBy({ left: direction === 'right' ? 140 : -140, behavior: 'smooth' })
+}
 
 const onGlobalKeydown = (event: KeyboardEvent) => {
   if (event.key === 'Escape') {
@@ -783,6 +825,7 @@ onMounted(() => {
   document.addEventListener('keydown', onGlobalKeydown)
   window.addEventListener('resize', syncRecentFilesMenuPosition)
   window.addEventListener('scroll', syncRecentFilesMenuPosition, true)
+  nextTick(syncQuickNavScrollHints)
 })
 
 onUnmounted(() => {
@@ -841,6 +884,18 @@ const getRowVisual = (item: { name: string; is_dir: boolean; path: string }) => 
       iconRing: 'ring-amber-200/60 dark:ring-amber-500/20',
       badgeBg: 'bg-amber-50 dark:bg-amber-500/10',
       badgeText: 'text-amber-700 dark:text-amber-300',
+      category: 'folder' as FileTypeCategory,
+      ext: '',
+    }
+  }
+  if (isSessionDirItem(item)) {
+    return {
+      icon: '💬',
+      label: '会话目录',
+      iconBg: 'bg-sky-50 dark:bg-sky-500/10',
+      iconRing: 'ring-sky-200/60 dark:ring-sky-500/20',
+      badgeBg: 'bg-sky-50 dark:bg-sky-500/10',
+      badgeText: 'text-sky-700 dark:text-sky-300',
       category: 'folder' as FileTypeCategory,
       ext: '',
     }
@@ -960,6 +1015,13 @@ const clearMultiSelect = () => {
   multiSelectMode.value = false
 }
 
+const toggleMultiSelectMode = () => {
+  multiSelectMode.value = !multiSelectMode.value
+  if (!multiSelectMode.value) {
+    selectedPaths.value = new Set()
+  }
+}
+
 const handleRowClick = (item: any) => {
   if (isMobile.value && item.is_dir) {
     fetchDirectory(item.path)
@@ -1027,6 +1089,16 @@ const mountCurrentDirectoryToSession = () => {
 
 const shouldShowRowActions = (item: { path: string }) => selectedItem.value?.path === item.path
 
+const trashNavLink = computed(() => {
+  if (!userWorkspaceRoot.value) return null
+  return {
+    key: 'trash',
+    label: '回收站',
+    path: `${userWorkspaceRoot.value}/.trash`,
+    icon: '🗑️',
+  }
+})
+
 const quickNavLinks = computed(() => {
   const links: Array<{
     key: string
@@ -1038,20 +1110,31 @@ const quickNavLinks = computed(() => {
   }> = []
   if (userWorkspaceRoot.value) {
     links.push({ key: 'home', label: '我的目录', path: userWorkspaceRoot.value, icon: '🏠' })
+    links.push({ key: 'docs', label: '我的文档', path: `${userWorkspaceRoot.value}/docs`, icon: '📄' })
+    if (props.conversationId) {
+      links.push({
+        key: 'session',
+        label: '本会话目录',
+        path: `${userWorkspaceRoot.value}/${props.conversationId}`,
+        icon: '💬',
+        disabled: !props.sessionStarted,
+        disabledTitle: '发送首条消息后会话目录才会创建',
+      })
+    }
     links.push({ key: 'uploads', label: 'uploads', path: `${userWorkspaceRoot.value}/uploads`, icon: '📤' })
-    links.push({ key: 'trash', label: '回收站', path: `${userWorkspaceRoot.value}/.trash`, icon: '🗑️' })
-  }
-  if (props.conversationId && userWorkspaceRoot.value) {
-    links.push({
-      key: 'session',
-      label: '本会话目录',
-      path: `${userWorkspaceRoot.value}/${props.conversationId}`,
-      icon: '💬',
-      disabled: !props.sessionStarted,
-      disabledTitle: '发送首条消息后会话目录才会创建',
-    })
   }
   return links
+})
+
+watch(quickNavLinks, () => {
+  nextTick(syncQuickNavScrollHints)
+})
+
+watch(quickNavScrollRef, (el, _, onCleanup) => {
+  if (!el || typeof ResizeObserver === 'undefined') return
+  const observer = new ResizeObserver(() => syncQuickNavScrollHints())
+  observer.observe(el)
+  onCleanup(() => observer.disconnect())
 })
 
 const handleQuickNavClick = (link: { path: string; disabled?: boolean; disabledTitle?: string }) => {
@@ -1391,62 +1474,93 @@ const closeDrawer = () => {
 
             <div class="workspace-drawer-scroll flex-1 overflow-y-auto overscroll-y-contain p-3 sm:p-4 bg-white dark:bg-gray-900/60 min-h-0 touch-pan-y flex flex-col">
               <div class="flex flex-col flex-1 min-h-0">
-                <div class="flex items-center gap-1.5 mb-3 shrink-0 overflow-x-auto no-scrollbar flex-nowrap min-w-0 touch-pan-x">
-                  <button
-                    v-for="link in quickNavLinks"
-                    :key="link.key"
-                    type="button"
-                    class="inline-flex shrink-0 whitespace-nowrap items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-bold border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 transition-all"
-                    :class="link.disabled
-                      ? 'opacity-40 cursor-not-allowed text-gray-400 dark:text-gray-500'
-                      : 'hover:border-primary/30 hover:text-primary'"
-                    :aria-disabled="link.disabled ? 'true' : undefined"
-                    :title="link.disabled ? link.disabledTitle : link.label"
-                    @click="handleQuickNavClick(link)"
+                <div class="relative mb-3 shrink-0 min-w-0">
+                  <div
+                    ref="quickNavScrollRef"
+                    class="flex items-center gap-1.5 overflow-x-auto no-scrollbar flex-nowrap min-w-0 touch-pan-x scroll-smooth pr-1"
+                    @scroll="syncQuickNavScrollHints"
                   >
-                    <span>{{ link.icon }}</span>
-                    <span>{{ link.label }}</span>
-                  </button>
-                  <div class="shrink-0">
-                    <button
-                      ref="recentFilesTriggerRef"
-                      type="button"
-                      class="inline-flex shrink-0 whitespace-nowrap items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-bold border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 transition-all"
-                      :class="recentFilesOpen ? 'border-primary/30 text-primary bg-primary/5' : 'text-gray-500 hover:border-primary/30 hover:text-primary'"
-                      @click.stop="toggleRecentFilesMenu"
-                    >
-                      <span>🕒</span>
-                      <span>最近文件</span>
-                      <svg
-                        class="w-3 h-3 transition-transform"
-                        :class="recentFilesOpen ? 'rotate-180' : ''"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                        aria-hidden="true"
+                      <button
+                        v-for="link in quickNavLinks"
+                        :key="link.key"
+                        type="button"
+                        class="inline-flex shrink-0 whitespace-nowrap items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-bold border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 transition-all"
+                        :class="link.disabled
+                          ? 'opacity-40 cursor-not-allowed text-gray-400 dark:text-gray-500'
+                          : 'hover:border-primary/30 hover:text-primary'"
+                        :aria-disabled="link.disabled ? 'true' : undefined"
+                        :title="link.disabled ? link.disabledTitle : link.label"
+                        @click="handleQuickNavClick(link)"
                       >
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7" />
-                      </svg>
+                        <span>{{ link.icon }}</span>
+                        <span>{{ link.label }}</span>
+                      </button>
+                      <div class="shrink-0">
+                        <button
+                          ref="recentFilesTriggerRef"
+                          type="button"
+                          class="inline-flex shrink-0 whitespace-nowrap items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-bold border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 transition-all"
+                          :class="recentFilesOpen ? 'border-primary/30 text-primary bg-primary/5' : 'text-gray-500 hover:border-primary/30 hover:text-primary'"
+                          @click.stop="toggleRecentFilesMenu"
+                        >
+                          <span>🕒</span>
+                          <span>最近文件</span>
+                          <svg
+                            class="w-3 h-3 transition-transform"
+                            :class="recentFilesOpen ? 'rotate-180' : ''"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                          >
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7" />
+                          </svg>
+                        </button>
+                      </div>
+                      <button
+                        v-if="trashNavLink"
+                        type="button"
+                        class="inline-flex shrink-0 whitespace-nowrap items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-bold border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 transition-all hover:border-primary/30 hover:text-primary"
+                        @click="handleQuickNavClick(trashNavLink)"
+                      >
+                        <span>{{ trashNavLink.icon }}</span>
+                        <span>{{ trashNavLink.label }}</span>
                     </button>
                   </div>
-                  <div class="flex shrink-0 items-center gap-1.5">
-                    <button
-                      v-if="selectedPaths.size > 0"
-                      type="button"
-                      class="inline-flex shrink-0 whitespace-nowrap items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-bold border border-primary/30 text-primary bg-primary/10 transition-all"
-                      @click="mountSelectedBatch"
-                    >
-                      批量添加 ({{ selectedPaths.size }})
-                    </button>
-                    <button
-                      type="button"
-                      class="inline-flex shrink-0 whitespace-nowrap items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-bold border border-gray-200 dark:border-gray-700 text-gray-500 transition-all"
-                      :class="multiSelectMode ? 'text-primary border-primary/30 bg-primary/5' : ''"
-                      @click="multiSelectMode = !multiSelectMode; if (!multiSelectMode) clearMultiSelect()"
-                    >
-                      {{ multiSelectMode ? '取消多选' : '多选' }}
-                    </button>
-                  </div>
+                  <div
+                    v-if="quickNavScrollLeft"
+                    class="pointer-events-none absolute inset-y-0 left-0 w-6 bg-gradient-to-r from-white via-white/95 to-transparent dark:from-gray-900 dark:via-gray-900/95"
+                    aria-hidden="true"
+                  />
+                  <div
+                    v-if="quickNavScrollRight"
+                    class="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-white via-white/95 to-transparent dark:from-gray-900 dark:via-gray-900/95"
+                    aria-hidden="true"
+                  />
+                  <button
+                    v-if="quickNavScrollRight"
+                    type="button"
+                    class="absolute right-0 top-1/2 z-10 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-400 shadow-sm transition-colors hover:border-primary/30 hover:text-primary dark:border-gray-700 dark:bg-gray-900/95 dark:text-gray-500"
+                    title="向右滑动查看更多"
+                    aria-label="向右滑动查看更多"
+                    @click="scrollQuickNav('right')"
+                  >
+                    <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                  <button
+                    v-if="quickNavScrollLeft"
+                    type="button"
+                    class="absolute left-0 top-1/2 z-10 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-400 shadow-sm transition-colors hover:border-primary/30 hover:text-primary dark:border-gray-700 dark:bg-gray-900/95 dark:text-gray-500"
+                    title="向左滑动查看更多"
+                    aria-label="向左滑动查看更多"
+                    @click="scrollQuickNav('left')"
+                  >
+                    <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M15 19l-7-7 7-7" />
+                    </svg>
+                  </button>
                 </div>
 
                 <div
@@ -1582,10 +1696,14 @@ const closeDrawer = () => {
 
                 <div class="flex-1 min-h-[240px] border border-gray-100 dark:border-gray-800 rounded-xl overflow-hidden flex flex-col relative bg-gray-50/10">
                   <div class="grid grid-cols-12 gap-2 px-4 py-2 border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-900/20 text-[10px] font-black text-gray-400 tracking-wider shrink-0">
+                    <div v-if="multiSelectMode" class="col-span-1" aria-hidden="true" />
                     <button
                       type="button"
-                      class="col-span-7 sm:col-span-6 inline-flex items-center gap-1 text-left hover:text-primary transition-colors focus:outline-none"
-                      :class="sortKey === 'name' ? 'text-primary' : ''"
+                      class="inline-flex items-center gap-1 text-left hover:text-primary transition-colors focus:outline-none"
+                      :class="[
+                        multiSelectMode ? 'col-span-6 sm:col-span-5' : 'col-span-7 sm:col-span-6',
+                        sortKey === 'name' ? 'text-primary' : '',
+                      ]"
                       @click="toggleSort('name')"
                     >
                       <span>名称</span>
@@ -1632,7 +1750,7 @@ const closeDrawer = () => {
                     </div>
                   </div>
 
-                  <div class="flex-1 overflow-y-auto custom-scrollbar p-1 min-h-0" @contextmenu="handleListContextMenu">
+                  <div class="flex-1 overflow-y-auto custom-scrollbar p-1 pb-16 min-h-0" @contextmenu="handleListContextMenu">
                     <div v-if="displayItems.length === 0 && !searchLoading" class="h-full flex flex-col items-center justify-center text-gray-400 py-12 px-4">
                       <span class="text-4xl mb-2">{{ isRecursiveListingActive || isSearchActive ? '🔍' : '📂' }}</span>
                       <span class="text-xs font-bold">{{ displayEmptyHint }}</span>
@@ -1664,7 +1782,10 @@ const closeDrawer = () => {
                           <input type="checkbox" class="rounded border-gray-300 text-primary" :checked="selectedPaths.has(item.path)" @click.stop="toggleMultiSelect(item)">
                         </div>
                         <template v-for="visual in [getRowVisual(item)]" :key="item.path + '-visual'">
-                          <div class="col-span-7 sm:col-span-6 flex items-start gap-2.5 min-w-0">
+                          <div
+                            class="flex items-start gap-2.5 min-w-0"
+                            :class="multiSelectMode ? 'col-span-6 sm:col-span-5' : 'col-span-7 sm:col-span-6'"
+                          >
                             <div
                               class="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 ring-1 text-sm mt-0.5"
                               :class="[visual.iconBg, visual.iconRing]"
@@ -1685,6 +1806,12 @@ const closeDrawer = () => {
                                 title="当前登录用户的 AI 会话工作目录"
                               >
                                 用户工作目录
+                              </span>
+                              <span
+                                v-if="isSessionDirItem(item)"
+                                class="inline-flex sm:hidden mt-1 px-1.5 py-0.5 rounded-md text-[9px] font-bold bg-sky-50 dark:bg-sky-500/10 text-sky-700 dark:text-sky-300 ring-1 ring-sky-200/60 dark:ring-sky-500/20"
+                              >
+                                会话目录
                               </span>
                               <div
                                 v-if="isRecursiveListingActive && getItemLocationHint(item.path)"
@@ -1801,6 +1928,50 @@ const closeDrawer = () => {
                         </button>
                       </div>
                     </div>
+                  </div>
+
+                  <div class="absolute bottom-3 right-3 z-20 flex flex-col items-end gap-2 pointer-events-none">
+                    <button
+                      v-if="multiSelectMode && selectedPaths.size > 0"
+                      type="button"
+                      class="pointer-events-auto inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary px-3.5 py-2 text-[11px] font-bold text-white shadow-lg shadow-primary/20 transition-all hover:brightness-105 active:scale-[0.98]"
+                      @click="mountSelectedBatch"
+                    >
+                      批量添加 ({{ selectedPaths.size }})
+                    </button>
+                    <button
+                      type="button"
+                      class="pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full border shadow-lg transition-all active:scale-95"
+                      :class="multiSelectMode
+                        ? 'border-primary bg-primary text-white shadow-primary/25'
+                        : 'border-gray-200 bg-white text-gray-600 hover:border-primary/30 hover:text-primary dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:shadow-black/30'"
+                      :title="multiSelectMode ? '取消多选' : '多选'"
+                      :aria-label="multiSelectMode ? '取消多选' : '多选'"
+                      @click="toggleMultiSelectMode"
+                    >
+                      <svg
+                        v-if="multiSelectMode"
+                        class="h-5 w-5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                      <svg
+                        v-else
+                        class="h-5 w-5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 11H5a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2v-4" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7h4a2 2 0 012 2v6" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7V5a2 2 0 012-2h2a2 2 0 012 2v2" />
+                      </svg>
+                    </button>
                   </div>
                 </div>
               </div>

--- a/frontend/src/utils/redisKeyGroups.ts
+++ b/frontend/src/utils/redisKeyGroups.ts
@@ -89,6 +89,12 @@ export const REDIS_KEY_CATEGORIES: RedisKeyCategory[] = [
     match: (key) => key.startsWith('portal:prefs:'),
   },
   {
+    id: 'workspace_recent',
+    label: '工作空间最近文件',
+    description: '浏览工作空间时按用户隔离的最近访问文件记录',
+    match: (key) => key.startsWith('agent:workspace_recent_files:'),
+  },
+  {
     id: 'rate_limit',
     label: '限流',
     description: '接口限流计数',

--- a/frontend/src/utils/redisKeyGroups.ts
+++ b/frontend/src/utils/redisKeyGroups.ts
@@ -95,6 +95,12 @@ export const REDIS_KEY_CATEGORIES: RedisKeyCategory[] = [
     match: (key) => key.startsWith('agent:workspace_recent_files:'),
   },
   {
+    id: 'workspace_browser_prefs',
+    label: '工作空间浏览偏好',
+    description: '工作空间文件浏览器的筛选与搜索偏好（按用户隔离）',
+    match: (key) => key.startsWith('agent:workspace_browser_prefs:'),
+  },
+  {
     id: 'rate_limit',
     label: '限流',
     description: '接口限流计数',

--- a/frontend/src/utils/workspaceFilePreview.ts
+++ b/frontend/src/utils/workspaceFilePreview.ts
@@ -94,16 +94,24 @@ export function resolvePublicUploadsPreviewUrl(path: string): string | null {
   return null
 }
 
+/** 已是可直接用于 img/iframe/fetch 的 URL，无需再走 fs preview 转换 */
+export function isDirectRenderableUrl(url: string): boolean {
+  return (
+    url.startsWith('http://') ||
+    url.startsWith('https://') ||
+    url.startsWith('data:') ||
+    url.startsWith('blob:') ||
+    url.startsWith('quick:') ||
+    url.startsWith('canvas:') ||
+    url.startsWith('/static/') ||
+    url.startsWith('/api/') ||
+    url.startsWith('/assets/')
+  )
+}
+
 export function resolveFsPreviewUrl(path: string, conversationId?: string | null): string {
   if (!path) return ''
-  if (
-    path.startsWith('http://') ||
-    path.startsWith('https://') ||
-    path.startsWith('data:') ||
-    path.startsWith('/static/') ||
-    path.startsWith('/api/') ||
-    path.startsWith('/assets/')
-  ) {
+  if (isDirectRenderableUrl(path)) {
     return path
   }
   const publicUploadUrl = resolvePublicUploadsPreviewUrl(path)

--- a/frontend/src/utils/workspaceFilePreview.ts
+++ b/frontend/src/utils/workspaceFilePreview.ts
@@ -21,6 +21,18 @@ export type CanvasPanelData = {
   compareTitle?: string
 }
 
+export function normalizeWorkspacePath(path: string): string {
+  return String(path || '').replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+export function isSameWorkspacePreviewPath(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean {
+  if (!a || !b) return false
+  return normalizeWorkspacePath(a) === normalizeWorkspacePath(b)
+}
+
 export function getWorkspaceFileExtension(name: string): string {
   const parts = name.split('.')
   if (parts.length < 2) return ''

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -48,7 +48,7 @@ import SkillBrowserDrawer from "@/components/embed/SkillBrowserDrawer.vue";
 import ChatCanvas from "@/components/embed/ChatCanvas.vue";
 import AttachmentImageThumb from "@/components/embed/AttachmentImageThumb.vue";
 import { isImageAttachment, getServerAttachmentPath } from "@/utils/attachmentImages";
-import { openWorkspaceFileInCanvas } from "@/utils/workspaceFilePreview";
+import { openWorkspaceFileInCanvas, isSameWorkspacePreviewPath } from "@/utils/workspaceFilePreview";
 import { sanitizeStreamContent } from "@/utils/streamContentSanitize";
 import {
   splitSqlToolLogDetails,
@@ -1976,6 +1976,7 @@ const handleSelectLocalFs = (payload: { type: 'local_file' | 'local_dir'; path: 
 
 const canvasVisible = ref(false);
 const canvasFromWorkspace = ref(false);
+const workspaceCanvasPreviewPath = ref<string | null>(null);
 const canvasData = ref<{
   type: 'html' | 'code' | 'mermaid' | 'pdf' | 'csv' | 'image' | 'compare';
   title: string;
@@ -2004,6 +2005,7 @@ const closeCanvas = () => {
 watch(canvasVisible, (visible) => {
   if (!visible) {
     canvasFromWorkspace.value = false;
+    workspaceCanvasPreviewPath.value = null;
     revokeActiveBlobUrl();
   }
 });
@@ -2013,6 +2015,15 @@ onUnmounted(() => {
 });
 
 const handleWorkspaceFilePreview = async (payload: { path: string; name: string }) => {
+  if (
+    canvasVisible.value &&
+    canvasFromWorkspace.value &&
+    isSameWorkspacePreviewPath(workspaceCanvasPreviewPath.value, payload.path)
+  ) {
+    closeCanvas();
+    workspaceCanvasPreviewPath.value = null;
+    return;
+  }
   canvasFromWorkspace.value = true;
   await openWorkspaceFileInCanvas({
     path: payload.path,
@@ -2021,6 +2032,7 @@ const handleWorkspaceFilePreview = async (payload: { path: string; name: string 
     showToast,
     activeBlobUrlRef: activeBlobUrl,
     onOpen: (data) => {
+      workspaceCanvasPreviewPath.value = payload.path;
       canvasData.value = data as typeof canvasData.value;
       canvasVisible.value = true;
     },

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -2374,7 +2374,7 @@ import MemoryBrowserDrawer from "@/components/embed/MemoryBrowserDrawer.vue";
 import SkillBrowserDrawer from "@/components/embed/SkillBrowserDrawer.vue";
 import AttachmentImageThumb from "@/components/embed/AttachmentImageThumb.vue";
 import { isImageAttachment, getServerAttachmentPath } from "@/utils/attachmentImages";
-import { openWorkspaceFileInCanvas, resolvePublicUploadsPreviewUrl, shouldAttachWorkspaceSourcePath } from "@/utils/workspaceFilePreview";
+import { openWorkspaceFileInCanvas, isDirectRenderableUrl, resolvePublicUploadsPreviewUrl, shouldAttachWorkspaceSourcePath } from "@/utils/workspaceFilePreview";
 import TraceLogViewer from "@/components/TraceLogViewer.vue";
 import { sanitizeStreamContent } from "@/utils/streamContentSanitize";
 import { normalizeAgentSwitchCommand } from "@/utils/agentSwitchCommands";
@@ -3756,7 +3756,7 @@ const handlePreviewImageUrl = (url: string, filename: string) => {
 
 const resolveFileUrl = (url: string): string => {
   if (!url) return '';
-  if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('data:') || url.startsWith('quick:') || url.startsWith('canvas:')) {
+  if (isDirectRenderableUrl(url)) {
     return url;
   }
   const publicUploadUrl = resolvePublicUploadsPreviewUrl(url);

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -2374,7 +2374,7 @@ import MemoryBrowserDrawer from "@/components/embed/MemoryBrowserDrawer.vue";
 import SkillBrowserDrawer from "@/components/embed/SkillBrowserDrawer.vue";
 import AttachmentImageThumb from "@/components/embed/AttachmentImageThumb.vue";
 import { isImageAttachment, getServerAttachmentPath } from "@/utils/attachmentImages";
-import { openWorkspaceFileInCanvas, isDirectRenderableUrl, resolvePublicUploadsPreviewUrl, shouldAttachWorkspaceSourcePath } from "@/utils/workspaceFilePreview";
+import { openWorkspaceFileInCanvas, isDirectRenderableUrl, isSameWorkspacePreviewPath, resolvePublicUploadsPreviewUrl, shouldAttachWorkspaceSourcePath } from "@/utils/workspaceFilePreview";
 import TraceLogViewer from "@/components/TraceLogViewer.vue";
 import { sanitizeStreamContent } from "@/utils/streamContentSanitize";
 import { normalizeAgentSwitchCommand } from "@/utils/agentSwitchCommands";
@@ -2909,6 +2909,15 @@ const handleSelectLocalFs = (payload: { type: 'local_file' | 'local_dir'; path: 
 };
 
 const handleWorkspaceFilePreview = async (payload: { path: string; name: string }) => {
+  if (
+    canvasVisible.value &&
+    canvasFromWorkspace.value &&
+    isSameWorkspacePreviewPath(workspaceCanvasPreviewPath.value, payload.path)
+  ) {
+    closeCanvas();
+    workspaceCanvasPreviewPath.value = null;
+    return;
+  }
   canvasFromWorkspace.value = true;
   await openWorkspaceFileInCanvas({
     path: payload.path,
@@ -2917,6 +2926,7 @@ const handleWorkspaceFilePreview = async (payload: { path: string; name: string 
     showToast,
     activeBlobUrlRef: activeBlobUrl,
     onOpen: (data) => {
+      workspaceCanvasPreviewPath.value = payload.path;
       canvasData.value = data as typeof canvasData.value;
       canvasVisible.value = true;
     },
@@ -3586,6 +3596,7 @@ const saveAndResend = async () => {
 // Canvas Panel States
 const canvasVisible = ref(false);
 const canvasFromWorkspace = ref(false);
+const workspaceCanvasPreviewPath = ref<string | null>(null);
 const canvasData = ref<{ type: 'html' | 'code' | 'mermaid' | 'pdf' | 'csv' | 'image' | 'compare'; title: string; content: string; sourcePath?: string; compareContent?: string; compareTitle?: string } | null>(null);
 const activeBlobUrl = ref('');
 
@@ -3607,6 +3618,7 @@ const closeCanvas = () => {
 watch(canvasVisible, (visible) => {
   if (!visible) {
     canvasFromWorkspace.value = false;
+    workspaceCanvasPreviewPath.value = null;
     revokeActiveBlobUrl();
   }
 });

--- a/tests/ai/runtime/test_agentscope_workspace.py
+++ b/tests/ai/runtime/test_agentscope_workspace.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from app.services.ai.runtime.agentscope.workspace import (
+    USER_SESSIONS_DIR_NAME,
     WORKSPACE_USER_KEY_SEP,
     USER_DOCS_DIR_NAME,
     clear_workspace_cache,
@@ -44,6 +45,7 @@ async def test_resolve_session_workdir_isolates_user_and_conversation(tmp_path, 
     )
     assert path.startswith(str(tmp_path))
     assert f"alice{WORKSPACE_USER_KEY_SEP}1" in path
+    assert USER_SESSIONS_DIR_NAME in path
     assert "conv_abc" in path
 
 
@@ -114,8 +116,7 @@ async def test_delete_workspace_for_session_removes_files(tmp_path, monkeypatch)
         user_name="carol",
         conversation_id="c2",
     )
-    marker = os.path.join(workdir, "sessions", "marker.txt")
-    os.makedirs(os.path.dirname(marker), exist_ok=True)
+    marker = os.path.join(workdir, "marker.txt")
     with open(marker, "w", encoding="utf-8") as handle:
         handle.write("x")
 

--- a/tests/ai/runtime/test_agentscope_workspace.py
+++ b/tests/ai/runtime/test_agentscope_workspace.py
@@ -4,10 +4,12 @@ import pytest
 
 from app.services.ai.runtime.agentscope.workspace import (
     WORKSPACE_USER_KEY_SEP,
+    USER_DOCS_DIR_NAME,
     clear_workspace_cache,
     delete_workspace_for_session,
     get_local_workspace_offloader,
     resolve_session_workdir,
+    resolve_user_docs_dir,
     resolve_user_workspace_root,
     resolve_workspace_user_key,
 )
@@ -43,6 +45,21 @@ async def test_resolve_session_workdir_isolates_user_and_conversation(tmp_path, 
     assert path.startswith(str(tmp_path))
     assert f"alice{WORKSPACE_USER_KEY_SEP}1" in path
     assert "conv_abc" in path
+
+
+def test_resolve_user_docs_dir_is_per_user_not_per_conversation(tmp_path):
+    docs_a = resolve_user_docs_dir(
+        root=str(tmp_path),
+        user_id=1,
+        user_name="alice",
+    )
+    docs_b = resolve_user_docs_dir(
+        root=str(tmp_path),
+        user_id=1,
+        user_name="alice",
+    )
+    assert docs_a == docs_b
+    assert docs_a.endswith(os.path.join(f"alice{WORKSPACE_USER_KEY_SEP}1", USER_DOCS_DIR_NAME))
 
 
 @pytest.mark.asyncio

--- a/tests/ai/runtime/test_workspace_prompt.py
+++ b/tests/ai/runtime/test_workspace_prompt.py
@@ -41,7 +41,7 @@ async def test_append_workspace_prompt_when_file_tools_and_conversation(monkeypa
     )
     assert "Base prompt" in result
     assert "[Session Workspace & Path Sandbox]" in result
-    assert "/tmp/workspaces/u1/conv-1" in result or "/tmp/workspaces/u1/conv_1" in result
+    assert "/tmp/workspaces/u1/sessions/conv-1" in result or "/tmp/workspaces/u1/sessions/conv_1" in result
     assert "/tmp/workspaces/u1/docs" in result
     assert "/uploads/" in result
     assert "/sandbox/" in result

--- a/tests/ai/runtime/test_workspace_prompt.py
+++ b/tests/ai/runtime/test_workspace_prompt.py
@@ -41,7 +41,8 @@ async def test_append_workspace_prompt_when_file_tools_and_conversation(monkeypa
     )
     assert "Base prompt" in result
     assert "[Session Workspace & Path Sandbox]" in result
-    assert "/tmp/workspaces/u1/conv-1" in result
+    assert "/tmp/workspaces/u1/conv-1" in result or "/tmp/workspaces/u1/conv_1" in result
+    assert "/tmp/workspaces/u1/docs" in result
     assert "/uploads/" in result
     assert "/sandbox/" in result
     assert "Grep" in result

--- a/tests/api/v1/test_fs_browser.py
+++ b/tests/api/v1/test_fs_browser.py
@@ -1,9 +1,27 @@
 import pytest
 import os
+import json
 from httpx import AsyncClient, ASGITransport
 from app.main import app
 from app.utils.fs_access import get_user_private_workspace_root, get_user_uploads_dir
 from app.utils.fs_paths import get_data_base_dir
+from app.api.v1.endpoints.fs import (
+    WORKSPACE_RECENT_REDIS_PREFIX,
+    WorkspaceRecentFileItem,
+    _sanitize_workspace_recent_files,
+)
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store: dict[str, str] = {}
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, ex=None, nx=False):
+        self.store[key] = value
+        return True
 
 @pytest.mark.asyncio
 async def test_list_root_directory(db_session, valid_api_key):
@@ -436,3 +454,172 @@ async def test_search_glob_pattern(db_session, valid_api_key):
         names = {item["name"] for item in resp.json()["data"]["items"]}
         assert "glob-test.md" in names
         assert "glob-test.md".replace(".md", ".txt") not in names
+
+
+@pytest.mark.no_infrastructure
+def test_sanitize_workspace_recent_files_filters_invalid_paths():
+    base = get_data_base_dir()
+    user_info = {"user_id": 42, "username": "alice", "is_admin": False}
+    workspace = get_user_private_workspace_root(user_info)
+    allowed_file = os.path.join(workspace, "notes.md")
+    other_file = os.path.join(base, "agent_workspaces", "bob__99", "secret.txt")
+    trash_file = os.path.join(workspace, ".trash", "old.md")
+
+    items = [
+        WorkspaceRecentFileItem(path=allowed_file, name="notes.md", mtime=100),
+        WorkspaceRecentFileItem(path=other_file, name="secret.txt", mtime=200),
+        WorkspaceRecentFileItem(path=trash_file, name="old.md", mtime=300),
+        WorkspaceRecentFileItem(path=allowed_file, name="notes.md", mtime=400),
+    ]
+    cleaned = _sanitize_workspace_recent_files(items, user_info)
+    assert len(cleaned) == 1
+    assert cleaned[0].path == os.path.normpath(allowed_file)
+    assert cleaned[0].mtime == 100
+
+
+@pytest.mark.asyncio
+async def test_workspace_recent_files_save_and_get(db_session, valid_api_key, monkeypatch):
+    fake = FakeRedis()
+
+    async def _redis():
+        return fake
+
+    monkeypatch.setattr("app.core.redis.get_redis", _redis)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        me_resp = await client.get(
+            "/api/portal/auth/me",
+            headers={"X-API-Key": valid_api_key},
+        )
+        user_info = me_resp.json()["data"]
+        workspace_root = get_user_private_workspace_root(user_info)
+        os.makedirs(workspace_root, exist_ok=True)
+        sample = os.path.join(workspace_root, "recent-demo.txt")
+        with open(sample, "w", encoding="utf-8") as handle:
+            handle.write("demo")
+
+        empty_resp = await client.get(
+            "/api/v1/chat/fs/recent-files",
+            headers={"X-API-Key": valid_api_key},
+        )
+        assert empty_resp.status_code == 200
+        assert empty_resp.json()["data"]["items"] == []
+
+        save_resp = await client.put(
+            "/api/v1/chat/fs/recent-files",
+            json={
+                "items": [
+                    {"path": sample, "name": "recent-demo.txt", "mtime": 123.5},
+                ]
+            },
+            headers={"X-API-Key": valid_api_key},
+        )
+        assert save_resp.status_code == 200
+        saved_items = save_resp.json()["data"]["items"]
+        assert len(saved_items) == 1
+        assert saved_items[0]["name"] == "recent-demo.txt"
+        assert saved_items[0]["mtime"] == 123.5
+
+        user_id = int(user_info["user_id"])
+        redis_key = f"{WORKSPACE_RECENT_REDIS_PREFIX}{user_id}"
+        assert redis_key in fake.store
+
+        get_resp = await client.get(
+            "/api/v1/chat/fs/recent-files",
+            headers={"X-API-Key": valid_api_key},
+        )
+        assert get_resp.status_code == 200
+        got_items = get_resp.json()["data"]["items"]
+        assert len(got_items) == 1
+        assert got_items[0]["path"] == os.path.normpath(sample)
+
+
+@pytest.mark.asyncio
+async def test_workspace_recent_files_user_isolation(
+    db_session, valid_api_key, admin_api_key, monkeypatch
+):
+    fake = FakeRedis()
+
+    async def _redis():
+        return fake
+
+    monkeypatch.setattr("app.core.redis.get_redis", _redis)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        user_me = await client.get(
+            "/api/portal/auth/me",
+            headers={"X-API-Key": valid_api_key},
+        )
+        admin_me = await client.get(
+            "/api/portal/auth/me",
+            headers={"X-API-Key": admin_api_key},
+        )
+        user_info = user_me.json()["data"]
+        admin_info = admin_me.json()["data"]
+        user_workspace = get_user_private_workspace_root(user_info)
+        admin_workspace = get_user_private_workspace_root(admin_info)
+        os.makedirs(user_workspace, exist_ok=True)
+        os.makedirs(admin_workspace, exist_ok=True)
+        user_file = os.path.join(user_workspace, "user-only.txt")
+        admin_file = os.path.join(admin_workspace, "admin-only.txt")
+        with open(user_file, "w", encoding="utf-8") as handle:
+            handle.write("user")
+        with open(admin_file, "w", encoding="utf-8") as handle:
+            handle.write("admin")
+
+        await client.put(
+            "/api/v1/chat/fs/recent-files",
+            json={"items": [{"path": user_file, "name": "user-only.txt", "mtime": 1}]},
+            headers={"X-API-Key": valid_api_key},
+        )
+        await client.put(
+            "/api/v1/chat/fs/recent-files",
+            json={"items": [{"path": admin_file, "name": "admin-only.txt", "mtime": 2}]},
+            headers={"X-API-Key": admin_api_key},
+        )
+
+        user_key = f"{WORKSPACE_RECENT_REDIS_PREFIX}{int(user_info['user_id'])}"
+        admin_key = f"{WORKSPACE_RECENT_REDIS_PREFIX}{int(admin_info['user_id'])}"
+        assert user_key != admin_key
+        assert json.loads(fake.store[user_key])["items"][0]["name"] == "user-only.txt"
+        assert json.loads(fake.store[admin_key])["items"][0]["name"] == "admin-only.txt"
+
+        user_recent = await client.get(
+            "/api/v1/chat/fs/recent-files",
+            headers={"X-API-Key": valid_api_key},
+        )
+        admin_recent = await client.get(
+            "/api/v1/chat/fs/recent-files",
+            headers={"X-API-Key": admin_api_key},
+        )
+        user_names = {item["name"] for item in user_recent.json()["data"]["items"]}
+        admin_names = {item["name"] for item in admin_recent.json()["data"]["items"]}
+        assert user_names == {"user-only.txt"}
+        assert admin_names == {"admin-only.txt"}
+
+
+@pytest.mark.asyncio
+async def test_workspace_recent_files_put_filters_other_user_paths(
+    db_session, valid_api_key, monkeypatch
+):
+    fake = FakeRedis()
+
+    async def _redis():
+        return fake
+
+    monkeypatch.setattr("app.core.redis.get_redis", _redis)
+
+    base = get_data_base_dir()
+    other_file = os.path.join(base, "agent_workspaces", "other_user__999", "secret.txt")
+    os.makedirs(os.path.dirname(other_file), exist_ok=True)
+    with open(other_file, "w", encoding="utf-8") as handle:
+        handle.write("secret")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.put(
+            "/api/v1/chat/fs/recent-files",
+            json={"items": [{"path": other_file, "name": "secret.txt", "mtime": 9}]},
+            headers={"X-API-Key": valid_api_key},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["data"]["items"] == []

--- a/tests/api/v1/test_fs_browser.py
+++ b/tests/api/v1/test_fs_browser.py
@@ -6,8 +6,10 @@ from app.main import app
 from app.utils.fs_access import get_user_private_workspace_root, get_user_uploads_dir
 from app.utils.fs_paths import get_data_base_dir
 from app.api.v1.endpoints.fs import (
+    WORKSPACE_BROWSER_PREFS_REDIS_PREFIX,
     WORKSPACE_RECENT_REDIS_PREFIX,
     WorkspaceRecentFileItem,
+    _sanitize_workspace_browser_prefs,
     _sanitize_workspace_recent_files,
 )
 
@@ -623,3 +625,105 @@ async def test_workspace_recent_files_put_filters_other_user_paths(
         )
         assert resp.status_code == 200
         assert resp.json()["data"]["items"] == []
+
+
+@pytest.mark.no_infrastructure
+def test_sanitize_workspace_browser_prefs_normalizes_invalid_values():
+    prefs = _sanitize_workspace_browser_prefs({
+        "include_subdirs": "yes",
+        "type_filter": "NOT_A_TYPE",
+    })
+    assert prefs.include_subdirs is True
+    assert prefs.type_filter == "all"
+
+    prefs = _sanitize_workspace_browser_prefs({
+        "include_subdirs": False,
+        "type_filter": "markdown",
+    })
+    assert prefs.include_subdirs is False
+    assert prefs.type_filter == "markdown"
+
+
+@pytest.mark.asyncio
+async def test_workspace_browser_prefs_save_and_get(db_session, valid_api_key, monkeypatch):
+    fake = FakeRedis()
+
+    async def _redis():
+        return fake
+
+    monkeypatch.setattr("app.core.redis.get_redis", _redis)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        empty_resp = await client.get(
+            "/api/v1/chat/fs/browser-prefs",
+            headers={"X-API-Key": valid_api_key},
+        )
+        assert empty_resp.status_code == 200
+        assert empty_resp.json()["data"] == {
+            "include_subdirs": True,
+            "type_filter": "all",
+        }
+
+        save_resp = await client.put(
+            "/api/v1/chat/fs/browser-prefs",
+            json={"include_subdirs": False, "type_filter": "markdown"},
+            headers={"X-API-Key": valid_api_key},
+        )
+        assert save_resp.status_code == 200
+        assert save_resp.json()["data"] == {
+            "include_subdirs": False,
+            "type_filter": "markdown",
+        }
+
+        me_resp = await client.get(
+            "/api/portal/auth/me",
+            headers={"X-API-Key": valid_api_key},
+        )
+        user_id = int(me_resp.json()["data"]["user_id"])
+        redis_key = f"{WORKSPACE_BROWSER_PREFS_REDIS_PREFIX}{user_id}"
+        assert redis_key in fake.store
+
+        get_resp = await client.get(
+            "/api/v1/chat/fs/browser-prefs",
+            headers={"X-API-Key": valid_api_key},
+        )
+        assert get_resp.status_code == 200
+        assert get_resp.json()["data"] == {
+            "include_subdirs": False,
+            "type_filter": "markdown",
+        }
+
+
+@pytest.mark.asyncio
+async def test_workspace_browser_prefs_user_isolation(
+    db_session, valid_api_key, admin_api_key, monkeypatch
+):
+    fake = FakeRedis()
+
+    async def _redis():
+        return fake
+
+    monkeypatch.setattr("app.core.redis.get_redis", _redis)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.put(
+            "/api/v1/chat/fs/browser-prefs",
+            json={"include_subdirs": False, "type_filter": "code"},
+            headers={"X-API-Key": valid_api_key},
+        )
+        await client.put(
+            "/api/v1/chat/fs/browser-prefs",
+            json={"include_subdirs": True, "type_filter": "image"},
+            headers={"X-API-Key": admin_api_key},
+        )
+
+        user_resp = await client.get(
+            "/api/v1/chat/fs/browser-prefs",
+            headers={"X-API-Key": valid_api_key},
+        )
+        admin_resp = await client.get(
+            "/api/v1/chat/fs/browser-prefs",
+            headers={"X-API-Key": admin_api_key},
+        )
+        assert user_resp.json()["data"]["type_filter"] == "code"
+        assert admin_resp.json()["data"]["type_filter"] == "image"

--- a/tests/utils/test_fs_access.py
+++ b/tests/utils/test_fs_access.py
@@ -5,12 +5,14 @@ import pytest
 from app.utils.fs_access import (
     get_allowed_fs_roots,
     get_user_docs_dir,
+    get_user_sessions_dir,
     get_user_sandbox_dir,
     get_user_uploads_dir,
     is_fs_virtual_root,
     is_path_allowed,
     is_path_writable,
     is_session_dir_name,
+    is_session_workdir_path,
     normalize_fs_path,
 )
 from app.utils.fs_paths import get_data_base_dir
@@ -167,12 +169,36 @@ def test_get_user_docs_dir(tmp_path, monkeypatch):
     assert get_user_docs_dir(user_info) == expected
 
 
+def test_get_user_sessions_dir(tmp_path, monkeypatch):
+    base = str(tmp_path / "data")
+    monkeypatch.setattr("app.utils.fs_access.get_data_base_dir", lambda: base)
+    monkeypatch.setattr("app.utils.fs_paths.get_data_base_dir", lambda: base)
+    monkeypatch.setattr(
+        "app.services.ai.runtime.agentscope.workspace.default_workspace_root",
+        lambda: os.path.join(base, "agent_workspaces"),
+    )
+    user_info = {"user_id": 1, "user_name": "alice", "role": "user"}
+    expected = os.path.normpath(os.path.join(base, "agent_workspaces", "alice__1", "sessions"))
+    assert get_user_sessions_dir(user_info) == expected
+
+
 def test_is_session_dir_name():
     assert is_session_dir_name("f50e7890-8882-4dd7-b97f-598cd324826f") is True
     assert is_session_dir_name("conv_abc") is True
     assert is_session_dir_name("docs") is False
     assert is_session_dir_name("uploads") is False
+    assert is_session_dir_name("sessions") is False
     assert is_session_dir_name("test") is False
+
+
+def test_is_session_workdir_path(tmp_path):
+    user_root = os.path.join(tmp_path, "alice__1")
+    new_session = os.path.join(user_root, "sessions", "f50e7890-8882-4dd7-b97f-598cd324826f")
+    legacy_session = os.path.join(user_root, "f50e7890-8882-4dd7-b97f-598cd324826f")
+    assert is_session_workdir_path(user_root, new_session) is True
+    assert is_session_workdir_path(user_root, legacy_session) is True
+    assert is_session_workdir_path(user_root, os.path.join(user_root, "docs")) is False
+    assert is_session_workdir_path(user_root, os.path.join(user_root, "sessions", "test")) is False
 
 
 def test_get_user_sandbox_dir(tmp_path, monkeypatch):

--- a/tests/utils/test_fs_access.py
+++ b/tests/utils/test_fs_access.py
@@ -4,11 +4,13 @@ import pytest
 
 from app.utils.fs_access import (
     get_allowed_fs_roots,
+    get_user_docs_dir,
     get_user_sandbox_dir,
     get_user_uploads_dir,
     is_fs_virtual_root,
     is_path_allowed,
     is_path_writable,
+    is_session_dir_name,
     normalize_fs_path,
 )
 from app.utils.fs_paths import get_data_base_dir
@@ -150,6 +152,27 @@ def test_get_user_uploads_dir(tmp_path, monkeypatch):
     user_info = {"user_id": 1, "user_name": "alice", "role": "user"}
     expected = os.path.normpath(os.path.join(base, "agent_workspaces", "alice__1", "uploads"))
     assert get_user_uploads_dir(user_info) == expected
+
+
+def test_get_user_docs_dir(tmp_path, monkeypatch):
+    base = str(tmp_path / "data")
+    monkeypatch.setattr("app.utils.fs_access.get_data_base_dir", lambda: base)
+    monkeypatch.setattr("app.utils.fs_paths.get_data_base_dir", lambda: base)
+    monkeypatch.setattr(
+        "app.services.ai.runtime.agentscope.workspace.default_workspace_root",
+        lambda: os.path.join(base, "agent_workspaces"),
+    )
+    user_info = {"user_id": 1, "user_name": "alice", "role": "user"}
+    expected = os.path.normpath(os.path.join(base, "agent_workspaces", "alice__1", "docs"))
+    assert get_user_docs_dir(user_info) == expected
+
+
+def test_is_session_dir_name():
+    assert is_session_dir_name("f50e7890-8882-4dd7-b97f-598cd324826f") is True
+    assert is_session_dir_name("conv_abc") is True
+    assert is_session_dir_name("docs") is False
+    assert is_session_dir_name("uploads") is False
+    assert is_session_dir_name("test") is False
 
 
 def test_get_user_sandbox_dir(tmp_path, monkeypatch):


### PR DESCRIPTION

## 概要 (Overview)

本 PR 在 `a235854`（最近文件 Redis 化）基础上，继续完善工作空间浏览与 AgentScope 目录体系：

1. **浏览偏好**从 `localStorage` 迁移到 Redis，按用户隔离
2. **会话目录与文档目录分工**：会话临时文件走 `sessions/{conversationId}/`，用户交付文档默认落盘 `docs/`
3. **工作空间抽屉 UI 增强**：多选浮标、快捷导航滚动提示、会话目录标识、双击预览切换等
4. **修复**图片画布预览 `blob:` URL 破图、多选模式表格列错位

涉及 16 个文件，+911 / -120 行。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)

- [x] **浏览偏好 Redis 化**：`includeSubdirs`、`typeFilter` 从 `localStorage` 迁至 Redis（`agent:workspace_browser_prefs:{user_id}`），新增 `GET/PUT /api/v1/chat/fs/browser-prefs`，支持旧 `localStorage` 数据一次性迁移
- [x] **会话目录 / 文档目录分工**：
  - 会话工作目录：`agent_workspaces/{user}/sessions/{conversationId}/`（AgentScope LocalWorkspace，工具相对路径默认相对此目录）
  - 文档目录：`agent_workspaces/{user}/docs/`（跨会话，Word/Excel 等默认输出、Write 未指定路径时由提示词引导）
- [x] **旧路径兼容**：保留 `agent_workspaces/{user}/{conversationId}/` 平铺路径的读取与浏览能力（`resolve_legacy_session_workdir`）
- [x] **工作空间多选浮标**：右下角 FAB 切换多选，选中后显示「批量添加 (n)」
- [x] **画布预览双击切换**：同一文件再次双击关闭左侧画布预览
- [x] **Redis 管理页**：`redisKeyGroups.ts` 补充 `workspace_browser_prefs` 分组

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)

- [x] **快捷导航重排**：我的目录 → 我的文档 → 本会话目录 → uploads → 最近文件 → 回收站
- [x] **快捷导航横向滚动提示**：左右渐变 + 箭头按钮，`ResizeObserver` 自适应
- [x] **会话目录视觉标识**：`sessions` 容器及 UUID 子目录显示 💬 + 天蓝「会话目录」标签；`sessions` 文件夹显示名改为「会话目录」
- [x] **多选模式列对齐**：表头与数据行同步增减复选框列宽，修复大小/修改时间错位

### 3. 🐞 关键修复 (Bug Fixes)

- [x] **图片画布预览破图**：`ChatCanvas` 将 axios 生成的 `blob:` URL 误转 preview API；新增 `isDirectRenderableUrl()` 识别可直接渲染地址
- [x] **多选模式表格错位**：12 列网格溢出导致大小/时间列换行，已修复
- [x] **Vue 编译错误**：表头按钮重复 `:class` 属性导致 build 失败，已合并为数组绑定

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `c6d0ccf` | feat: 工作空间浏览偏好改为 Redis 按用户隔离存储 |
| `3a56de2` | fix: 修复工作空间图片画布预览 blob URL 被误转换导致破图 |
| `e32ae68` | feat: 区分会话目录与 docs 文档目录，并增强工作空间浏览体验 |
| `d5ad75c` | feat: 会话目录迁入 sessions 子目录并优化工作空间标识 |

---

## 测试覆盖 (Testing)

- [ ] **UI 兼容性**: 已验证不同浏览器下的展示效果。
- [x] **核心功能**:
  - `tests/api/v1/test_fs_browser.py` — 浏览偏好 / 最近文件 Redis API、用户隔离、路径过滤
  - `tests/ai/runtime/test_agentscope_workspace.py` — 会话目录 `sessions/{id}` 路径解析
  - `tests/ai/runtime/test_workspace_prompt.py` — 系统提示词注入路径
  - `tests/utils/test_fs_access.py` — `get_user_sessions_dir`、`is_session_workdir_path`
  - `frontend/scripts/workspaceFilePreview.test.ts` — `blob:` URL、`isSameWorkspacePreviewPath`
- [ ] **回归测试**: 确认未引入已知回归错误。

> [!IMPORTANT]
> 提交前请务必确认已更新 `tests/CHECKLIST.md` 中的自动化测试清单。

---

## 其他备注 (Notes)

### 目录结构（变更后）

```
agent_workspaces/{username__userId}/
├── docs/              # 用户交付文档（跨会话）
├── uploads/           # 聊天上传附件
├── sandbox/           # SQLite 临时库
├── sessions/          # 会话目录容器
│   └── {conversationId}/
├── .trash/            # 回收站
└── {旧UUID}/          # 历史平铺会话目录（只读兼容，不自动迁移）
```