### PR TITLE
Pull Request: feat: 优化智能体工具促发策略与品牌个性化助手名称自定义

### DIFF
--- a/app/api/portal/endpoints/system.py
+++ b/app/api/portal/endpoints/system.py
@@ -672,6 +672,7 @@ async def update_branding_settings(
         hide_version_link=body.hide_version_link,
         contact_markdown=body.contact_markdown,
         copyright_text=body.copyright_text,
+        default_agent_name=body.default_agent_name,
         changed_by=user.get("user_name", "admin"),
     )
     return await BrandingSettingsService.get_raw_settings()

--- a/app/schemas/branding.py
+++ b/app/schemas/branding.py
@@ -4,6 +4,7 @@ from app.services.branding_settings_service import (
     DEFAULT_ICON_URL,
     DEFAULT_LOGIN_SUBTITLE,
     DEFAULT_PRODUCT_NAME,
+    DEFAULT_AGENT_NAME,
 )
 
 
@@ -16,6 +17,7 @@ class BrandingSettings(BaseModel):
     hide_version_link: bool = False
     contact_markdown: str = ""
     copyright_text: str = ""
+    default_agent_name: str = DEFAULT_AGENT_NAME
 
 
 class BrandingSettingsUpdate(BrandingSettings):
@@ -31,3 +33,4 @@ class PublicBrandingResponse(BaseModel):
     hide_version_link: bool = False
     contact_markdown: str = ""
     copyright_text: str = ""
+    default_agent_name: str

--- a/app/services/ai/intent_service.py
+++ b/app/services/ai/intent_service.py
@@ -167,13 +167,6 @@ _DATA_QUERY_STRONG_SIGNALS = [
 ]
 
 
-def looks_like_business_data_request(user_question: str) -> bool:
-    """轻量启发式：用户是否在请求结构化业务数据（供通用助手反幻觉门控兜底）。"""
-    q = (user_question or "").strip().lower()
-    if not q:
-        return False
-    return any(sig in q for sig in _DATA_QUERY_SIGNALS)
-
 
 def looks_like_strong_business_data_request(user_question: str) -> bool:
     """低置信度兜底用：只有明确业务数据对象/指标/记录信号才算强查数。"""
@@ -527,13 +520,13 @@ def resolve_intent_source(
     semantic_confidence: Any = None,
     turn_intent: Any = None,
 ) -> IntentSourceFrame:
-    """Resolve the request source before routing to a specialized agent/tool.
+    """在将请求路由至专属智能体/工具前，仲裁本轮请求的来源类型。
 
-    A semantic DATA_QUERY label is useful evidence, but public profile lookups
-    must be carved out first: generic requests such as "查一下 X 公司信息" may
-    look like "querying data" while their source is actually public search.
-    Strong record/metric/list signals and data-result follow-ups are accepted
-    immediately; otherwise high-confidence DATA_QUERY evidence is still allowed.
+    语义模型输出的 DATA_QUERY 标签只是证据，不能直接等同于"来自内部业务库"：
+    - "查一下 X 公司信息"等公开主体查询可能被误判为 DATA_QUERY，但来源实为公网搜索，
+      需要通过 looks_like_public_profile_lookup 提前拦截；
+    - 强业务数据词（列表/记录/统计/明细等）或数据追问信号则直接采信为内部结构化数据；
+    - 其余情况在语义置信度 >= 0.65 时才接受 DATA_QUERY 判定，不足时回落为 UNKNOWN。
     """
     query = (query or "").strip()
     if looks_like_web_search_query(query):

--- a/app/services/ai/intent_service.py
+++ b/app/services/ai/intent_service.py
@@ -1,5 +1,6 @@
 import json
 import re
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional, List, Dict
 from pydantic import BaseModel, Field
@@ -162,6 +163,7 @@ _DATA_QUERY_STRONG_SIGNALS = [
     "统计", "多少", "列表", "记录", "趋势", "top", "明细", "汇总", "对比",
     "数量", "报表", "指标", "数据集", "数据库", "sql", "工单", "告警记录",
     "故障记录", "操作日志", "设备清单", "资产列表",
+    "count", "list", "record", "records", "table", "metric", "metrics", "report",
 ]
 
 
@@ -179,6 +181,27 @@ def looks_like_strong_business_data_request(user_question: str) -> bool:
     if not q:
         return False
     return any(sig in q for sig in _DATA_QUERY_STRONG_SIGNALS)
+
+
+def looks_like_public_profile_lookup(user_question: str) -> bool:
+    """用户在查公开主体资料，而不是内部业务库记录。
+
+    这类问题常见形态是“查一下 X 公司信息 / 了解某品牌资料”。它们可能没有
+    “联网/新闻/官网”等显式公网词，但语义来源仍更接近公开搜索，不应仅因
+    “查一下”或意图模型误判而进入 data_query。
+    """
+    q = (user_question or "").strip().lower()
+    if not q:
+        return False
+    if looks_like_strong_business_data_request(q):
+        return False
+    lookup_verbs = (*_DATA_QUERY_GENERIC_VERBS, "了解", "搜一下", "搜索", "search")
+    profile_subjects = ("公司", "企业", "机构", "品牌", "人物", "company", "brand")
+    profile_fields = ("信息", "资料", "简介", "介绍", "背景", "官网", "新闻", "动态", "profile", "info")
+    has_lookup = any(term in q for term in lookup_verbs)
+    if not has_lookup:
+        return False
+    return any(subject in q for subject in profile_subjects) and any(field in q for field in profile_fields)
 
 
 def looks_like_short_field_or_continuation_followup(user_question: str) -> bool:
@@ -469,6 +492,117 @@ class IntentResponse(BaseModel):
     confidence: float = Field(description="Confidence score from 0.0 to 1.0")
     reasoning: str = Field(description="Brief explanation of why this intent was chosen")
     entities: List[str] = Field(default_factory=list, description="Extracted key entities (e.g., room name, metric)")
+
+
+class IntentSource(str, Enum):
+    INTERNAL_STRUCTURED_DATA = "internal_structured_data"
+    PUBLIC_WEB = "public_web"
+    INTERNAL_DOCS = "internal_docs"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class IntentSourceFrame:
+    source: IntentSource
+    confidence: float
+    reasoning: str
+
+
+def _intent_name(value: Any) -> str:
+    raw = getattr(value, "value", value)
+    return str(raw or "").strip().upper()
+
+
+def _coerce_confidence(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def resolve_intent_source(
+    query: str,
+    *,
+    semantic_intent: Any = None,
+    semantic_confidence: Any = None,
+    turn_intent: Any = None,
+) -> IntentSourceFrame:
+    """Resolve the request source before routing to a specialized agent/tool.
+
+    A semantic DATA_QUERY label is useful evidence, but public profile lookups
+    must be carved out first: generic requests such as "查一下 X 公司信息" may
+    look like "querying data" while their source is actually public search.
+    Strong record/metric/list signals and data-result follow-ups are accepted
+    immediately; otherwise high-confidence DATA_QUERY evidence is still allowed.
+    """
+    query = (query or "").strip()
+    if looks_like_web_search_query(query):
+        return IntentSourceFrame(
+            source=IntentSource.PUBLIC_WEB,
+            confidence=0.95,
+            reasoning="explicit public web/search signal",
+        )
+
+    if looks_like_knowledge_query(query):
+        return IntentSourceFrame(
+            source=IntentSource.INTERNAL_DOCS,
+            confidence=0.85,
+            reasoning="internal documentation or SOP signal",
+        )
+
+    if looks_like_public_profile_lookup(query):
+        return IntentSourceFrame(
+            source=IntentSource.UNKNOWN,
+            confidence=0.8,
+            reasoning="public profile lookup without structured-data signal",
+        )
+
+    has_structured_signal = looks_like_strong_business_data_request(query)
+    has_data_followup_signal = (
+        looks_like_data_followup(query)
+        or looks_like_pure_result_followup(query)
+        or looks_like_short_field_or_continuation_followup(query)
+    )
+    if has_structured_signal or has_data_followup_signal:
+        return IntentSourceFrame(
+            source=IntentSource.INTERNAL_STRUCTURED_DATA,
+            confidence=0.9 if has_data_followup_signal else 0.72,
+            reasoning=(
+                "data-result follow-up signal"
+                if has_data_followup_signal
+                else "strong internal structured data signal"
+            ),
+        )
+
+    semantic_name = _intent_name(semantic_intent)
+    semantic_score = _coerce_confidence(semantic_confidence)
+    if semantic_name == IntentType.DATA_QUERY.value and semantic_score >= 0.65:
+        return IntentSourceFrame(
+            source=IntentSource.INTERNAL_STRUCTURED_DATA,
+            confidence=semantic_score,
+            reasoning="router semantic intent is DATA_QUERY",
+        )
+
+    turn_name = _intent_name(turn_intent)
+    if turn_name == IntentType.DATA_QUERY.value:
+        return IntentSourceFrame(
+            source=IntentSource.INTERNAL_STRUCTURED_DATA,
+            confidence=0.9,
+            reasoning="turn classification intent is DATA_QUERY",
+        )
+
+    if semantic_name in {IntentType.GENERAL.value, IntentType.KNOWLEDGE_BASE.value, IntentType.UNKNOWN.value}:
+        return IntentSourceFrame(
+            source=IntentSource.UNKNOWN,
+            confidence=semantic_score,
+            reasoning=f"router semantic intent is {semantic_name}",
+        )
+
+    return IntentSourceFrame(
+        source=IntentSource.UNKNOWN,
+        confidence=0.0,
+        reasoning="no reliable source signal",
+    )
 
 class IntentService:
     """

--- a/app/services/ai/router_service.py
+++ b/app/services/ai/router_service.py
@@ -2,7 +2,14 @@ from typing import List, Optional
 import json
 import logging
 from app.core.llm.client import get_llm_async
-from app.services.ai.intent_service import IntentResponse, IntentType, intent_service
+from app.services.ai.intent_service import (
+    IntentResponse,
+    IntentSource,
+    IntentSourceFrame,
+    IntentType,
+    intent_service,
+    resolve_intent_source,
+)
 from app.services.ai.runtime.agentscope.chat import chat_client_from_handle
 from app.services.ai.runtime.agentscope.messages import RuntimeContentBlock, RuntimeMessage
 from app.services.ai.turn_classifier import AMBIGUOUS_INTENT_CONFIDENCE_THRESHOLD
@@ -249,7 +256,25 @@ class RouterService:
                 )
 
         intent_info = await self._resolve_intent_evidence(user_input, history)
-        routing_agents = self._constrain_candidates_by_intent(agents_metadata, intent_info)
+        source_frame = resolve_intent_source(
+            user_input,
+            semantic_intent=getattr(intent_info, "intent", None),
+            semantic_confidence=getattr(intent_info, "confidence", None),
+        )
+        data_route_allowed = (
+            source_frame.source == IntentSource.INTERNAL_STRUCTURED_DATA
+            or (
+                last_agent_name
+                and self._is_data_query_agent(agents_metadata, last_agent_name)
+                and should_inherit_data_agent_session(user_input)
+            )
+        )
+        routing_agents = self._constrain_candidates_by_intent(
+            agents_metadata,
+            intent_info,
+            source_frame=source_frame,
+            data_route_allowed=bool(data_route_allowed),
+        )
 
         # 2. Unified LLM Routing
         # 路由提示词内置在代码中（DEFAULT_SYSTEM_PROMPT），不再从数据库配置读取，
@@ -298,7 +323,10 @@ class RouterService:
                     result_json,
                     routing_agents,
                     enable_multi_agent,
+                    fallback_agents_metadata=agents_metadata,
                     intent_info=intent_info,
+                    source_frame=source_frame,
+                    data_route_allowed=bool(data_route_allowed),
                 )
                 if route_result is not None:
                     return route_result
@@ -330,17 +358,37 @@ class RouterService:
             logger.warning("Semantic evidence failed before routing: %s", exc)
             return None
 
+    def _should_constrain_to_data_agents(
+        self,
+        intent_info: Optional[IntentResponse],
+        source_frame: Optional[IntentSourceFrame],
+        data_route_allowed: bool,
+    ) -> bool:
+        """是否满足将候选收缩到数据查询智能体的全部条件。
+
+        须同时满足：
+        1. 语义意图为 DATA_QUERY 且置信度超过模糊阈值（排除低置信误判）；
+        2. 意图来源确认为内部结构化数据（排除公网查询 / 公司信息等误判）；
+        3. 路由层允许进入数据查询路径（排除会话粘性以外的追问被强制推进）。
+        """
+        if not intent_info or intent_info.intent != IntentType.DATA_QUERY:
+            return False
+        if intent_info.confidence < AMBIGUOUS_INTENT_CONFIDENCE_THRESHOLD:
+            return False
+        if source_frame is None or source_frame.source != IntentSource.INTERNAL_STRUCTURED_DATA:
+            return False
+        return data_route_allowed
+
     def _constrain_candidates_by_intent(
         self,
         agents: List[dict],
         intent_info: Optional[IntentResponse],
+        *,
+        source_frame: Optional[IntentSourceFrame] = None,
+        data_route_allowed: bool = False,
     ) -> List[dict]:
-        """Use high-confidence semantic evidence as a capability constraint, not a domain keyword rule."""
-        if (
-            not intent_info
-            or intent_info.intent != IntentType.DATA_QUERY
-            or intent_info.confidence < AMBIGUOUS_INTENT_CONFIDENCE_THRESHOLD
-        ):
+        """Constrain to data agents only when the request source is truly data."""
+        if not self._should_constrain_to_data_agents(intent_info, source_frame, data_route_allowed):
             return agents
 
         data_agents = [
@@ -492,7 +540,10 @@ class RouterService:
         agents_metadata: List[dict],
         enable_multi_agent: bool,
         *,
+        fallback_agents_metadata: Optional[List[dict]] = None,
         intent_info: Optional[IntentResponse] = None,
+        source_frame: Optional[IntentSourceFrame] = None,
+        data_route_allowed: bool = True,
     ) -> Optional[RouteResult]:
         confidence = result_json.get("confidence", 0.5)
         target_name = result_json.get("agent_name")
@@ -523,9 +574,30 @@ class RouterService:
         if not target_agent:
             logger.warning(f"Router suggested unknown agent: {target_name}. Falling back to General Chat.")
             return self._fallback_to_general(
-                agents_metadata,
+                fallback_agents_metadata or agents_metadata,
                 f"Router returned unknown agent: {target_name}",
                 intent_info=intent_info,
+            )
+
+        if self._is_data_query_agent(agents_metadata, target_agent.get("name")) and not data_route_allowed:
+            source_reason = getattr(source_frame, "reasoning", "unknown source")
+            fallback_agents = fallback_agents_metadata or agents_metadata
+            if self._find_fallback_agent(fallback_agents):
+                logger.info(
+                    "Router selected data agent %s without internal structured-data source (%s); falling back to Main.",
+                    target_agent.get("name"),
+                    source_reason,
+                )
+                return self._fallback_to_general(
+                    fallback_agents,
+                    f"Router selected data agent without internal structured-data source: {source_reason}",
+                    intent_info=intent_info,
+                )
+            logger.info(
+                "Router selected data agent %s without internal structured-data source (%s), "
+                "but no fallback Main agent is available; keeping router result.",
+                target_agent.get("name"),
+                source_reason,
             )
 
         resolved_secondaries: List[str] = []

--- a/app/services/ai/runners/assistant_agent_runner.py
+++ b/app/services/ai/runners/assistant_agent_runner.py
@@ -628,6 +628,12 @@ class AssistantAgentRunner(BaseExecutor):
                         tools,
                         available_sub_agent_names=available_sub_agent_names,
                         sub_agent_targets_by_capability=sub_agent_targets_by_capability,
+                        semantic_intent=self.route_hints.get("semantic_intent"),
+                        semantic_confidence=self.route_hints.get("semantic_confidence"),
+                        turn_intent=(
+                            getattr(self.turn_classification, "intent", None)
+                            or getattr(self.intent_info, "intent", None)
+                        ),
                     )
                     if tool_nudge is not None:
                         native_system_content = f"{tool_nudge.message}\n\n{native_system_content}"

--- a/app/services/ai/tool_nudge_policy.py
+++ b/app/services/ai/tool_nudge_policy.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, List, Mapping, Optional, Set
 
 # 不主动促发的工具（写入/管理/记忆维护类）：避免推动模型产生副作用或与专门机制重复。
@@ -96,6 +97,20 @@ def should_consider_tool_nudge(user_query: str) -> bool:
 STRONG_FORCE_SCORE = 0.5
 
 
+class ToolIntentSource(str, Enum):
+    INTERNAL_STRUCTURED_DATA = "internal_structured_data"
+    PUBLIC_WEB = "public_web"
+    INTERNAL_DOCS = "internal_docs"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ToolIntentFrame:
+    source: ToolIntentSource
+    confidence: float
+    reasoning: str
+
+
 @dataclass(frozen=True)
 class ToolNudge:
     tool_name: str
@@ -160,6 +175,84 @@ def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
     return any(term and term in text for term in terms)
 
 
+def _intent_name(value: Any) -> str:
+    raw = getattr(value, "value", value)
+    return str(raw or "").strip().upper()
+
+
+def _coerce_confidence(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def resolve_tool_intent_source(
+    query: str,
+    *,
+    semantic_intent: Any = None,
+    semantic_confidence: Any = None,
+    turn_intent: Any = None,
+) -> ToolIntentFrame:
+    """Resolve the request source before any specific tool/sub-agent is nudged."""
+    from app.services.ai.intent_service import (
+        looks_like_knowledge_query,
+        looks_like_strong_business_data_request,
+        looks_like_web_search_query,
+    )
+
+    if looks_like_web_search_query(query):
+        return ToolIntentFrame(
+            source=ToolIntentSource.PUBLIC_WEB,
+            confidence=0.95,
+            reasoning="explicit public web/search signal",
+        )
+
+    if looks_like_knowledge_query(query):
+        return ToolIntentFrame(
+            source=ToolIntentSource.INTERNAL_DOCS,
+            confidence=0.85,
+            reasoning="internal documentation or SOP signal",
+        )
+
+    semantic_name = _intent_name(semantic_intent)
+    semantic_score = _coerce_confidence(semantic_confidence)
+    if semantic_name == "DATA_QUERY" and semantic_score >= 0.65:
+        return ToolIntentFrame(
+            source=ToolIntentSource.INTERNAL_STRUCTURED_DATA,
+            confidence=semantic_score,
+            reasoning="router semantic intent is DATA_QUERY",
+        )
+
+    turn_name = _intent_name(turn_intent)
+    if turn_name == "DATA_QUERY":
+        return ToolIntentFrame(
+            source=ToolIntentSource.INTERNAL_STRUCTURED_DATA,
+            confidence=0.9,
+            reasoning="turn classification intent is DATA_QUERY",
+        )
+
+    if semantic_name in {"GENERAL", "KNOWLEDGE_BASE", "UNKNOWN"}:
+        return ToolIntentFrame(
+            source=ToolIntentSource.UNKNOWN,
+            confidence=semantic_score,
+            reasoning=f"router semantic intent is {semantic_name}",
+        )
+
+    if looks_like_strong_business_data_request(query):
+        return ToolIntentFrame(
+            source=ToolIntentSource.INTERNAL_STRUCTURED_DATA,
+            confidence=0.72,
+            reasoning="strong internal structured data signal",
+        )
+
+    return ToolIntentFrame(
+        source=ToolIntentSource.UNKNOWN,
+        confidence=0.0,
+        reasoning="no reliable source signal",
+    )
+
+
 def _resolve_notification_nudge(query: str, tools: List[Any]) -> Optional[ToolNudge]:
     normalized_query = query.lower()
     if not _contains_any(normalized_query, _NOTIFICATION_ACTION_TERMS):
@@ -191,10 +284,13 @@ def resolve_tool_nudge(
     user_query: str,
     tools: List[Any],
     *,
-    min_score: float = 0.34,
+    min_score: float = 0.25,
     exclude_tools: Optional[Set[str]] = None,
     available_sub_agent_names: Optional[Set[str]] = None,
     sub_agent_targets_by_capability: Optional[Mapping[str, str]] = None,
+    semantic_intent: Any = None,
+    semantic_confidence: Any = None,
+    turn_intent: Any = None,
 ) -> Optional[ToolNudge]:
     """解析本轮是否需要工具促发；返回相关度最高的一条便签或 None。
 
@@ -204,14 +300,16 @@ def resolve_tool_nudge(
     query = (user_query or "").strip()
     if not query or not should_consider_tool_nudge(query):
         return None
+    intent_frame = resolve_tool_intent_source(
+        query,
+        semantic_intent=semantic_intent,
+        semantic_confidence=semantic_confidence,
+        turn_intent=turn_intent,
+    )
 
     # 特殊规则：对于强查数或强知识库检索意图，若绑定了 sub_agent_call，优先做静默子代理委派
     sub_agent_tool = next((t for t in (tools or []) if getattr(t, "name", "") == "sub_agent_call"), None)
     if sub_agent_tool:
-        from app.services.ai.intent_service import (
-            looks_like_business_data_request,
-            looks_like_knowledge_query,
-        )
         def _sub_agent_available(name: str) -> bool:
             if available_sub_agent_names is None:
                 return True
@@ -227,7 +325,7 @@ def resolve_tool_nudge(
             return fallback_name if _sub_agent_available(fallback_name) else None
 
         # 优先判断更具体的知识库检索意图
-        if looks_like_knowledge_query(query):
+        if intent_frame.source == ToolIntentSource.INTERNAL_DOCS:
             target_agent_name = _target_for_capability("knowledge_base", "knowledge-base")
             if not target_agent_name:
                 return None
@@ -242,7 +340,7 @@ def resolve_tool_nudge(
                 message=f"【本轮工具优先】本轮用户请求涉及制度、SOP或规范文档检索。{desc}",
                 force_first_call=True,
             )
-        elif looks_like_business_data_request(query):
+        elif intent_frame.source == ToolIntentSource.INTERNAL_STRUCTURED_DATA:
             target_agent_name = _target_for_capability("data_query", "chat-bi")
             if not target_agent_name:
                 return None
@@ -281,7 +379,8 @@ def resolve_tool_nudge(
             best_score = score
             best_tool = tool
 
-    if best_tool is None or best_score < min_score:
+    effective_min_score = 0.2 if intent_frame.source == ToolIntentSource.PUBLIC_WEB else min_score
+    if best_tool is None or best_score < effective_min_score:
         return None
 
     tool_name = str(getattr(best_tool, "name", "") or "")

--- a/app/services/ai/tool_nudge_policy.py
+++ b/app/services/ai/tool_nudge_policy.py
@@ -15,8 +15,13 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any, List, Mapping, Optional, Set
+
+from app.services.ai.intent_service import (
+    IntentSource as ToolIntentSource,
+    IntentSourceFrame as ToolIntentFrame,
+    resolve_intent_source,
+)
 
 # 不主动促发的工具（写入/管理/记忆维护类）：避免推动模型产生副作用或与专门机制重复。
 _NUDGE_EXCLUDED_TOOLS = frozenset({
@@ -97,20 +102,6 @@ def should_consider_tool_nudge(user_query: str) -> bool:
 STRONG_FORCE_SCORE = 0.5
 
 
-class ToolIntentSource(str, Enum):
-    INTERNAL_STRUCTURED_DATA = "internal_structured_data"
-    PUBLIC_WEB = "public_web"
-    INTERNAL_DOCS = "internal_docs"
-    UNKNOWN = "unknown"
-
-
-@dataclass(frozen=True)
-class ToolIntentFrame:
-    source: ToolIntentSource
-    confidence: float
-    reasoning: str
-
-
 @dataclass(frozen=True)
 class ToolNudge:
     tool_name: str
@@ -175,84 +166,6 @@ def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
     return any(term and term in text for term in terms)
 
 
-def _intent_name(value: Any) -> str:
-    raw = getattr(value, "value", value)
-    return str(raw or "").strip().upper()
-
-
-def _coerce_confidence(value: Any) -> float:
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def resolve_tool_intent_source(
-    query: str,
-    *,
-    semantic_intent: Any = None,
-    semantic_confidence: Any = None,
-    turn_intent: Any = None,
-) -> ToolIntentFrame:
-    """Resolve the request source before any specific tool/sub-agent is nudged."""
-    from app.services.ai.intent_service import (
-        looks_like_knowledge_query,
-        looks_like_strong_business_data_request,
-        looks_like_web_search_query,
-    )
-
-    if looks_like_web_search_query(query):
-        return ToolIntentFrame(
-            source=ToolIntentSource.PUBLIC_WEB,
-            confidence=0.95,
-            reasoning="explicit public web/search signal",
-        )
-
-    if looks_like_knowledge_query(query):
-        return ToolIntentFrame(
-            source=ToolIntentSource.INTERNAL_DOCS,
-            confidence=0.85,
-            reasoning="internal documentation or SOP signal",
-        )
-
-    semantic_name = _intent_name(semantic_intent)
-    semantic_score = _coerce_confidence(semantic_confidence)
-    if semantic_name == "DATA_QUERY" and semantic_score >= 0.65:
-        return ToolIntentFrame(
-            source=ToolIntentSource.INTERNAL_STRUCTURED_DATA,
-            confidence=semantic_score,
-            reasoning="router semantic intent is DATA_QUERY",
-        )
-
-    turn_name = _intent_name(turn_intent)
-    if turn_name == "DATA_QUERY":
-        return ToolIntentFrame(
-            source=ToolIntentSource.INTERNAL_STRUCTURED_DATA,
-            confidence=0.9,
-            reasoning="turn classification intent is DATA_QUERY",
-        )
-
-    if semantic_name in {"GENERAL", "KNOWLEDGE_BASE", "UNKNOWN"}:
-        return ToolIntentFrame(
-            source=ToolIntentSource.UNKNOWN,
-            confidence=semantic_score,
-            reasoning=f"router semantic intent is {semantic_name}",
-        )
-
-    if looks_like_strong_business_data_request(query):
-        return ToolIntentFrame(
-            source=ToolIntentSource.INTERNAL_STRUCTURED_DATA,
-            confidence=0.72,
-            reasoning="strong internal structured data signal",
-        )
-
-    return ToolIntentFrame(
-        source=ToolIntentSource.UNKNOWN,
-        confidence=0.0,
-        reasoning="no reliable source signal",
-    )
-
-
 def _resolve_notification_nudge(query: str, tools: List[Any]) -> Optional[ToolNudge]:
     normalized_query = query.lower()
     if not _contains_any(normalized_query, _NOTIFICATION_ACTION_TERMS):
@@ -300,7 +213,7 @@ def resolve_tool_nudge(
     query = (user_query or "").strip()
     if not query or not should_consider_tool_nudge(query):
         return None
-    intent_frame = resolve_tool_intent_source(
+    intent_frame = resolve_intent_source(
         query,
         semantic_intent=semantic_intent,
         semantic_confidence=semantic_confidence,

--- a/app/services/branding_settings_service.py
+++ b/app/services/branding_settings_service.py
@@ -5,6 +5,7 @@ from app.services.config_service import ConfigService
 DEFAULT_PRODUCT_NAME = "云枢 · 智能体平台"
 DEFAULT_LOGIN_SUBTITLE = "Yunshu Intelligent Agent Platform"
 DEFAULT_ICON_URL = "/favicon.png"
+DEFAULT_AGENT_NAME = "云枢智能助手"
 
 
 class BrandingSettingsService:
@@ -16,6 +17,7 @@ class BrandingSettingsService:
     CONFIG_HIDE_VERSION_LINK = "branding.hide_version_link"
     CONFIG_CONTACT_MARKDOWN = "branding.contact_markdown"
     CONFIG_COPYRIGHT_TEXT = "branding.copyright_text"
+    CONFIG_DEFAULT_AGENT_NAME = "branding.default_agent_name"
 
     @staticmethod
     async def _get_bool(key: str, default: bool = False) -> bool:
@@ -38,6 +40,8 @@ class BrandingSettingsService:
             "hide_version_link": await cls._get_bool(cls.CONFIG_HIDE_VERSION_LINK, False),
             "contact_markdown": (await ConfigService.get(cls.CONFIG_CONTACT_MARKDOWN, "")) or "",
             "copyright_text": (await ConfigService.get(cls.CONFIG_COPYRIGHT_TEXT, "")) or "",
+            "default_agent_name": (await ConfigService.get(cls.CONFIG_DEFAULT_AGENT_NAME, DEFAULT_AGENT_NAME) or "").strip()
+            or DEFAULT_AGENT_NAME,
         }
 
     @classmethod
@@ -54,6 +58,7 @@ class BrandingSettingsService:
                 "hide_version_link": False,
                 "contact_markdown": "",
                 "copyright_text": "",
+                "default_agent_name": DEFAULT_AGENT_NAME,
             }
         return {
             "enabled": True,
@@ -64,6 +69,7 @@ class BrandingSettingsService:
             "hide_version_link": raw["hide_version_link"],
             "contact_markdown": raw["contact_markdown"],
             "copyright_text": raw["copyright_text"],
+            "default_agent_name": raw["default_agent_name"],
         }
 
     @classmethod
@@ -78,6 +84,7 @@ class BrandingSettingsService:
         hide_version_link: bool,
         contact_markdown: str,
         copyright_text: str,
+        default_agent_name: str,
         changed_by: str = "system",
     ) -> None:
         await ConfigService.set_config(
@@ -133,6 +140,13 @@ class BrandingSettingsService:
             cls.CONFIG_COPYRIGHT_TEXT,
             copyright_text or "",
             description="登录页底部版权文案",
+            category="branding",
+            changed_by=changed_by,
+        )
+        await ConfigService.set_config(
+            cls.CONFIG_DEFAULT_AGENT_NAME,
+            (default_agent_name or DEFAULT_AGENT_NAME).strip(),
+            description="默认智能助手名称",
             category="branding",
             changed_by=changed_by,
         )

--- a/frontend/src/components/embed/WelcomeDashboard.vue
+++ b/frontend/src/components/embed/WelcomeDashboard.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useBranding } from '@/composables/useBranding';
+
+const { branding } = useBranding();
 
 const props = defineProps<{
   welcomeMessage: string;
@@ -82,7 +85,7 @@ const recommendedPrompts = computed(() => {
         {{ greeting }}！
       </h1>
       <p class="text-gray-500 dark:text-gray-400 text-sm max-w-md mx-auto leading-relaxed">
-        {{ welcomeMessage || '我是您的云枢智能助手，准备好帮您处理任何任务了。' }}
+        {{ welcomeMessage || ('我是您的' + (branding.default_agent_name || '云枢智能助手') + '，准备好帮您处理任何任务了。') }}
       </p>
     </div>
 

--- a/frontend/src/constants/branding.ts
+++ b/frontend/src/constants/branding.ts
@@ -2,6 +2,7 @@ export const DEFAULT_PRODUCT_NAME = '云枢 · 智能体平台'
 export const DEFAULT_LOGIN_SUBTITLE = 'Yunshu Intelligent Agent Platform'
 export const DEFAULT_ICON_URL = '/favicon.png'
 export const DEFAULT_REPO_URL = 'https://github.com/RandyChen1985/yunshu-ai-agent-platform'
+export const DEFAULT_AGENT_NAME = '云枢智能助手'
 
 export interface PublicBranding {
   enabled: boolean
@@ -12,6 +13,7 @@ export interface PublicBranding {
   hide_version_link: boolean
   contact_markdown: string
   copyright_text: string
+  default_agent_name: string
 }
 
 export const DEFAULT_BRANDING: PublicBranding = {
@@ -23,4 +25,5 @@ export const DEFAULT_BRANDING: PublicBranding = {
   hide_version_link: false,
   contact_markdown: '',
   copyright_text: '',
+  default_agent_name: DEFAULT_AGENT_NAME,
 }

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -52,7 +52,7 @@
                             {{ currentExpertAgent.display_name || currentExpertAgent.name }}
                         </template>
                         <template v-else>
-                            云枢智能助手
+                            {{ branding.default_agent_name || '云枢智能助手' }}
                         </template>
                     </span>
                     <span v-if="isProcessing" class="flex h-1.5 w-1.5 relative">
@@ -2348,7 +2348,10 @@ import {
   isWorkspaceSlashCommand,
 } from "@/constants/workspaceCommand";
 
+import { useBranding } from "@/composables/useBranding";
+
 const toast = useToast();
+const { branding } = useBranding();
 const {
   bannerMessage: quotaBannerMessage,
   isBlocked: quotaIsBlocked,

--- a/frontend/src/views/SystemConfig.vue
+++ b/frontend/src/views/SystemConfig.vue
@@ -304,6 +304,7 @@ const brandingConfig = ref({
   hide_version_link: false,
   contact_markdown: '',
   copyright_text: '',
+  default_agent_name: '云枢智能助手',
 })
 const brandingIconInput = ref<HTMLInputElement | null>(null)
 
@@ -320,6 +321,7 @@ const fetchBrandingConfig = async () => {
       hide_version_link: !!data.hide_version_link,
       contact_markdown: data.contact_markdown || '',
       copyright_text: data.copyright_text || '',
+      default_agent_name: data.default_agent_name || '云枢智能助手',
     }
   } catch {
     showToast('品牌配置加载失败', 'error')
@@ -1539,6 +1541,17 @@ onMounted(() => {
                 class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary focus:ring-primary text-sm"
                 placeholder="Yunshu Intelligent Agent Platform"
               />
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">默认智能助手名称</label>
+              <input
+                v-model="brandingConfig.default_agent_name"
+                type="text"
+                class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary focus:ring-primary text-sm"
+                placeholder="云枢智能助手"
+              />
+              <p class="text-xs text-gray-400 mt-1">影响未开启品牌个性化时或未指定时的智能助手默认名称（例如：Nexus AI）</p>
             </div>
 
             <div>

--- a/tests/CHECKLIST.md
+++ b/tests/CHECKLIST.md
@@ -198,3 +198,5 @@
 | 生成文件下载服务 (Generated File Download) | `tests/ai/tools/test_generated_file_service.py`, `tests/api/v1/test_generated_file_download.py` | **私有下载链接**：验证 artifact manifest 发布、token 鉴权、`GET /api/v1/chat/generated-files/{artifact_id}` 下载与过期失效。 | ✅ 通过 | 2026-06-26 |
 | ChatBI Schema 检索失败快速熔断拦截 (ChatBI Schema Fatal Early Interrupt) | `app/services/ai/runners/chatbi/react_stream.py` | **Schema 检索熔断拦截**：验证在 ReAct 循环中，每次工具调用后进行 `state.halt_current_react` 判定时，若检测到 Schema 致命错误（例如连续 2 次检索未命中数据集定义），则能够立刻触发熔断打断当前流，避免大模型死磕空转。 | ✅ 已完成 | 2026-06-26 |
 | 个人消息通知配置与连通性测试 (Notification Settings & Connectivity) | `tests/api/portal/test_notifications.py` | **个人通知配置与测试**：验证获取默认与自定义配置、打星号脱敏、反解真实密码、保存配置、钉钉/企微/邮件真实连通性测试、重构钉钉工具读取当前用户通知配置。 | ✅ 通过 | 2026-07-06 |
+| 智能体工具促发优化 (Tool Nudge Optimization) | `tests/ai/test_tool_nudge_policy.py` | **联网优先与意图过滤**：验证语义意图、单轮分类意图对工具促发路由的影响，包括联网检索优先（降低推荐阈值）和强数据查询意图的正确促发、模糊匹配排除。 | ✅ 通过 | 2026-07-06 |
+

--- a/tests/ai/test_tool_nudge_policy.py
+++ b/tests/ai/test_tool_nudge_policy.py
@@ -7,6 +7,7 @@ from app.services.ai.tool_nudge_policy import (
     resolve_tool_nudge,
     should_consider_tool_nudge,
 )
+from app.services.ai.intent_service import IntentType
 
 pytestmark = pytest.mark.no_infrastructure
 
@@ -99,6 +100,97 @@ def test_sub_agent_call_nudge_for_data_query_uses_capability_target():
     assert "agent_name='biz-data-agent'" in nudge.message
     assert "agent_name='chat-bi'" not in nudge.message
     assert nudge.should_force_first_call is True
+
+
+def test_general_semantic_company_info_prefers_web_tool_over_data_sub_agent():
+    tools = [
+        _tool("sub_agent_call", "委派其他专有子智能体执行特定任务（如查数、查手册等）"),
+        _tool("web_search_baidu", "联网搜索公司信息、官网、新闻和最新资讯"),
+    ]
+
+    nudge = resolve_tool_nudge(
+        "查一下有孚网络公司信息",
+        tools,
+        available_sub_agent_names={"biz-data-agent"},
+        sub_agent_targets_by_capability={"data_query": "biz-data-agent"},
+        semantic_intent=IntentType.GENERAL,
+        semantic_confidence=0.92,
+    )
+
+    assert nudge is not None
+    assert nudge.tool_name == "web_search_baidu"
+    assert nudge.should_force_first_call is False
+
+
+def test_public_news_query_prefers_web_tool_over_data_sub_agent():
+    tools = [
+        _tool("sub_agent_call", "委派其他专有子智能体执行特定任务（如查数、查手册等）"),
+        _tool("web_search_baidu", "联网搜索公司信息、官网、新闻和最新资讯"),
+    ]
+
+    nudge = resolve_tool_nudge(
+        "查一下有孚网络最新新闻",
+        tools,
+        available_sub_agent_names={"biz-data-agent"},
+        sub_agent_targets_by_capability={"data_query": "biz-data-agent"},
+    )
+
+    assert nudge is not None
+    assert nudge.tool_name == "web_search_baidu"
+
+
+def test_ambiguous_lookup_does_not_force_data_sub_agent():
+    tools = [
+        _tool("sub_agent_call", "委派其他专有子智能体执行特定任务（如查数、查手册等）"),
+    ]
+
+    nudge = resolve_tool_nudge(
+        "查一下 abc",
+        tools,
+        available_sub_agent_names={"biz-data-agent"},
+        sub_agent_targets_by_capability={"data_query": "biz-data-agent"},
+    )
+
+    assert nudge is None
+
+
+def test_data_query_semantic_forces_data_sub_agent():
+    tools = [
+        _tool("sub_agent_call", "委派其他专有子智能体执行特定任务（如查数、查手册等）"),
+        _tool("web_search_baidu", "联网搜索公司信息、官网、新闻和最新资讯"),
+    ]
+
+    nudge = resolve_tool_nudge(
+        "查一下客户订单列表",
+        tools,
+        available_sub_agent_names={"biz-data-agent"},
+        sub_agent_targets_by_capability={"data_query": "biz-data-agent"},
+        semantic_intent=IntentType.DATA_QUERY,
+        semantic_confidence=0.91,
+    )
+
+    assert nudge is not None
+    assert nudge.tool_name == "sub_agent_call"
+    assert "agent_name='biz-data-agent'" in nudge.message
+    assert nudge.should_force_first_call is True
+
+
+def test_server_load_query_prefers_shell_tool_over_data_sub_agent():
+    tools = [
+        _tool("sub_agent_call", "委派其他专有子智能体执行特定任务（如查数、查手册等）"),
+        _tool("exec_command", "在服务器上执行 shell 命令，查看服务器负载、CPU、内存、磁盘和进程状态"),
+    ]
+
+    nudge = resolve_tool_nudge(
+        "查一下我机器的服务器负载情况",
+        tools,
+        available_sub_agent_names={"biz-data-agent"},
+        sub_agent_targets_by_capability={"data_query": "biz-data-agent"},
+    )
+
+    assert nudge is not None
+    assert nudge.tool_name == "exec_command"
+    assert nudge.should_force_first_call is False
 
 
 def test_sub_agent_call_nudge_skips_when_target_agent_unavailable():

--- a/tests/ai/test_tool_nudge_policy.py
+++ b/tests/ai/test_tool_nudge_policy.py
@@ -122,6 +122,26 @@ def test_general_semantic_company_info_prefers_web_tool_over_data_sub_agent():
     assert nudge.should_force_first_call is False
 
 
+def test_misclassified_company_info_does_not_force_data_sub_agent():
+    tools = [
+        _tool("sub_agent_call", "委派其他专有子智能体执行特定任务（如查数、查手册等）"),
+        _tool("web_search_baidu", "联网搜索公司信息、官网、新闻和最新资讯"),
+    ]
+
+    nudge = resolve_tool_nudge(
+        "查一下有孚网络公司信息",
+        tools,
+        available_sub_agent_names={"biz-data-agent"},
+        sub_agent_targets_by_capability={"data_query": "biz-data-agent"},
+        semantic_intent=IntentType.DATA_QUERY,
+        semantic_confidence=0.93,
+    )
+
+    assert nudge is not None
+    assert nudge.tool_name == "web_search_baidu"
+    assert nudge.should_force_first_call is False
+
+
 def test_public_news_query_prefers_web_tool_over_data_sub_agent():
     tools = [
         _tool("sub_agent_call", "委派其他专有子智能体执行特定任务（如查数、查手册等）"),

--- a/tests/services/ai/test_router_service.py
+++ b/tests/services/ai/test_router_service.py
@@ -484,6 +484,43 @@ async def test_route_query_constrains_candidates_for_high_confidence_data_intent
 
 
 @pytest.mark.asyncio
+async def test_route_query_public_company_lookup_not_forced_to_data_agent(mock_agents_metadata):
+    """公网公司资料查询即使被语义模型误判为 DATA_QUERY，也不能收缩或落到 ChatBI。"""
+    service = RouterService()
+    evidence = IntentResponse(
+        intent=IntentType.DATA_QUERY,
+        confidence=0.93,
+        reasoning="误判为查询业务数据",
+        entities=["有孚网络"],
+    )
+    mock_chat = _mock_chat_client(json.dumps({
+        "thought": "错误地选择数据查询智能体",
+        "agent_name": "ChatBI",
+        "confidence": 0.88,
+    }))
+
+    with patch.object(service, "_fetch_agents_from_db", new_callable=AsyncMock) as mock_fetch, \
+         patch("app.services.ai.router_service.intent_service.identify_intent", new_callable=AsyncMock) as mock_identify, \
+         patch("app.services.ai.router_service.get_llm_async", new_callable=AsyncMock) as mock_get_llm, \
+         patch("app.services.ai.router_service.chat_client_from_handle") as mock_chat_factory:
+        mock_fetch.return_value = mock_agents_metadata
+        mock_identify.return_value = evidence
+        mock_get_llm.return_value = object()
+        mock_chat_factory.return_value = mock_chat
+
+        result = await service.route_query("查一下有孚网络公司信息")
+
+    assert result.agent_id == "agent-general"
+    assert result.intent_info == evidence
+    assert "without internal structured-data source" in result.reasoning
+
+    routed_messages = mock_chat.generate_text.call_args.args[0]
+    system_prompt = routed_messages[0].content[0].text
+    assert "ID: ChatBI" in system_prompt
+    assert "ID: general-chat" in system_prompt
+
+
+@pytest.mark.asyncio
 async def test_route_query_data_evidence_survives_invalid_constrained_route(mock_agents_metadata):
     """受约束候选的路由模型失败时，应回落 Main 并保留语义供其委派。"""
     service = RouterService()


### PR DESCRIPTION

## 概要 (Overview)
本次 PR 包含两大部分核心优化：
1. **智能体路由与工具促发策略深度优化**：引入了统一的“意图来源仲裁”机制，通过结合语义意图、单轮分类与启发式规则，防止公网查询/公开主体信息被误路由至内部数据子代理（如 ChatBI），同时增加了多场景单元测试。
2. **品牌个性化配置增强**：支持管理员自定义“默认智能助手名称”，允许平台解耦特定品牌，实现通用化部署。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)
- [x] **统一意图来源仲裁**：在 `intent_service.py` 引入 `IntentSource` 和 `resolve_intent_source()` 仲裁层，根据规则过滤和意图置信度，精准定位请求来源（内部数据、文档还是公网）。
- [x] **路由双层守卫**：在 `router_service.py` 候选收缩与结果校验中引入 `data_route_allowed` 双层校验，防御数据幻觉与误路由。
- [x] **品牌自定义助手名称**：后端 `BrandingSettingsService`、Schema 和 API 接口支持自定义配置 `default_agent_name`；前端在未开启个性化或未配置时自动兜底为 "云枢智能助手"，若配置则动态显示（例如 Nexus AI）。

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)
- [x] **系统品牌配置项**：在系统设置“品牌个性化”面板中，新增“默认智能助手名称”输入项，支持配置落库。
- [x] **对话界面动态化**：对 `EmbedChat.vue` 标题状态栏和 `WelcomeDashboard.vue` 欢迎词卡片进行了重构，将原硬编码的 "云枢智能助手" 改为根据品牌配置动态渲染。

### 3. 🐞 关键修复 (Bug Fixes)
- [x] **防误判拦截**：实现了 `looks_like_public_profile_lookup` 启发式匹配，有效拦截形如“查一下 X 公司信息”等容易被 LLM 误判为 DATA_QUERY 的公开搜索请求。
- [x] **代码清理**：删除了 `intent_service.py` 中无调用的废弃死函数 `looks_like_business_data_request`；提炼了 `_should_constrain_to_data_agents()` 并补充了详细中文业务逻辑注释。

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `7a1b255` | feat(branding): 品牌个性化支持自定义智能助手名称 |
| `0f516b2` | refactor(ai): 清理工具促发策略代码，提升可读性 |
| `75197e9` | feat(ai): 优化工具促发策略 (Tool Nudge Policy)，支持识别语义和单轮意图 |

---

## 测试覆盖 (Testing)
- [x] **UI 兼容性**: 验证了系统品牌设置 Tab、嵌入聊天页面的自适应显示，打包构建完成且无编译错误。
- [x] **核心功能**: 添加了 `tests/ai/test_tool_nudge_policy.py` 和 `tests/services/ai/test_router_service.py` 覆盖以下场景：
  - 语义为 GENERAL + 公司资料 -> 优先进入 web_search。
  - 语义误判为 DATA_QUERY + 公司信息 -> 正确防御拦截，退回到 main 兜底。
  - 强数据查询语义 + 内部业务记录 -> 正确强制进入数据子代理。
- [x] **回归测试**: 手动验证会话粘性追问场景，确认在多轮数据对话中其粘性机制不受阻断影响。

> [!IMPORTANT]
> 提交前请务必确认已更新 `tests/CHECKLIST.md` 中的自动化测试清单。


```