### PR TITLE
Pull Request: feat(metadata,widget,rag): 新增数据集权限管理与集成挂件优化，修复多项前端渲染及后端 RAGFlow 接口兼容故障

### DIFF
--- a/app/api/portal/endpoints/metadata.py
+++ b/app/api/portal/endpoints/metadata.py
@@ -14,6 +14,8 @@ from app.schemas.metadata import (
     MetricSchema, MetricResponse,
     RelationshipSchema, RelationshipResponse
 )
+from app.models.user import User
+from app.models.permission import Role
 from app.core.dependencies import require_admin, get_current_user, require_permission
 from app.core.errors import ErrorCode
 from app.services.permission_service import PermissionService
@@ -69,6 +71,193 @@ async def get_dataset(
         raise HTTPException(status_code=404, detail="数据集不存在")
     await MetadataService.repair_stale_local_sync_flags([ds])
     return ds
+
+
+@router.get("/datasets/{dataset_id}/permissions")
+async def get_metadata_dataset_permissions(
+    dataset_id: int,
+    conn: AsyncSession = Depends(get_db_session),
+    user: dict = Depends(get_current_user)
+):
+    """获取元数据数据集授权的所有角色和用户列表"""
+    from app.models.permission import ResourcePermission, Role
+    from app.models.user import User
+    from sqlalchemy import select
+
+    stmt = select(ResourcePermission).where(
+        ResourcePermission.resource_type == "metadata",
+        ResourcePermission.resource_id == str(dataset_id),
+        ResourcePermission.enabled == True
+    )
+    result = await conn.execute(stmt)
+    perms = result.scalars().all()
+
+    user_ids = [p.user_id for p in perms if p.user_id is not None]
+    role_ids = [p.role_id for p in perms if p.role_id is not None]
+
+    granted_users = []
+    granted_roles = []
+
+    if user_ids:
+        user_stmt = select(User.user_name, User.real_name).where(User.id.in_(user_ids), User.status == 1)
+        user_res = await conn.execute(user_stmt)
+        granted_users = [{"user_name": u.user_name, "real_name": u.real_name} for u in user_res.all()]
+
+    if role_ids:
+        role_stmt = select(Role.code, Role.name).where(Role.id.in_(role_ids))
+        role_res = await conn.execute(role_stmt)
+        granted_roles = [{"code": r.code, "name": r.name} for r in role_res.all()]
+
+    return {
+        "code": 0,
+        "data": {
+            "users": granted_users,
+            "roles": granted_roles
+        }
+    }
+
+
+class AddPermissionsRequest(BaseModel):
+    target_type: str  # "user" 或 "role"
+    target_ids: List[int]
+
+class DeletePermissionRequest(BaseModel):
+    target_type: str  # "user" 或 "role"
+    target_id: int
+
+
+@router.get("/candidates")
+async def get_metadata_auth_candidates(
+    conn: AsyncSession = Depends(get_db_session),
+    user: dict = Depends(require_permission("element", "element:metadata:edit"))
+):
+    """获取可用于数据集权限分配的活跃角色和用户候选列表 (需数据集编辑权限)"""
+    from app.models.permission import Role
+    from app.models.user import User
+    from sqlalchemy import select
+
+    role_stmt = select(Role.id, Role.code, Role.name)
+    role_res = await conn.execute(role_stmt)
+    roles = [{"id": r.id, "code": r.code, "name": r.name} for r in role_res.all()]
+
+    user_stmt = select(User.id, User.user_name, User.real_name).where(User.status == 1)
+    user_res = await conn.execute(user_stmt)
+    users = [{"id": u.id, "user_name": u.user_name, "real_name": u.real_name} for u in user_res.all()]
+
+    return {
+        "code": 0,
+        "data": {
+            "roles": roles,
+            "users": users
+        }
+    }
+
+
+@router.post("/datasets/{dataset_id}/permissions", dependencies=[Depends(require_permission("element", "element:metadata:edit"))])
+async def add_metadata_dataset_permissions(
+    dataset_id: int,
+    payload: AddPermissionsRequest,
+    conn: AsyncSession = Depends(get_db_session),
+    user: dict = Depends(get_current_user)
+):
+    """添加元数据数据集的授权角色或用户 (需数据集编辑权限)"""
+    from app.models.permission import ResourcePermission, UserRoleRelation
+    from sqlalchemy import select
+    
+    perm_service = PermissionService(conn)
+    affected_user_ids = set()
+
+    for tid in payload.target_ids:
+        # 查询是否已经有对应记录了
+        stmt = select(ResourcePermission).where(
+            ResourcePermission.resource_type == "metadata",
+            ResourcePermission.resource_id == str(dataset_id)
+        )
+        if payload.target_type == "user":
+            stmt = stmt.where(ResourcePermission.user_id == tid)
+            affected_user_ids.add(tid)
+        else:
+            stmt = stmt.where(ResourcePermission.role_id == tid)
+            # 获取该角色下的所有关联用户
+            r_users_stmt = select(UserRoleRelation.user_id).where(UserRoleRelation.role_id == tid)
+            r_users_res = await conn.execute(r_users_stmt)
+            for uid in r_users_res.scalars().all():
+                affected_user_ids.add(uid)
+
+        result = await conn.execute(stmt)
+        record = result.scalar_one_or_none()
+
+        if record:
+            record.enabled = True
+        else:
+            new_perm = ResourcePermission(
+                resource_type="metadata",
+                resource_id=str(dataset_id),
+                enabled=True
+            )
+            if payload.target_type == "user":
+                new_perm.user_id = tid
+            else:
+                new_perm.role_id = tid
+            conn.add(new_perm)
+
+    await conn.flush()
+
+    # 清理受影响用户的缓存，使其变更即刻生效
+    if affected_user_ids:
+        await perm_service.invalidate_cached_permissions_for_users(affected_user_ids)
+        from app.services.ai.config import invalidate_dataset_menu_cache
+        for uid in affected_user_ids:
+            await invalidate_dataset_menu_cache(user_id=uid)
+
+    return {"code": 0, "message": "权限配置已成功添加"}
+
+
+@router.delete("/datasets/{dataset_id}/permissions", dependencies=[Depends(require_permission("element", "element:metadata:edit"))])
+async def delete_metadata_dataset_permission(
+    dataset_id: int,
+    payload: DeletePermissionRequest,
+    conn: AsyncSession = Depends(get_db_session),
+    user: dict = Depends(get_current_user)
+):
+    """移除元数据数据集关联的某个角色或用户授权 (需数据集编辑权限)"""
+    from app.models.permission import ResourcePermission, UserRoleRelation
+    from sqlalchemy import select, delete
+
+    perm_service = PermissionService(conn)
+    affected_user_ids = set()
+
+    # 查出受影响的用户列表以作缓存清理
+    if payload.target_type == "user":
+        affected_user_ids.add(payload.target_id)
+    else:
+        r_users_stmt = select(UserRoleRelation.user_id).where(UserRoleRelation.role_id == payload.target_id)
+        r_users_res = await conn.execute(r_users_stmt)
+        for uid in r_users_res.scalars().all():
+            affected_user_ids.add(uid)
+
+    # 物理清除
+    stmt = delete(ResourcePermission).where(
+        ResourcePermission.resource_type == "metadata",
+        ResourcePermission.resource_id == str(dataset_id)
+    )
+    if payload.target_type == "user":
+        stmt = stmt.where(ResourcePermission.user_id == payload.target_id)
+    else:
+        stmt = stmt.where(ResourcePermission.role_id == payload.target_id)
+
+    await conn.execute(stmt)
+    await conn.flush()
+
+    # 清理权限缓存
+    if affected_user_ids:
+        await perm_service.invalidate_cached_permissions_for_users(affected_user_ids)
+        from app.services.ai.config import invalidate_dataset_menu_cache
+        for uid in affected_user_ids:
+            await invalidate_dataset_menu_cache(user_id=uid)
+
+    return {"code": 0, "message": "权限配置已成功移除"}
+
 
 @router.put("/datasets/{dataset_id}", response_model=DatasetResponse, dependencies=[Depends(require_permission("element", "element:metadata:edit"))])
 async def update_dataset(

--- a/app/api/portal/endpoints/metadata.py
+++ b/app/api/portal/endpoints/metadata.py
@@ -206,9 +206,9 @@ async def add_metadata_dataset_permissions(
     # 清理受影响用户的缓存，使其变更即刻生效
     if affected_user_ids:
         await perm_service.invalidate_cached_permissions_for_users(affected_user_ids)
-        from app.services.ai.config import invalidate_dataset_menu_cache
+        from app.services.ai.config import AgentConfigProvider
         for uid in affected_user_ids:
-            await invalidate_dataset_menu_cache(user_id=uid)
+            await AgentConfigProvider.invalidate_dataset_menu_cache(user_id=uid)
 
     return {"code": 0, "message": "权限配置已成功添加"}
 
@@ -252,9 +252,9 @@ async def delete_metadata_dataset_permission(
     # 清理权限缓存
     if affected_user_ids:
         await perm_service.invalidate_cached_permissions_for_users(affected_user_ids)
-        from app.services.ai.config import invalidate_dataset_menu_cache
+        from app.services.ai.config import AgentConfigProvider
         for uid in affected_user_ids:
-            await invalidate_dataset_menu_cache(user_id=uid)
+            await AgentConfigProvider.invalidate_dataset_menu_cache(user_id=uid)
 
     return {"code": 0, "message": "权限配置已成功移除"}
 

--- a/app/api/portal/endpoints/metadata.py
+++ b/app/api/portal/endpoints/metadata.py
@@ -99,14 +99,14 @@ async def get_metadata_dataset_permissions(
     granted_roles = []
 
     if user_ids:
-        user_stmt = select(User.user_name, User.real_name).where(User.id.in_(user_ids), User.status == 1)
+        user_stmt = select(User.id, User.user_name, User.real_name).where(User.id.in_(user_ids), User.status == 1)
         user_res = await conn.execute(user_stmt)
-        granted_users = [{"user_name": u.user_name, "real_name": u.real_name} for u in user_res.all()]
+        granted_users = [{"id": u.id, "user_name": u.user_name, "real_name": u.real_name} for u in user_res.all()]
 
     if role_ids:
-        role_stmt = select(Role.code, Role.name).where(Role.id.in_(role_ids))
+        role_stmt = select(Role.id, Role.code, Role.name).where(Role.id.in_(role_ids))
         role_res = await conn.execute(role_stmt)
-        granted_roles = [{"code": r.code, "name": r.name} for r in role_res.all()]
+        granted_roles = [{"id": r.id, "code": r.code, "name": r.name} for r in role_res.all()]
 
     return {
         "code": 0,

--- a/app/api/portal/endpoints/ragflow.py
+++ b/app/api/portal/endpoints/ragflow.py
@@ -395,7 +395,29 @@ async def delete_ragflow_datasets(
     client = RagFlowClient(config_prefix="knowledge_ragflow")
     metadata_service = KnowledgeBaseMetadataService(db)
     try:
-        await client.delete_datasets(payload.ids)
+        # 获取当前 RAGFlow 侧的所有有效数据集，以防删除已不存在的知识库时报错
+        try:
+            ragflow_datasets = await client.list_datasets(page=1, page_size=500)
+            existing_ids = {str(ds.get("id")) for ds in ragflow_datasets if ds.get("id")}
+        except Exception:
+            # 列表获取失败时的安全降级兜底：假设所有传入 ID 都在 RAGFlow 侧存在
+            existing_ids = set(payload.ids)
+
+        to_delete_in_ragflow = [kb_id for kb_id in payload.ids if kb_id in existing_ids]
+
+        if to_delete_in_ragflow:
+            await client.delete_datasets(to_delete_in_ragflow)
+
+        # 同步删除相关用户和角色的 ResourcePermission 授权记录
+        from app.models.permission import ResourcePermission
+        from sqlalchemy import delete
+        await db.execute(
+            delete(ResourcePermission).where(
+                ResourcePermission.resource_type == "dataset",
+                ResourcePermission.resource_id.in_(payload.ids)
+            )
+        )
+
         await metadata_service.mark_deleted(payload.ids, user_name=user.get("user_name"))
         await record_knowledge_audit(request, user, "datasets:delete", 200, {
             "action": "delete_dataset",
@@ -581,3 +603,49 @@ async def retrieval_test(
             "query_summary": payload.query[:200],
         }, error_message=str(e), started_at=started)
         raise
+
+
+@router.get("/datasets/{dataset_id}/permissions")
+async def get_dataset_permissions(
+    dataset_id: str,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session)
+):
+    """
+    获取指定知识库授权的所有用户和角色列表
+    """
+    from app.models.permission import ResourcePermission, Role
+    from app.models.user import User
+    from sqlalchemy import select
+
+    stmt = select(ResourcePermission).where(
+        ResourcePermission.resource_type == "dataset",
+        ResourcePermission.resource_id == dataset_id,
+        ResourcePermission.enabled == True
+    )
+    result = await db.execute(stmt)
+    perms = result.scalars().all()
+
+    user_ids = [p.user_id for p in perms if p.user_id is not None]
+    role_ids = [p.role_id for p in perms if p.role_id is not None]
+
+    granted_users = []
+    granted_roles = []
+
+    if user_ids:
+        user_stmt = select(User.user_name, User.real_name).where(User.id.in_(user_ids), User.status == 1)
+        user_res = await db.execute(user_stmt)
+        granted_users = [{"user_name": u.user_name, "real_name": u.real_name} for u in user_res.all()]
+
+    if role_ids:
+        role_stmt = select(Role.code, Role.name).where(Role.id.in_(role_ids))
+        role_res = await db.execute(role_stmt)
+        granted_roles = [{"code": r.code, "name": r.name} for r in role_res.all()]
+
+    return {
+        "code": 0,
+        "data": {
+            "users": granted_users,
+            "roles": granted_roles
+        }
+    }

--- a/app/api/portal/endpoints/ragflow.py
+++ b/app/api/portal/endpoints/ragflow.py
@@ -633,14 +633,14 @@ async def get_dataset_permissions(
     granted_roles = []
 
     if user_ids:
-        user_stmt = select(User.user_name, User.real_name).where(User.id.in_(user_ids), User.status == 1)
+        user_stmt = select(User.id, User.user_name, User.real_name).where(User.id.in_(user_ids), User.status == 1)
         user_res = await db.execute(user_stmt)
-        granted_users = [{"user_name": u.user_name, "real_name": u.real_name} for u in user_res.all()]
+        granted_users = [{"id": u.id, "user_name": u.user_name, "real_name": u.real_name} for u in user_res.all()]
 
     if role_ids:
-        role_stmt = select(Role.code, Role.name).where(Role.id.in_(role_ids))
+        role_stmt = select(Role.id, Role.code, Role.name).where(Role.id.in_(role_ids))
         role_res = await db.execute(role_stmt)
-        granted_roles = [{"code": r.code, "name": r.name} for r in role_res.all()]
+        granted_roles = [{"id": r.id, "code": r.code, "name": r.name} for r in role_res.all()]
 
     return {
         "code": 0,

--- a/app/services/ai/ragflow_client.py
+++ b/app/services/ai/ragflow_client.py
@@ -248,11 +248,48 @@ class RagFlowClient:
         """List chunks of a document"""
         await self._ensure_config()
         url = f"{self.base_url}/api/v1/datasets/{dataset_id}/documents/{document_id}/chunks"
-        params = {"page": page, "page_size": page_size}
         
-        async with httpx.AsyncClient(timeout=20.0) as client:
-            resp = await client.get(url, headers=self._get_headers(), params=params)
-            return await self._handle_response(resp, "List Chunks")
+        # RAGFlow limits page_size to <= 100. If larger, we fetch multiple pages of max size 100
+        if page_size <= 100:
+            params = {"page": page, "page_size": page_size}
+            async with httpx.AsyncClient(timeout=20.0) as client:
+                resp = await client.get(url, headers=self._get_headers(), params=params)
+                return await self._handle_response(resp, "List Chunks")
+        else:
+            merged_chunks = []
+            doc_meta = {}
+            start_offset = (page - 1) * page_size
+            end_offset = start_offset + page_size
+            
+            ragflow_page_size = 100
+            start_page = (start_offset // ragflow_page_size) + 1
+            end_page = ((end_offset - 1) // ragflow_page_size) + 1
+            
+            async with httpx.AsyncClient(timeout=20.0) as client:
+                for p in range(start_page, end_page + 1):
+                    params = {"page": p, "page_size": ragflow_page_size}
+                    resp = await client.get(url, headers=self._get_headers(), params=params)
+                    data = await self._handle_response(resp, f"List Chunks Page {p}")
+                    
+                    if isinstance(data, dict):
+                        page_chunks = data.get("chunks") or []
+                        if not doc_meta and "doc" in data:
+                            doc_meta = data["doc"]
+                    else:
+                        page_chunks = []
+                        
+                    if not page_chunks:
+                        break
+                    merged_chunks.extend(page_chunks)
+                    if len(page_chunks) < ragflow_page_size:
+                        break
+            
+            slice_start = start_offset - (start_page - 1) * ragflow_page_size
+            slice_end = slice_start + page_size
+            return {
+                "chunks": merged_chunks[slice_start:slice_end],
+                "doc": doc_meta
+            }
 
     async def chat_stream(
         self, 

--- a/frontend/src/components/CitationPopover.vue
+++ b/frontend/src/components/CitationPopover.vue
@@ -232,12 +232,11 @@ onUnmounted(() => {
       </div>
 
       <div
-        class="citation-popover-body flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 py-2.5 text-sm text-gray-600 dark:text-gray-300 leading-relaxed whitespace-pre-wrap custom-scrollbar"
+        class="citation-popover-body flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 py-2.5 text-xs text-gray-600 dark:text-gray-300 leading-relaxed whitespace-pre-wrap custom-scrollbar"
+        v-html="citation.content"
         @wheel.stop
         @touchmove.stop
-      >
-        {{ citation.content }}
-      </div>
+      />
 
       <div class="flex items-center justify-between gap-2 px-3 py-2 border-t border-gray-100 dark:border-gray-700/60 flex-shrink-0">
         <span
@@ -273,3 +272,66 @@ onUnmounted(() => {
     </div>
   </Teleport>
 </template>
+
+<style scoped>
+.citation-popover-body :deep(table) {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 10px 0;
+  font-size: 11px;
+  line-height: 1.5;
+  background-color: #ffffff;
+}
+
+.dark .citation-popover-body :deep(table) {
+  background-color: #1f2937;
+}
+
+.citation-popover-body :deep(th),
+.citation-popover-body :deep(td) {
+  border: 1px solid #e5e7eb;
+  padding: 6px 8px;
+  text-align: left;
+  word-break: break-all;
+}
+
+.dark .citation-popover-body :deep(th),
+.dark .citation-popover-body :deep(td) {
+  border-color: #374151;
+}
+
+.citation-popover-body :deep(th) {
+  background-color: #f3f4f6;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.dark .citation-popover-body :deep(th) {
+  background-color: #374151;
+  color: #f9fafb;
+}
+
+.citation-popover-body :deep(tr:nth-child(even)) {
+  background-color: #f9fafb;
+}
+
+.dark .citation-popover-body :deep(tr:nth-child(even)) {
+  background-color: rgba(31, 41, 55, 0.4);
+}
+
+.citation-popover-body :deep(caption) {
+  font-size: 10px;
+  color: #6b7280;
+  padding: 6px 4px;
+  font-weight: 700;
+  text-align: left;
+  background-color: rgba(243, 244, 246, 0.5);
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.dark .citation-popover-body :deep(caption) {
+  color: #9ca3af;
+  background-color: rgba(55, 65, 81, 0.5);
+  border-color: #4b5563;
+}
+</style>

--- a/frontend/src/components/ConfirmModal.vue
+++ b/frontend/src/components/ConfirmModal.vue
@@ -7,12 +7,14 @@ interface Props {
   confirmText?: string
   cancelText?: string
   type?: 'danger' | 'primary' | 'warning'
+  loading?: boolean
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   confirmText: '确认',
   cancelText: '取消',
-  type: 'danger'
+  type: 'danger',
+  loading: false
 })
 
 const emit = defineEmits<{
@@ -23,6 +25,7 @@ const emit = defineEmits<{
 const confirmButtonRef = ref<HTMLButtonElement | null>(null)
 
 const handleKeydown = (e: KeyboardEvent) => {
+  if (props.loading) return
   if (e.key === 'Enter') {
     e.preventDefault()
     e.stopPropagation()
@@ -49,7 +52,7 @@ onUnmounted(() => {
     class="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
     role="dialog"
     aria-modal="true"
-    @click.self="$emit('cancel')"
+    @click.self="!loading && $emit('cancel')"
   >
     <div class="bg-white rounded-xl shadow-2xl max-w-sm w-full overflow-hidden scale-100 transition-transform duration-200">
       <div class="p-6 text-center">
@@ -68,21 +71,28 @@ onUnmounted(() => {
       <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
         <button
           ref="confirmButtonRef"
-          @click="$emit('confirm')"
+          @click="!loading && $emit('confirm')"
           type="button"
-          class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 text-base font-medium text-white sm:ml-3 sm:w-auto sm:text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2"
+          class="w-full inline-flex justify-center items-center gap-1.5 rounded-md border border-transparent shadow-sm px-4 py-2 text-base font-medium text-white sm:ml-3 sm:w-auto sm:text-sm transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed"
           :class="{
             'bg-red-600 hover:bg-red-700 focus:ring-red-500': type === 'danger',
             'bg-primary hover:bg-primary-dark focus:ring-primary': type === 'primary',
             'bg-yellow-600 hover:bg-yellow-700 focus:ring-yellow-500': type === 'warning'
           }"
+          :disabled="loading"
         >
-          {{ confirmText }}
+          <!-- SVG Loading Spinner -->
+          <svg v-if="loading" class="animate-spin -ml-1 mr-1 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          <span>{{ loading ? '处理中...' : confirmText }}</span>
         </button>
         <button 
-          @click="$emit('cancel')" 
+          @click="!loading && $emit('cancel')" 
           type="button" 
-          class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm focus:outline-none"
+          class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="loading"
         >
           {{ cancelText }}
         </button>

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -2367,6 +2367,9 @@ const saveReportModalOverlayStyle = computed(() => {
   const rem = pinnedDrawerRightRem.value;
   return { right: rem > 0 ? `${rem}rem` : "0" };
 });
+const saveReportModalOverlayClass = computed(() =>
+  showPortalDrawer.value && portalPinned.value ? 'right-[28rem]' : 'right-0'
+);
 
 const pinnedDrawerMarginStyle = computed(() => {
   const rem = pinnedDrawerRightRem.value;
@@ -5506,6 +5509,7 @@ onUnmounted(() => {
   <div
     v-if="showReportRunModal"
     class="fixed inset-y-0 left-0 z-[250] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
+    :class="saveReportModalOverlayClass"
     :style="saveReportModalOverlayStyle"
     @click.self="showReportRunModal = false"
   >
@@ -5606,6 +5610,7 @@ onUnmounted(() => {
   <div
     v-if="showSaveReportModal"
     class="fixed inset-y-0 left-0 z-[250] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
+    :class="saveReportModalOverlayClass"
     :style="saveReportModalOverlayStyle"
     @click.self="showSaveReportModal = false"
   >

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -1584,6 +1584,7 @@
     <div
       v-if="showSaveReportModal"
       class="fixed inset-y-0 left-0 z-[250] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
+      :class="saveReportModalOverlayClass"
       :style="saveReportModalOverlayStyle"
       @click.self="showSaveReportModal = false"
     >
@@ -1681,6 +1682,7 @@
     <div
       v-if="showReportRunModal"
       class="fixed inset-y-0 left-0 z-[250] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
+      :class="saveReportModalOverlayClass"
       :style="saveReportModalOverlayStyle"
       @click.self="showReportRunModal = false"
     >
@@ -5566,6 +5568,9 @@ const saveReportModalOverlayStyle = computed(() => {
   const rem = pinnedDrawerRightRem.value;
   return { right: rem > 0 ? `${rem}rem` : "0" };
 });
+const saveReportModalOverlayClass = computed(() =>
+  showPortalDrawer.value && portalPinned.value ? 'right-[28rem]' : 'right-0'
+);
 
 const pinnedDrawerMarginStyle = computed(() => {
   const rem = pinnedDrawerRightRem.value;

--- a/frontend/src/views/KnowledgeBaseManagement.vue
+++ b/frontend/src/views/KnowledgeBaseManagement.vue
@@ -80,7 +80,6 @@ const showCreateModal = ref(false)
 const showEditModal = ref(false)
 const deletingDataset = ref<KnowledgeBase | null>(null)
 const deletingDocument = ref<KnowledgeDocument | null>(null)
-const uploadFile = ref<File | null>(null)
 
 const form = ref({
   name: '',
@@ -267,7 +266,24 @@ const fetchDocumentsForDataset = async (dsId: string) => {
   documentsLoadingMap.value[dsId] = true
   try {
     const response = await axios.get(`/api/portal/ragflow/datasets/${dsId}/documents`)
-    documentsMap.value[dsId] = apiData(response)
+    const docs = apiData(response)
+    documentsMap.value[dsId] = docs
+
+    // 自动更新并同步清理 parsingDocIds
+    const nextParsing = { ...parsingDocIds.value }
+    let updated = false
+    for (const d of docs) {
+      if (nextParsing[d.id] && getDocStatus(d) !== 'parsing') {
+        delete nextParsing[d.id]
+        updated = true
+      }
+    }
+    if (updated) {
+      parsingDocIds.value = nextParsing
+    }
+
+    // 自动触发或检查是否需要轮询
+    checkAndStartDatasetPolling(dsId)
   } catch (err) {
     showToast(extractError(err), 'error')
     documentsMap.value[dsId] = []
@@ -276,13 +292,33 @@ const fetchDocumentsForDataset = async (dsId: string) => {
   }
 }
 
+const datasetPermissions = ref<{ users: any[], roles: any[] }>({ users: [], roles: [] })
+const loadingPermissions = ref(false)
+
+const fetchDatasetPermissions = async (datasetId: string) => {
+  loadingPermissions.value = true
+  datasetPermissions.value = { users: [], roles: [] }
+  try {
+    const response = await axios.get(`/api/portal/ragflow/datasets/${datasetId}/permissions`)
+    datasetPermissions.value = response.data?.data || { users: [], roles: [] }
+  } catch (err) {
+    console.error('获取知识库权限分配失败:', err)
+  } finally {
+    loadingPermissions.value = false
+  }
+}
+
 // 选中知识库节点
 const selectDatasetNode = (dataset: KnowledgeBase) => {
   selectedType.value = 'dataset'
-  selectedId.value = dataset.ragflow_dataset_id || dataset.id || ''
+  const dsId = dataset.ragflow_dataset_id || dataset.id || ''
+  selectedId.value = dsId
   selectedDataset.value = dataset
   selectedDocument.value = null
   toggleDatasetExpand(dataset, true)
+  if (dsId) {
+    fetchDatasetPermissions(dsId)
+  }
 }
 
 // 选中文档节点
@@ -293,11 +329,11 @@ const selectDocumentNode = (doc: KnowledgeDocument, dataset: KnowledgeBase) => {
   selectedDocument.value = doc
   const dsId = dataset.ragflow_dataset_id || dataset.id || ''
   const status = getDocStatus(doc)
-    if (dsId && (status === 'parsing' || parsingDocIds.value[doc.id])) {
+  if (dsId && (status === 'parsing' || parsingDocIds.value[doc.id])) {
     if (!parsingDocIds.value[doc.id]) {
       parsingDocIds.value = { ...parsingDocIds.value, [doc.id]: true }
     }
-    startParseStatusPolling(dsId, doc.id)
+    checkAndStartDatasetPolling(dsId)
   }
 }
 
@@ -411,16 +447,50 @@ const updateMetadata = async () => {
   }
 }
 
+const triggerDeleteDataset = (dataset: KnowledgeBase) => {
+  deletingDataset.value = dataset
+  const dsId = dataset.ragflow_dataset_id || dataset.id
+  if (dsId) {
+    // 异步静默拉取该知识库的最新授权记录，以便在确认弹窗中即时呈现正确的同步警告
+    fetchDatasetPermissions(dsId)
+  }
+}
+
+const deleteDatasetMessage = computed(() => {
+  if (!deletingDataset.value) return ''
+  const name = deletingDataset.value.platform_name || deletingDataset.value.name
+  
+  // 检查当前拉取出来的 datasetPermissions 中是否有授权角色或用户
+  const hasPerms = datasetPermissions.value.users?.length > 0 || datasetPermissions.value.roles?.length > 0
+  
+  if (deletingDataset.value.is_missing_in_ragflow) {
+    let baseMsg = '检测到该知识库已在 RAGFlow 端不存在或已被物理删除，确定清理云枢平台本地残留的相关配置和元数据信息吗？'
+    if (hasPerms) {
+      baseMsg += '（⚠️ 该知识库当前已授权的角色/用户访问权限关系也将被同步清除）'
+    }
+    return baseMsg
+  } else {
+    let baseMsg = `确定真实删除知识库「${name}」吗？RAGFlow 侧相应集群数据也将同步卸载，此操作不可逆。`
+    if (hasPerms) {
+      baseMsg += '（⚠️ 注意：该知识库当前已授权给角色/用户，删除后系统关联的全部授权记录将被同步擦除清理）'
+    }
+    return baseMsg
+  }
+})
+
 const confirmDeleteDataset = async () => {
-  if (!isEngineReady.value) {
+  // 如果当前删除的是在 RAGFlow 中已失效的配置，允许跳过引擎连接校验直接清理
+  if (!isEngineReady.value && !deletingDataset.value?.is_missing_in_ragflow) {
     showToast('知识库引擎未连接，暂不能删除知识库', 'warning')
     return
   }
   if (!deletingDataset.value) return
+  deleting.value = true
   try {
     const id = deletingDataset.value.ragflow_dataset_id || deletingDataset.value.id
+    const isMissing = deletingDataset.value.is_missing_in_ragflow
     await axios.delete('/api/portal/ragflow/datasets', { data: { ids: [id] } })
-    showToast('知识库已删除', 'success')
+    showToast(isMissing ? '本地失效配置已清理' : '知识库已删除', 'success')
     
     const deletedId = id
     deletingDataset.value = null
@@ -436,12 +506,18 @@ const confirmDeleteDataset = async () => {
     await fetchDatasets()
   } catch (err) {
     showToast(extractError(err), 'error')
+  } finally {
+    deleting.value = false
   }
 }
 
 const onFileChange = (event: Event) => {
   const input = event.target as HTMLInputElement
-  uploadFile.value = input.files?.[0] || null
+  if (input.files) {
+    const files = Array.from(input.files)
+    const newFiles = files.filter(f => !uploadFiles.value.some(existing => existing.name === f.name && existing.size === f.size))
+    uploadFiles.value = [...uploadFiles.value, ...newFiles]
+  }
 }
 
 const uploadDocument = async () => {
@@ -449,21 +525,60 @@ const uploadDocument = async () => {
     showToast('知识库引擎未连接，暂不能上传文档', 'warning')
     return
   }
-  if (!uploadFile.value || !selectedDatasetId.value) {
-    showToast('请选择要上传的文件', 'warning')
+  if (uploadFiles.value.length === 0 || !selectedDatasetId.value) {
+    showToast('请先选择要上传的文件', 'warning')
     return
   }
-  const payload = new FormData()
-  payload.append('file', uploadFile.value)
-  try {
-    await axios.post(`/api/portal/ragflow/datasets/${selectedDatasetId.value}/documents/upload`, payload)
-    showToast('文档上传成功，请在右侧或文档节点中触发解析', 'success')
-    uploadFile.value = null
-    // 重新获取该知识库下的文档
-    await fetchDocumentsForDataset(selectedDatasetId.value)
-  } catch (err) {
-    showToast(extractError(err), 'error')
+  uploading.value = true
+  
+  const total = uploadFiles.value.length
+  let successCount = 0
+  let failCount = 0
+  
+  for (let i = 0; i < total; i++) {
+    const file = uploadFiles.value[i]
+    uploadProgressText.value = `正在上传并解析: ${i + 1} / ${total} (${file.name})`
+    
+    const payload = new FormData()
+    payload.append('file', file)
+    
+    try {
+      const response = await axios.post(`/api/portal/ragflow/datasets/${selectedDatasetId.value}/documents/upload`, payload)
+      const resData = response.data?.data || {}
+      const docId = resData.id
+      
+      if (docId) {
+        parsingDocIds.value = { ...parsingDocIds.value, [docId]: true }
+        try {
+          await axios.post(`/api/portal/ragflow/datasets/${selectedDatasetId.value}/documents/parse`, {
+            ids: [docId]
+          })
+        } catch (parseErr) {
+          const nextParsing = { ...parsingDocIds.value }
+          delete nextParsing[docId]
+          parsingDocIds.value = nextParsing
+          console.error(`文档 ${file.name} 自动解析失败:`, parseErr)
+        }
+      }
+      successCount++
+    } catch (err) {
+      failCount++
+      console.error(`文档 ${file.name} 上传失败:`, err)
+    }
   }
+  
+  if (failCount === 0) {
+    showToast(`成功批量上传并触发解析了 ${successCount} 个文档`, 'success')
+  } else if (successCount > 0) {
+    showToast(`批量上传完成：成功 ${successCount} 个，失败 ${failCount} 个`, 'warning')
+  } else {
+    showToast('全部文档上传失败，请检查网络或知识库配置', 'error')
+  }
+  
+  clearAllUploadFiles()
+  await fetchDocumentsForDataset(selectedDatasetId.value)
+  uploading.value = false
+  uploadProgressText.value = ''
 }
 
 const confirmDeleteDocument = async () => {
@@ -472,6 +587,7 @@ const confirmDeleteDocument = async () => {
     return
   }
   if (!deletingDocument.value || !selectedDatasetId.value) return
+  deleting.value = true
   try {
     const docId = deletingDocument.value.id
     await axios.delete(`/api/portal/ragflow/datasets/${selectedDatasetId.value}/documents`, {
@@ -491,19 +607,96 @@ const confirmDeleteDocument = async () => {
     await fetchDocumentsForDataset(selectedDatasetId.value)
   } catch (err) {
     showToast(extractError(err), 'error')
+  } finally {
+    deleting.value = false
   }
 }
 
 /** 已触发解析、等待 RAGFlow 返回终态（防重复点击） */
 const parsingDocIds = ref<Record<string, boolean>>({})
-const parsePollTimers = new Map<string, ReturnType<typeof setInterval>>()
 
-const syncSelectedDocumentFromMap = (dsId: string, docId: string) => {
-  const updatedDoc = (documentsMap.value[dsId] || []).find(d => d.id === docId)
-  if (updatedDoc && selectedDocument.value?.id === docId) {
-    selectedDocument.value = updatedDoc
+// 基于知识库维度的自适应渐进退避轮询机制
+const datasetPollTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const datasetPollCounts = new Map<string, number>()
+
+const stopDatasetPolling = (dsId: string) => {
+  const timer = datasetPollTimers.get(dsId)
+  if (timer) {
+    clearTimeout(timer)
+    datasetPollTimers.delete(dsId)
   }
-  return updatedDoc
+  datasetPollCounts.delete(dsId)
+}
+
+const checkAndStartDatasetPolling = (dsId: string) => {
+  const docs = documentsMap.value[dsId] || []
+  const hasParsing = docs.some(d => getDocStatus(d) === 'parsing')
+  
+  if (hasParsing) {
+    startDatasetStatusPolling(dsId)
+  } else {
+    stopDatasetPolling(dsId)
+  }
+}
+
+const startDatasetStatusPolling = (dsId: string) => {
+  if (datasetPollTimers.has(dsId)) return
+  datasetPollCounts.set(dsId, 0)
+  
+  const poll = async () => {
+    let count = datasetPollCounts.get(dsId) || 0
+    count += 1
+    datasetPollCounts.set(dsId, count)
+    
+    try {
+      await fetchDocumentsForDataset(dsId)
+      
+      // 同步当前选中的文档详情信息
+      if (selectedDocument.value && selectedDatasetId.value === dsId) {
+        const updatedDoc = (documentsMap.value[dsId] || []).find(d => d.id === selectedDocument.value.id)
+        if (updatedDoc) {
+          selectedDocument.value = updatedDoc
+        }
+      }
+      
+      const docs = documentsMap.value[dsId] || []
+      const stillHasParsing = docs.some(d => getDocStatus(d) === 'parsing')
+      
+      if (!stillHasParsing) {
+        stopDatasetPolling(dsId)
+        return
+      }
+      
+      const maxPolls = 60 // 约 5-6 分钟
+      if (count >= maxPolls) {
+        stopDatasetPolling(dsId)
+        showToast('文档解析状态轮询超时，请手动刷新查看', 'warning')
+        return
+      }
+      
+      // 自适应渐进退避间隔：1~5次3秒，6~20次6秒，21次以上15秒
+      let interval = 3000
+      if (count > 20) {
+        interval = 15000
+      } else if (count > 5) {
+        interval = 6000
+      }
+      
+      const timer = setTimeout(poll, interval)
+      datasetPollTimers.set(dsId, timer)
+    } catch {
+      const maxPolls = 60
+      if (count >= maxPolls) {
+        stopDatasetPolling(dsId)
+      } else {
+        const timer = setTimeout(poll, 10000)
+        datasetPollTimers.set(dsId, timer)
+      }
+    }
+  }
+  
+  const timer = setTimeout(poll, 3000)
+  datasetPollTimers.set(dsId, timer)
 }
 
 const isDocParsing = (doc?: KnowledgeDocument | null) => {
@@ -516,56 +709,6 @@ const isDocParsing = (doc?: KnowledgeDocument | null) => {
 const isParseButtonDisabled = (doc?: KnowledgeDocument | null) => {
   if (!isEngineReady.value || !doc) return true
   return isDocParsing(doc)
-}
-
-const stopParsePolling = (docId: string) => {
-  const timer = parsePollTimers.get(docId)
-  if (timer) {
-    clearInterval(timer)
-    parsePollTimers.delete(docId)
-  }
-}
-
-const unmarkDocParsing = (docId: string) => {
-  stopParsePolling(docId)
-  if (!parsingDocIds.value[docId]) return
-  const next = { ...parsingDocIds.value }
-  delete next[docId]
-  parsingDocIds.value = next
-}
-
-const startParseStatusPolling = (dsId: string, docId: string) => {
-  stopParsePolling(docId)
-  let seenParsing = false
-  let pollCount = 0
-  const maxPolls = 90 // ~3 分钟
-
-  const timer = setInterval(async () => {
-    pollCount += 1
-    try {
-      await fetchDocumentsForDataset(dsId)
-      const doc = syncSelectedDocumentFromMap(dsId, docId)
-      const status = getDocStatus(doc)
-      if (status === 'parsing') {
-        seenParsing = true
-      }
-      const terminal = status !== 'parsing'
-      if (terminal && (seenParsing || pollCount >= 2)) {
-        unmarkDocParsing(docId)
-        return
-      }
-      if (pollCount >= maxPolls) {
-        unmarkDocParsing(docId)
-        showToast('解析状态轮询超时，请手动刷新查看', 'warning')
-      }
-    } catch {
-      if (pollCount >= maxPolls) {
-        unmarkDocParsing(docId)
-      }
-    }
-  }, 2000)
-
-  parsePollTimers.set(docId, timer)
 }
 
 // 解析单个文档
@@ -589,12 +732,10 @@ const parseSingleDocument = async (docId: string) => {
     })
     showToast('解析任务已触发', 'success')
     await fetchDocumentsForDataset(dsId)
-    syncSelectedDocumentFromMap(dsId, docId)
-
-    // 轮询直到解析完成/失败（RAGFlow 状态切换可能有延迟）
-    startParseStatusPolling(dsId, docId)
   } catch (err) {
-    unmarkDocParsing(docId)
+    const nextParsing = { ...parsingDocIds.value }
+    delete nextParsing[docId]
+    parsingDocIds.value = nextParsing
     showToast(extractError(err), 'error')
   }
 }
@@ -630,19 +771,24 @@ const canViewChunks = (dataset?: KnowledgeBase | null) => {
 
 const getDocStatus = (doc: any) => {
   if (!doc) return 'unparsed'
-  // RAGFlow returns parsing status in the 'run' field:
-  // "0": unparsed, "1": completed/parsed, "2": parsing, "3": failed
-  const run = String(doc.run ?? '')
-  if (run === '1') return 'parsed'
-  if (run === '2') return 'parsing'
-  if (run === '3') return 'failed'
-  if (run === '0') return 'unparsed'
   
-  // Fallback to doc.status if run is not available
-  const status = String(doc.status ?? '')
-  if (status === 'completed' || status === 'parsed' || status === '1') return 'parsed'
-  if (status === 'running' || status === 'parsing' || status === '2') return 'parsing'
-  if (status === 'failed' || status === '3') return 'failed'
+  // RAGFlow returns parsing status in the 'run' field:
+  // "0" / "UNSTART": unparsed, "1" / "DONE": completed/parsed, "2" / "RUNNING": parsing, "3" / "FAIL": failed
+  const run = String(doc.run ?? '').toUpperCase()
+  if (run === 'RUNNING' || run === '2') return 'parsing'
+  if (run === 'DONE' || run === '1') return 'parsed'
+  if (run === 'FAIL' || run === '3') return 'failed'
+  if (run === 'UNSTART' || run === '0') return 'unparsed'
+  
+  // Fallback to doc.status only if run is completely unavailable
+  if (doc.run === undefined || doc.run === null) {
+    const status = String(doc.status ?? '').toUpperCase()
+    // Note: status '1' in RAGFlow means file is active/enabled. DO NOT map '1' or '0' to parsing status here!
+    if (status === 'COMPLETED' || status === 'PARSED') return 'parsed'
+    if (status === 'RUNNING' || status === 'PARSING') return 'parsing'
+    if (status === 'FAILED') return 'failed'
+  }
+  
   return 'unparsed'
 }
 
@@ -703,10 +849,112 @@ const fetchChunks = async () => {
     loadingChunks.value = false
   }
 }
+const uploading = ref(false)
+const uploadProgressText = ref('')
+const isDragOver = ref(false)
+const fileInputRef = ref<HTMLInputElement | null>(null)
+const uploadFiles = ref<File[]>([])
+
+const triggerFileSelect = () => {
+  if (uploading.value) return
+  fileInputRef.value?.click()
+}
+
+const clearAllUploadFiles = () => {
+  uploadFiles.value = []
+  if (fileInputRef.value) {
+    fileInputRef.value.value = ''
+  }
+}
+
+const removeUploadFile = (index: number) => {
+  uploadFiles.value.splice(index, 1)
+  if (uploadFiles.value.length === 0 && fileInputRef.value) {
+    fileInputRef.value.value = ''
+  }
+}
+
+const onFileDrop = (e: DragEvent) => {
+  isDragOver.value = false
+  if (uploading.value) return
+  const files = e.dataTransfer?.files
+  if (files && files.length > 0) {
+    const fileList = Array.from(files)
+    const newFiles = fileList.filter(f => !uploadFiles.value.some(existing => existing.name === f.name && existing.size === f.size))
+    uploadFiles.value = [...uploadFiles.value, ...newFiles]
+  }
+}
+
+const getFileExtension = (filename: string) => {
+  if (!filename) return 'FILE'
+  const idx = filename.lastIndexOf('.')
+  return idx !== -1 ? filename.slice(idx + 1).toLowerCase() : 'FILE'
+}
+
+const getFileIconClass = (filename: string) => {
+  const ext = getFileExtension(filename)
+  switch (ext) {
+    case 'pdf': return 'bg-red-500 shadow-[0_0_4px_#ef4444]'
+    case 'doc':
+    case 'docx': return 'bg-blue-500 shadow-[0_0_4px_#3b82f6]'
+    case 'xls':
+    case 'xlsx': return 'bg-emerald-500 shadow-[0_0_4px_#10b981]'
+    case 'ppt':
+    case 'pptx': return 'bg-orange-500 shadow-[0_0_4px_#f97316]'
+    case 'txt':
+    case 'md': return 'bg-gray-500 shadow-[0_0_4px_#6b7280]'
+    default: return 'bg-primary shadow-[0_0_4px_#1e40af]'
+  }
+}
+
+const formatFileSize = (bytes: number) => {
+  if (bytes === 0) return '0 Bytes'
+  const k = 1024
+  const sizes = ['Bytes', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+
+const deleting = ref(false)
+const refreshingDocs = ref(false)
+const handleManualRefreshDocs = async () => {
+  const dsId = selectedDataset.value?.ragflow_dataset_id || selectedDataset.value?.id
+  if (!dsId) return
+  refreshingDocs.value = true
+  try {
+    await fetchDocumentsForDataset(dsId)
+    showToast('已刷新当前文档列表及状态', 'success')
+  } catch (err) {
+    showToast(extractError(err), 'error')
+  } finally {
+    refreshingDocs.value = false
+  }
+}
+
+const reparsingDocId = ref('')
+const handleReparseDocument = async (doc: any) => {
+  if (!isEngineReady.value) {
+    showToast('知识库引擎未连接，暂不能重新解析', 'warning')
+    return
+  }
+  reparsingDocId.value = doc.id
+  try {
+    await axios.post(`/api/portal/ragflow/datasets/${selectedDatasetId.value}/documents/parse`, {
+      ids: [doc.id]
+    })
+    showToast('已重新触发该文档的解析任务', 'success')
+    parsingDocIds.value = { ...parsingDocIds.value, [doc.id]: true }
+    await fetchDocumentsForDataset(selectedDatasetId.value)
+  } catch (err) {
+    showToast(extractError(err), 'error')
+  } finally {
+    reparsingDocId.value = ''
+  }
+}
 
 onUnmounted(() => {
-  for (const docId of parsePollTimers.keys()) {
-    unmarkDocParsing(docId)
+  for (const dsId of datasetPollTimers.keys()) {
+    stopDatasetPolling(dsId)
   }
 })
 
@@ -876,13 +1124,13 @@ onMounted(async () => {
                   <!-- Display doc count -->
                   <span
                     v-if="!dataset.is_missing_in_ragflow"
-                    class="text-[10px] px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 font-semibold"
+                    class="text-[10px] px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 font-semibold group-hover:hidden transition-all duration-150"
                   >
                     {{ dataset.doc_count ?? dataset.document_count ?? 0 }}
                   </span>
                   <span
                     v-else
-                    class="text-[10px] px-2 py-0.5 rounded-full bg-amber-100 text-amber-700"
+                    class="text-[10px] px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 group-hover:hidden transition-all duration-150"
                   >
                     失联
                   </span>
@@ -903,7 +1151,7 @@ onMounted(async () => {
                       v-if="canDelete && !isReadOnlyDataset(dataset)"
                       class="p-1 rounded hover:bg-red-50 text-gray-400 hover:text-red-600 transition-all bg-inherit"
                       title="删除知识库"
-                      @click.stop="deletingDataset = dataset"
+                      @click.stop="triggerDeleteDataset(dataset)"
                     >
                       <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -954,7 +1202,7 @@ onMounted(async () => {
                     <div class="flex items-center gap-2 shrink-0 min-w-[12px] justify-end">
                       <!-- Status indicators -->
                       <span
-                        class="w-1.5 h-1.5 rounded-full shrink-0 transition-all"
+                        class="w-1.5 h-1.5 rounded-full shrink-0 transition-all group-hover/doc:hidden"
                         :class="{
                           'bg-emerald-500 shadow-[0_0_4px_#10b981]': getDocStatus(doc) === 'parsed',
                           'bg-amber-500 animate-pulse shadow-[0_0_4px_#f59e0b]': getDocStatus(doc) === 'parsing',
@@ -999,16 +1247,36 @@ onMounted(async () => {
               </div>
               <p class="text-sm text-gray-500 mt-1.5">{{ selectedDataset.platform_description || selectedDataset.description || '暂无对该知识库的描述' }}</p>
             </div>
-            <button
-              v-if="canEdit && !isReadOnlyDataset(selectedDataset)"
-              class="px-4 py-2 text-sm font-medium border border-gray-200 rounded-xl hover:bg-gray-50 transition-all flex items-center gap-1.5 shrink-0"
-              @click="openEdit(selectedDataset)"
-            >
-              <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-              </svg>
-              编辑元数据
-            </button>
+            <div class="flex items-center gap-2 shrink-0">
+              <button
+                v-if="!selectedDataset.is_missing_in_ragflow"
+                class="p-2 border border-gray-200 rounded-xl hover:bg-gray-50 transition-all flex items-center justify-center text-gray-500 hover:text-primary hover:border-primary/30 shrink-0"
+                title="刷新文档及状态"
+                :disabled="refreshingDocs"
+                @click="handleManualRefreshDocs"
+              >
+                <svg 
+                  class="w-4 h-4" 
+                  :class="{ 'animate-spin': refreshingDocs }" 
+                  fill="none" 
+                  stroke="currentColor" 
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
+                </svg>
+              </button>
+              <button
+                v-if="canEdit && !isReadOnlyDataset(selectedDataset)"
+                class="px-4 py-2 text-sm font-medium border border-gray-200 rounded-xl hover:bg-gray-50 transition-all flex items-center gap-1.5"
+                @click="openEdit(selectedDataset)"
+              >
+                <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                </svg>
+                编辑元数据
+              </button>
+            </div>
           </div>
 
           <!-- RAG Parameters cards grid -->
@@ -1066,34 +1334,185 @@ onMounted(async () => {
             </div>
           </div>
 
+          <!-- 权限分配说明卡片 -->
+          <div class="space-y-2 bg-gray-50/20 p-4 rounded-xl border border-gray-150">
+            <div class="flex items-center justify-between">
+              <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider select-none">系统授权分配详情</h3>
+              <span v-if="loadingPermissions" class="text-xs text-gray-400 animate-pulse flex items-center gap-1 select-none">
+                <span class="w-2.5 h-2.5 rounded-full border border-gray-300 border-t-transparent animate-spin"></span>
+                正在读取权限分配...
+              </span>
+            </div>
+            
+            <div class="text-xs space-y-3 mt-1.5">
+              <!-- 可见性基本说明 -->
+              <p class="text-gray-500 leading-normal select-none">
+                公开级别为 
+                <span class="font-bold text-gray-800 uppercase px-1.5 py-0.5 rounded bg-gray-100 text-[10px]">{{ selectedDataset.visibility || 'Private' }}</span>。
+                <span v-if="selectedDataset.visibility === 'public'">此知识库全平台公开，所有配置该权限的角色或平台用户均有权进行检索。</span>
+                <span v-else-if="selectedDataset.visibility === 'team'">此知识库部门公开，创建者、系统管理员以及业务归属部门（{{ selectedDataset.owner || '未指派' }}）的用户有权访问。</span>
+                <span v-else>此知识库为私有，仅创建者、系统管理员以及下方被额外明确指派了权限的角色/用户有权进行访问。</span>
+              </p>
+
+              <!-- 被指派的用户/角色列表 -->
+              <div v-if="!loadingPermissions && (datasetPermissions.users.length || datasetPermissions.roles.length)" class="flex flex-col gap-2.5 pt-2 border-t border-gray-100">
+                <div v-if="datasetPermissions.roles.length" class="flex items-start gap-2">
+                  <span class="text-gray-400 font-medium shrink-0 mt-0.5 select-none">授权角色:</span>
+                  <div class="flex flex-wrap gap-1.5">
+                    <span 
+                      v-for="r in datasetPermissions.roles" 
+                      :key="r.code"
+                      class="px-2 py-0.5 rounded bg-blue-50 text-blue-700 font-semibold border border-blue-100/50 flex items-center gap-1 select-none"
+                    >
+                      <svg class="w-3 h-3 text-blue-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0z" />
+                      </svg>
+                      {{ r.name }} ({{ r.code }})
+                    </span>
+                  </div>
+                </div>
+                
+                <div v-if="datasetPermissions.users.length" class="flex items-start gap-2">
+                  <span class="text-gray-400 font-medium shrink-0 mt-0.5 select-none">授权用户:</span>
+                  <div class="flex flex-wrap gap-1.5">
+                    <span 
+                      v-for="u in datasetPermissions.users" 
+                      :key="u.user_name"
+                      class="px-2 py-0.5 rounded bg-emerald-50 text-emerald-700 font-semibold border border-emerald-100/50 flex items-center gap-1 select-none"
+                    >
+                      <svg class="w-3 h-3 text-emerald-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd" />
+                      </svg>
+                      {{ u.real_name || u.user_name }} ({{ u.user_name }})
+                    </span>
+                  </div>
+                </div>
+              </div>
+              
+              <div v-else-if="!loadingPermissions" class="text-gray-400 italic pt-2 border-t border-gray-100 select-none">
+                未分配额外的用户或角色角色访问权限。
+              </div>
+            </div>
+          </div>
+
           <!-- Document Upload Region -->
           <div class="space-y-3">
             <h3 class="text-sm font-semibold text-gray-800">上传新文档到此知识库</h3>
             <div
               v-if="canUpload && !selectedDataset.is_missing_in_ragflow && !isReadOnlyDataset(selectedDataset)"
-              class="border-2 border-dashed border-gray-300 hover:border-primary rounded-2xl p-6 transition-all flex flex-col items-center justify-center bg-gray-50/30 group"
+              class="border-2 border-dashed rounded-2xl p-6 transition-all duration-300 flex flex-col items-center justify-center bg-gray-50/30 group relative overflow-hidden"
+              :class="[
+                isDragOver ? 'border-primary bg-primary/5 scale-[1.01]' : 'border-gray-300 hover:border-primary',
+                uploading ? 'pointer-events-none' : ''
+              ]"
+              @dragover.prevent="isDragOver = true"
+              @dragleave.prevent="isDragOver = false"
+              @drop.prevent="onFileDrop"
             >
-              <svg class="w-10 h-10 text-gray-400 group-hover:text-primary transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
-              </svg>
+              <!-- 隐藏的真实多文件输入框 -->
               <input
+                ref="fileInputRef"
                 type="file"
-                class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-xl file:border-0 file:text-sm file:font-semibold file:bg-primary/10 file:text-primary hover:file:bg-primary/20 file:cursor-pointer mt-4"
-                :disabled="!isEngineReady"
+                multiple
+                class="hidden"
+                accept=".pdf,.docx,.doc,.txt,.csv,.xlsx,.xls,.pptx,.ppt,.md"
+                :disabled="uploading || !isEngineReady"
                 @change="onFileChange"
               />
-              <div class="flex items-center gap-3 mt-4 w-full max-w-xs">
-                <button
-                  class="w-full px-4 py-2.5 rounded-xl bg-gray-900 text-white text-sm font-semibold shadow hover:bg-gray-800 transition-all disabled:opacity-50"
-                  :disabled="!uploadFile || !isEngineReady"
-                  @click="uploadDocument"
-                >
-                  上传至服务器
-                </button>
+
+              <!-- 上传中全局模糊遮罩 -->
+              <div
+                v-if="uploading"
+                class="absolute inset-0 bg-white/95 backdrop-blur-sm flex flex-col items-center justify-center rounded-2xl transition-all duration-300 z-10 p-4"
+              >
+                <span class="w-9 h-9 rounded-full border-2 border-primary border-t-transparent animate-spin"></span>
+                <p class="text-xs font-bold text-gray-800 mt-4 text-center animate-pulse leading-relaxed">
+                  {{ uploadProgressText || '正在上传文件，请稍候...' }}
+                </p>
               </div>
-              <p class="text-xs text-gray-400 mt-2">支持 PDF, DOCX, TXT 等任意结构化文档，上传后可在左侧树节点展开管理和手动解析。</p>
+
+              <!-- 1. 未选择文件时的引导界面 -->
+              <div 
+                v-if="uploadFiles.length === 0"
+                class="w-full flex flex-col items-center justify-center py-5 cursor-pointer select-none"
+                @click="triggerFileSelect"
+              >
+                <div class="w-12 h-12 rounded-full bg-primary/5 flex items-center justify-center text-primary group-hover:scale-110 transition-transform duration-300">
+                  <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                  </svg>
+                </div>
+                <p class="text-sm font-medium text-gray-700 mt-3">
+                  将一个或多个文件拖拽至此处，或 <span class="text-primary hover:underline font-semibold">点击上传</span>
+                </p>
+                <p class="text-xs text-gray-400 mt-1.5">支持多文件上传，类型包含 PDF, DOCX, TXT, MD, XLSX 等</p>
+              </div>
+
+              <!-- 2. 已选择文件时的批量卡片队列展示 -->
+              <div v-else class="w-full space-y-4">
+                <div class="flex items-center justify-between text-xs text-gray-400 border-b pb-2 select-none">
+                  <span>待上传队列 ({{ uploadFiles.length }} 个文件)</span>
+                  <button class="text-red-500 hover:underline font-semibold" @click="clearAllUploadFiles">清空全部</button>
+                </div>
+                
+                <!-- 待上传文件滚动卡片容器 -->
+                <div class="max-h-[160px] overflow-y-auto pr-1 space-y-2 custom-scrollbar">
+                  <div 
+                    v-for="(f, fIdx) in uploadFiles" 
+                    :key="fIdx"
+                    class="flex items-center gap-3 p-2.5 bg-white rounded-xl border border-gray-150 shadow-sm relative group/card"
+                  >
+                    <!-- 文件后缀高亮块 -->
+                    <div 
+                      class="w-8 h-8 rounded-lg flex items-center justify-center text-white shrink-0 font-bold text-[9px] uppercase select-none"
+                      :class="getFileIconClass(f.name)"
+                    >
+                      {{ getFileExtension(f.name) }}
+                    </div>
+                    <!-- 文件名与大小 -->
+                    <div class="flex-1 min-w-0">
+                      <p class="text-xs font-semibold text-gray-800 truncate" :title="f.name">
+                        {{ f.name }}
+                      </p>
+                      <p class="text-[10px] text-gray-400 mt-0.5 select-none">
+                        {{ formatFileSize(f.size) }}
+                      </p>
+                    </div>
+                    <!-- 移出队列按钮 -->
+                    <button 
+                      class="p-1 rounded-full text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+                      title="移出队列"
+                      @click="removeUploadFile(fIdx)"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+
+                <!-- 动作按钮区 -->
+                <div class="flex items-center justify-center gap-3 pt-2">
+                  <button
+                    class="px-4 py-2 border border-gray-200 rounded-xl hover:bg-gray-50 text-gray-600 text-xs font-semibold transition-all"
+                    @click="triggerFileSelect"
+                  >
+                    继续添加文件
+                  </button>
+                  <button
+                    class="px-5 py-2 rounded-xl bg-primary hover:bg-primary/90 text-white text-xs font-semibold shadow-md shadow-primary/10 hover:shadow-lg transition-all flex items-center justify-center gap-1.5 disabled:opacity-50"
+                    :disabled="uploading || !isEngineReady"
+                    @click="uploadDocument"
+                  >
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+                    </svg>
+                    <span>确认批量上传解析</span>
+                  </button>
+                </div>
+              </div>
             </div>
-            <div v-else class="rounded-xl bg-gray-50/50 p-4 border text-center text-sm text-gray-400">
+            <div v-else class="rounded-xl bg-gray-50/50 p-4 border text-center text-sm text-gray-400 select-none">
               <span v-if="isReadOnlyDataset(selectedDataset)" class="text-amber-600 font-medium">⚠️ 只读模式：您不是该知识库的创建人，仅可查看，不可修改或上传文档</span>
               <span v-else>当前状态无法向知识库上传文档（可能由于 RAGFlow 失联或权限受限）</span>
             </div>
@@ -1201,6 +1620,97 @@ onMounted(async () => {
             <div class="bg-gray-50/50 p-4 rounded-xl border border-gray-150">
               <span class="text-xs text-gray-400 font-semibold uppercase tracking-wider block">上传及最后更新时间</span>
               <span class="text-sm font-bold text-gray-800 mt-2.5 block truncate">{{ formatTime(selectedDocument.update_time || selectedDocument.created_at) }}</span>
+            </div>
+          </div>
+
+          <!-- RAG 解析状态诊断看板 -->
+          <div 
+            v-if="selectedDocument"
+            class="p-4 rounded-xl border select-none"
+            :class="{
+              'bg-blue-50/20 border-blue-100': getDocStatus(selectedDocument) === 'parsing',
+              'bg-red-50/20 border-red-100': getDocStatus(selectedDocument) === 'failed',
+              'bg-emerald-50/20 border-emerald-100': getDocStatus(selectedDocument) === 'parsed',
+              'bg-gray-50/30 border-gray-150': getDocStatus(selectedDocument) === 'unparsed'
+            }"
+          >
+            <div class="flex items-start justify-between gap-4">
+              <div class="space-y-1.5 flex-1 min-w-0">
+                <span class="text-xs font-bold uppercase tracking-wider block" :class="{
+                  'text-blue-600': getDocStatus(selectedDocument) === 'parsing',
+                  'text-red-600': getDocStatus(selectedDocument) === 'failed',
+                  'text-emerald-600': getDocStatus(selectedDocument) === 'parsed',
+                  'text-gray-400': getDocStatus(selectedDocument) === 'unparsed'
+                }">
+                  RAG 解析状态诊断
+                </span>
+                
+                <!-- 解析中：显示进度条 -->
+                <div v-if="getDocStatus(selectedDocument) === 'parsing'" class="space-y-2 mt-2">
+                  <div class="flex items-center justify-between text-xs">
+                    <span class="text-gray-500 font-medium">切片构建进度：</span>
+                    <span class="font-bold text-blue-600">{{ ((selectedDocument.progress ?? 0) * 100).toFixed(1) }}%</span>
+                  </div>
+                  <div class="w-full bg-blue-100/50 rounded-full h-2 overflow-hidden">
+                    <div 
+                      class="bg-blue-500 h-2 rounded-full transition-all duration-500 ease-out"
+                      :style="{ width: `${Math.min(100, (selectedDocument.progress ?? 0) * 100)}%` }"
+                    ></div>
+                  </div>
+                  <p class="text-[11px] text-blue-500/80 font-mono italic mt-1.5 truncate" :title="selectedDocument.progress_msg">
+                    实时状态: {{ selectedDocument.progress_msg || '正在启动解析器...' }}
+                  </p>
+                </div>
+
+                <!-- 解析失败：显示红字报错 -->
+                <div v-else-if="getDocStatus(selectedDocument) === 'failed'" class="space-y-1.5 mt-2">
+                  <div class="flex items-start gap-1.5 text-xs text-red-600 bg-red-50/50 p-2.5 rounded-lg border border-red-100/30">
+                    <svg class="w-4 h-4 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                    <div class="break-all font-mono leading-normal">
+                      <strong>解析失败原因：</strong>
+                      {{ selectedDocument.progress_msg || '未知外部切片解析故障。请确保文件可读且非加密 PDF。' }}
+                    </div>
+                  </div>
+                </div>
+
+                <!-- 解析完成 -->
+                <div v-else-if="getDocStatus(selectedDocument) === 'parsed'" class="text-xs text-emerald-600/80 mt-2 flex items-center gap-1.5">
+                  <svg class="w-4 h-4 text-emerald-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
+                  </svg>
+                  <span>该文档已顺利完成切片构建与向量化，当前可提供高质量的语义召回服务。</span>
+                </div>
+
+                <!-- 未解析 -->
+                <div v-else class="text-xs text-gray-500 mt-2 flex items-center gap-1.5">
+                  <svg class="w-4 h-4 text-gray-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <span>文档处于就绪态，尚未执行分块解析。请点击上方按钮触发解析。</span>
+                </div>
+              </div>
+
+              <!-- 右侧独立控制：失败时的一键重新解析 -->
+              <div v-if="getDocStatus(selectedDocument) === 'failed' && !isReadOnlyDataset(selectedDataset)" class="shrink-0 self-center">
+                <button
+                  class="px-3 py-1.5 rounded-lg border border-red-200 hover:border-red-300 bg-white hover:bg-red-50 text-red-600 hover:text-red-700 text-xs font-semibold shadow-sm transition-all flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
+                  :disabled="reparsingDocId === selectedDocument.id || !isEngineReady"
+                  @click="handleReparseDocument(selectedDocument)"
+                >
+                  <svg 
+                    class="w-3.5 h-3.5" 
+                    :class="{ 'animate-spin': reparsingDocId === selectedDocument.id }"
+                    fill="none" 
+                    stroke="currentColor" 
+                    viewBox="0 0 24 24"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 1121.21 15H18" />
+                  </svg>
+                  <span>重新解析</span>
+                </button>
+              </div>
             </div>
           </div>
 
@@ -1338,9 +1848,10 @@ onMounted(async () => {
     <!-- Confirm delete modals -->
     <ConfirmModal
       v-if="deletingDataset"
-      title="删除知识库"
-      :message="`确定真实删除知识库「${deletingDataset.platform_name || deletingDataset.name}」吗？RAGFlow 侧相应集群数据也将同步卸载，此操作不可逆。`"
-      confirm-text="确认物理删除"
+      :title="deletingDataset.is_missing_in_ragflow ? '清理失效残留配置' : '删除知识库'"
+      :message="deleteDatasetMessage"
+      :confirm-text="deletingDataset.is_missing_in_ragflow ? '确认清理残留配置' : '确认物理删除'"
+      :loading="deleting"
       @confirm="confirmDeleteDataset"
       @cancel="deletingDataset = null"
     />
@@ -1349,6 +1860,7 @@ onMounted(async () => {
       title="删除文档"
       :message="`确定从当前知识库中删除文档「${deletingDocument.name || deletingDocument.id}」吗？已解析的 Vector Chunks 数据将同步清空，此操作不可逆。`"
       confirm-text="确认删除"
+      :loading="deleting"
       @confirm="confirmDeleteDocument"
       @cancel="deletingDocument = null"
     />

--- a/frontend/src/views/KnowledgeBaseManagement.vue
+++ b/frontend/src/views/KnowledgeBaseManagement.vue
@@ -42,6 +42,8 @@ type KnowledgeDocument = {
   size?: number
   update_time?: string
   created_at?: string
+  progress?: number
+  progress_msg?: string
 }
 
 type RagFlowConfigSummary = {
@@ -537,6 +539,7 @@ const uploadDocument = async () => {
   
   for (let i = 0; i < total; i++) {
     const file = uploadFiles.value[i]
+    if (!file) continue
     uploadProgressText.value = `正在上传并解析: ${i + 1} / ${total} (${file.name})`
     
     const payload = new FormData()
@@ -652,8 +655,9 @@ const startDatasetStatusPolling = (dsId: string) => {
       await fetchDocumentsForDataset(dsId)
       
       // 同步当前选中的文档详情信息
-      if (selectedDocument.value && selectedDatasetId.value === dsId) {
-        const updatedDoc = (documentsMap.value[dsId] || []).find(d => d.id === selectedDocument.value.id)
+      const currentDocument = selectedDocument.value
+      if (currentDocument && selectedDatasetId.value === dsId) {
+        const updatedDoc = (documentsMap.value[dsId] || []).find(d => d.id === currentDocument.id)
         if (updatedDoc) {
           selectedDocument.value = updatedDoc
         }

--- a/frontend/src/views/KnowledgeRetrievalTest.vue
+++ b/frontend/src/views/KnowledgeRetrievalTest.vue
@@ -30,18 +30,34 @@ const { hasPermission } = useUser()
 const showDatasetSelector = ref(false)
 const datasetIds = ref<string[]>([])
 const query = ref('')
+
+// A/B 对照检索模式状态
+const isCompareMode = ref(false)
+
+// A 参数组使用原本的变量名
 const topK = ref(5)
 const similarityThreshold = ref(0.2)
 const vectorSimilarityWeight = ref(0.3)
+
+// B 参数组
+const topK_B = ref(8)
+const similarityThreshold_B = ref(0.2)
+const vectorSimilarityWeight_B = ref(0.3)
+
 const loading = ref(false)
+const loading_B = ref(false)
 const results = ref<RetrievalChunk[]>([])
+const results_B = ref<RetrievalChunk[]>([])
 const errorMessage = ref('')
+const errorMessage_B = ref('')
+
 const ragflowConfig = ref<RagFlowConfigSummary | null>(null)
 
 const canTest = computed(() => hasPermission('element:knowledge:test_retrieval') && isKnowledgeEnabled.value)
 const isKnowledgeEnabled = computed(() => ragflowConfig.value?.knowledge_base_enabled !== false)
 const datasetIdsText = computed(() => datasetIds.value.join(','))
 const ragflowApiUrl = computed(() => ragflowConfig.value?.api_url || '未配置')
+
 const friendlyRagFlowError = computed(() => {
   if (!errorMessage.value) return ''
   const lower = errorMessage.value.toLowerCase()
@@ -54,6 +70,20 @@ const friendlyRagFlowError = computed(() => {
     return '当前无法连接 RAGFlow 服务，请确认 RAGFlow 服务是否可访问、网关是否正常，以及系统配置中的 RAGFlow 地址/API Key 是否正确。'
   }
   return errorMessage.value
+})
+
+const friendlyRagFlowErrorB = computed(() => {
+  if (!errorMessage_B.value) return ''
+  const lower = errorMessage_B.value.toLowerCase()
+  if (
+    lower.includes('ragflow') ||
+    lower.includes('bad gateway') ||
+    lower.includes('failed to connect') ||
+    lower.includes('configuration missing')
+  ) {
+    return '当前无法连接 RAGFlow 服务，请确认 RAGFlow 服务是否可访问、网关是否正常，以及系统配置中的 RAGFlow 地址/API Key 是否正确。'
+  }
+  return errorMessage_B.value
 })
 
 const extractError = (err: unknown) => {
@@ -75,7 +105,15 @@ const validate = () => {
     return false
   }
   if (topK.value < 1 || topK.value > 50) {
-    showToast('top_k 需在 1 到 50 之间', 'warning')
+    showToast('A组 top_k 需在 1 到 50 之间', 'warning')
+    return false
+  }
+  return true
+}
+
+const validateB = () => {
+  if (topK_B.value < 1 || topK_B.value > 50) {
+    showToast('B组 top_k 需在 1 到 50 之间', 'warning')
     return false
   }
   return true
@@ -87,24 +125,71 @@ const runRetrieval = async () => {
     return
   }
   if (!validate()) return
-  loading.value = true
+  if (isCompareMode.value && !validateB()) return
+
   errorMessage.value = ''
-  results.value = []
-  try {
-    const response = await axios.post('/api/portal/ragflow/retrieval-test', {
+  errorMessage_B.value = ''
+
+  if (!isCompareMode.value) {
+    loading.value = true
+    results.value = []
+    results_B.value = []
+    try {
+      const response = await axios.post('/api/portal/ragflow/retrieval-test', {
+        query: query.value.trim(),
+        dataset_ids: datasetIds.value,
+        top_k: topK.value,
+        similarity_threshold: similarityThreshold.value,
+        vector_similarity_weight: vectorSimilarityWeight.value
+      })
+      results.value = response.data?.data || []
+      showToast(`检索完成，命中 ${results.value.length} 条`, 'success')
+    } catch (err) {
+      errorMessage.value = extractError(err)
+      showToast(errorMessage.value, 'error')
+    } finally {
+      loading.value = false
+    }
+  } else {
+    loading.value = true
+    loading_B.value = true
+    results.value = []
+    results_B.value = []
+    
+    const promiseA = axios.post('/api/portal/ragflow/retrieval-test', {
       query: query.value.trim(),
       dataset_ids: datasetIds.value,
       top_k: topK.value,
       similarity_threshold: similarityThreshold.value,
       vector_similarity_weight: vectorSimilarityWeight.value
+    }).then(response => {
+      results.value = response.data?.data || []
+    }).catch(err => {
+      errorMessage.value = extractError(err)
+    }).finally(() => {
+      loading.value = false
     })
-    results.value = response.data?.data || []
-    showToast(`检索完成，命中 ${results.value.length} 条`, 'success')
-  } catch (err) {
-    errorMessage.value = extractError(err)
-    showToast(errorMessage.value, 'error')
-  } finally {
-    loading.value = false
+
+    const promiseB = axios.post('/api/portal/ragflow/retrieval-test', {
+      query: query.value.trim(),
+      dataset_ids: datasetIds.value,
+      top_k: topK_B.value,
+      similarity_threshold: similarityThreshold_B.value,
+      vector_similarity_weight: vectorSimilarityWeight_B.value
+    }).then(response => {
+      results_B.value = response.data?.data || []
+    }).catch(err => {
+      errorMessage_B.value = extractError(err)
+    }).finally(() => {
+      loading_B.value = false
+    })
+
+    await Promise.all([promiseA, promiseB])
+    if (errorMessage.value || errorMessage_B.value) {
+      showToast('对照检索执行完毕，部分请求可能遇到错误', 'warning')
+    } else {
+      showToast(`对照检索完成，A组命中 ${results.value.length} 条，B组命中 ${results_B.value.length} 条`, 'success')
+    }
   }
 }
 
@@ -132,6 +217,29 @@ const copyResult = (chunk: RetrievalChunk) => {
 const formatScore = (chunk: RetrievalChunk) => {
   const score = chunk.similarity ?? chunk.score
   return typeof score === 'number' ? score.toFixed(4) : '-'
+}
+
+const highlightContent = (content?: string, q?: string) => {
+  const text = content || ''
+  if (!text.trim()) return '无内容片段'
+  const search = q || ''
+  if (!search.trim()) return text
+
+  const keywords = search.trim().split(/[\s,，.。;；!！?？|]+/).filter(x => x.length > 0)
+  if (keywords.length === 0) return text
+
+  let highlighted = text
+  try {
+    keywords.forEach(keyword => {
+      if (keyword.length === 1 && !/[\u4e00-\u9fa5]/.test(keyword)) return
+      const escaped = keyword.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+      const regex = new RegExp(`(?<!<[^>]*)((${escaped}))(?![^<]*>)`, 'gi')
+      highlighted = highlighted.replace(regex, '<mark class="bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-100 rounded px-0.5 font-semibold">$1</mark>')
+    })
+  } catch (e) {
+    console.error('Highlight error:', e)
+  }
+  return highlighted
 }
 
 const fetchRagFlowConfig = async () => {
@@ -219,38 +327,88 @@ onMounted(fetchRagFlowConfig)
             ></textarea>
           </div>
 
-          <!-- Parameters -->
-          <div class="space-y-3">
+          <!-- Compare Mode Switch -->
+          <div class="flex items-center justify-between border-t border-b border-gray-100 py-3 shrink-0 select-none">
+            <span class="text-xs font-bold text-gray-700">A/B 对照检索模式</span>
+            <label class="relative inline-flex items-center cursor-pointer select-none">
+              <input type="checkbox" v-model="isCompareMode" class="sr-only peer" />
+              <div class="w-9 h-5 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-primary"></div>
+            </label>
+          </div>
+
+          <!-- Parameters Block -->
+          <div v-if="!isCompareMode" class="space-y-3">
             <label class="block text-xs font-semibold text-gray-500 uppercase tracking-wider">参数调节</label>
             <div class="grid grid-cols-3 gap-3">
               <div>
-                <span class="block text-xs text-gray-500 mb-1">top_k</span>
-                <input v-model.number="topK" type="number" min="1" max="50" :disabled="!isKnowledgeEnabled" class="w-full border border-gray-200 rounded-lg px-2.5 py-1.5 text-sm disabled:cursor-not-allowed disabled:bg-gray-50" />
+                <span class="block text-[10px] text-gray-500 mb-1">top_k</span>
+                <input v-model.number="topK" type="number" min="1" max="50" :disabled="!isKnowledgeEnabled" class="w-full border border-gray-200 rounded-lg px-2.5 py-1.5 text-xs disabled:cursor-not-allowed disabled:bg-gray-50" />
               </div>
               <div>
-                <span class="block text-xs text-gray-500 mb-1">相似度阈值</span>
-                <input v-model.number="similarityThreshold" type="number" min="0" max="1" step="0.01" :disabled="!isKnowledgeEnabled" class="w-full border border-gray-200 rounded-lg px-2.5 py-1.5 text-sm disabled:cursor-not-allowed disabled:bg-gray-50" />
+                <span class="block text-[10px] text-gray-500 mb-1">相似度阈值</span>
+                <input v-model.number="similarityThreshold" type="number" min="0" max="1" step="0.01" :disabled="!isKnowledgeEnabled" class="w-full border border-gray-200 rounded-lg px-2.5 py-1.5 text-xs disabled:cursor-not-allowed disabled:bg-gray-50" />
               </div>
               <div>
-                <span class="block text-xs text-gray-500 mb-1">向量权重</span>
-                <input v-model.number="vectorSimilarityWeight" type="number" min="0" max="1" step="0.01" :disabled="!isKnowledgeEnabled" class="w-full border border-gray-200 rounded-lg px-2.5 py-1.5 text-sm disabled:cursor-not-allowed disabled:bg-gray-50" />
+                <span class="block text-[10px] text-gray-500 mb-1">向量权重</span>
+                <input v-model.number="vectorSimilarityWeight" type="number" min="0" max="1" step="0.01" :disabled="!isKnowledgeEnabled" class="w-full border border-gray-200 rounded-lg px-2.5 py-1.5 text-xs disabled:cursor-not-allowed disabled:bg-gray-50" />
+              </div>
+            </div>
+          </div>
+
+          <!-- Compare Mode Parameters Panel -->
+          <div v-else class="space-y-4">
+            <!-- Group A Config Card -->
+            <div class="p-3 border border-gray-200 rounded-xl bg-gray-50/20 space-y-2">
+              <span class="text-xs font-bold text-gray-800">对照组 A 参数</span>
+              <div class="grid grid-cols-3 gap-2">
+                <div>
+                  <span class="block text-[10px] text-gray-400 mb-1">top_k</span>
+                  <input v-model.number="topK" type="number" min="1" max="50" class="w-full border border-gray-200 rounded-lg px-2 py-1 text-xs" />
+                </div>
+                <div>
+                  <span class="block text-[10px] text-gray-400 mb-1">相似度阈值</span>
+                  <input v-model.number="similarityThreshold" type="number" min="0" max="1" step="0.01" class="w-full border border-gray-200 rounded-lg px-2 py-1 text-xs" />
+                </div>
+                <div>
+                  <span class="block text-[10px] text-gray-400 mb-1">向量权重</span>
+                  <input v-model.number="vectorSimilarityWeight" type="number" min="0" max="1" step="0.01" class="w-full border border-gray-200 rounded-lg px-2 py-1 text-xs" />
+                </div>
+              </div>
+            </div>
+
+            <!-- Group B Config Card -->
+            <div class="p-3 border border-gray-200 rounded-xl bg-gray-50/20 space-y-2">
+              <span class="text-xs font-bold text-gray-800">对照组 B 参数</span>
+              <div class="grid grid-cols-3 gap-2">
+                <div>
+                  <span class="block text-[10px] text-gray-400 mb-1">top_k</span>
+                  <input v-model.number="topK_B" type="number" min="1" max="50" class="w-full border border-gray-200 rounded-lg px-2 py-1 text-xs" />
+                </div>
+                <div>
+                  <span class="block text-[10px] text-gray-400 mb-1">相似度阈值</span>
+                  <input v-model.number="similarityThreshold_B" type="number" min="0" max="1" step="0.01" class="w-full border border-gray-200 rounded-lg px-2 py-1 text-xs" />
+                </div>
+                <div>
+                  <span class="block text-[10px] text-gray-400 mb-1">向量权重</span>
+                  <input v-model.number="vectorSimilarityWeight_B" type="number" min="0" max="1" step="0.01" class="w-full border border-gray-200 rounded-lg px-2 py-1 text-xs" />
+                </div>
               </div>
             </div>
           </div>
 
           <!-- Execute -->
-          <div class="pt-2 mt-auto">
+          <div class="pt-2 mt-auto shrink-0">
             <button
               type="button"
               class="w-full px-5 py-2.5 rounded-xl bg-gray-900 hover:bg-gray-800 text-white text-sm font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
-              :disabled="loading || !canTest"
+              :disabled="loading || loading_B || !canTest"
               @click="runRetrieval"
             >
-              <svg v-if="loading" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+              <svg v-if="loading || loading_B" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
               </svg>
-              {{ loading ? '检索中...' : '执行检索' }}
+              <span>{{ (loading || loading_B) ? '检索中...' : isCompareMode ? '执行对照检索' : '执行检索' }}</span>
             </button>
             <p class="text-[10px] text-gray-400 mt-2 text-center">检索测试会写入审计日志</p>
           </div>
@@ -261,56 +419,159 @@ onMounted(fetchRagFlowConfig)
       <!-- Right: Results Panel -->
       <section class="flex-1 bg-white rounded-2xl border border-gray-200 shadow-sm flex flex-col min-w-0 overflow-hidden">
         <!-- Results header -->
-        <div class="px-5 py-3.5 border-b border-gray-100 flex items-center justify-between shrink-0">
+        <div class="px-5 py-3.5 border-b border-gray-100 flex items-center justify-between shrink-0 select-none">
           <div class="flex items-center gap-2">
-            <h2 class="font-semibold text-gray-900">命中结果</h2>
-            <span v-if="results.length" class="text-xs bg-primary/10 text-primary font-bold px-2 py-0.5 rounded-full">{{ results.length }}</span>
+            <h2 class="font-semibold text-gray-900">{{ isCompareMode ? '对照检索测试' : '命中结果' }}</h2>
+            <span v-if="!isCompareMode && results.length" class="text-xs bg-primary/10 text-primary font-bold px-2 py-0.5 rounded-full">{{ results.length }}</span>
+            <span v-else-if="isCompareMode" class="text-xs bg-primary/10 text-primary font-bold px-2 py-0.5 rounded-full">A/B 对照模式</span>
           </div>
-          <span class="text-xs text-gray-400">{{ results.length > 0 ? `共 ${results.length} 条命中` : '等待检索' }}</span>
+          <span class="text-xs text-gray-400">
+            {{ isCompareMode ? '双栏并发对比中' : results.length > 0 ? `共 ${results.length} 条命中` : '等待检索' }}
+          </span>
         </div>
 
-        <!-- Error alert -->
-        <div v-if="errorMessage" class="mx-4 mt-4 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 shrink-0">
-          <div class="font-semibold">RAGFlow 暂时不可用</div>
-          <div class="mt-1">{{ friendlyRagFlowError }}</div>
-          <div class="mt-2 text-xs text-amber-700">
-            配置地址：<a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" :title="ragflowApiUrl" class="font-mono hover:underline truncate max-w-[200px] sm:max-w-[300px] inline-block align-bottom">{{ ragflowApiUrl }}</a>
+        <!-- 1. 常规模式列表 -->
+        <div v-if="!isCompareMode" class="flex-1 flex flex-col min-h-0 overflow-hidden">
+          <!-- Error alert -->
+          <div v-if="errorMessage" class="mx-4 mt-4 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 shrink-0">
+            <div class="font-semibold">RAGFlow 暂时不可用</div>
+            <div class="mt-1">{{ friendlyRagFlowError }}</div>
+            <div class="mt-2 text-xs text-amber-700">
+              配置地址：<a :href="ragflowApiUrl" target="_blank" rel="noopener noreferrer" :title="ragflowApiUrl" class="font-mono hover:underline truncate max-w-[200px] sm:max-w-[300px] inline-block align-bottom">{{ ragflowApiUrl }}</a>
+            </div>
+            <div class="mt-1 text-xs text-amber-600">原始错误：{{ errorMessage }}</div>
           </div>
-          <div class="mt-1 text-xs text-amber-600">原始错误：{{ errorMessage }}</div>
-        </div>
 
-        <!-- Results body (scrollable) -->
-        <div class="flex-1 overflow-y-auto">
-          <!-- Loading state -->
-          <div v-if="loading" class="flex flex-col items-center justify-center h-full gap-3 text-gray-400">
-            <span class="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin"></span>
-            <span class="text-sm">正在检索...</span>
-          </div>
-          <!-- Empty state -->
-          <div v-else-if="results.length === 0" class="flex flex-col items-center justify-center h-full gap-3 text-gray-400">
-            <svg class="w-12 h-12 text-gray-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
-            <span class="text-sm">{{ isKnowledgeEnabled ? '在左侧输入条件后执行检索' : '知识库功能未开启' }}</span>
-          </div>
-          <!-- Results list -->
-          <div v-else class="divide-y divide-gray-100">
-            <article v-for="(chunk, idx) in results" :key="chunk.chunk_id || chunk.id" class="p-5 space-y-3 hover:bg-gray-50/50 transition-colors">
-              <div class="flex items-start justify-between gap-4">
-                <div class="min-w-0 flex-1">
-                  <div class="flex items-center gap-2">
-                    <span class="text-xs font-bold text-gray-400 font-mono shrink-0">#{{ idx + 1 }}</span>
-                    <h3 class="font-semibold text-gray-900 truncate">{{ chunk.document_name || chunk.doc_name || '未知文档' }}</h3>
+          <div class="flex-1 overflow-y-auto">
+            <!-- Loading state -->
+            <div v-if="loading" class="flex flex-col items-center justify-center h-full gap-3 text-gray-400 select-none">
+              <span class="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin"></span>
+              <span class="text-sm">正在检索...</span>
+            </div>
+            <!-- Empty state -->
+            <div v-else-if="results.length === 0" class="flex flex-col items-center justify-center h-full gap-3 text-gray-400 select-none">
+              <svg class="w-12 h-12 text-gray-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <span class="text-sm">{{ isKnowledgeEnabled ? '在左侧输入条件后执行检索' : '知识库功能未开启' }}</span>
+            </div>
+            <!-- Results list -->
+            <div v-else class="divide-y divide-gray-100">
+              <article v-for="(chunk, idx) in results" :key="chunk.chunk_id || chunk.id" class="p-5 space-y-3 hover:bg-gray-50/50 transition-colors">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2">
+                      <span class="text-xs font-bold text-gray-400 font-mono shrink-0">#{{ idx + 1 }}</span>
+                      <h3 class="font-semibold text-gray-900 truncate" :title="chunk.document_name || chunk.doc_name">{{ chunk.document_name || chunk.doc_name || '未知文档' }}</h3>
+                    </div>
+                    <p class="text-xs text-gray-500 mt-1 font-mono">
+                      Chunk: {{ chunk.chunk_id || chunk.id || '-' }} · 相似度: <span class="font-bold" :class="(chunk.similarity ?? chunk.score ?? 0) >= 0.5 ? 'text-emerald-600' : 'text-amber-600'">{{ formatScore(chunk) }}</span>
+                    </p>
                   </div>
-                  <p class="text-xs text-gray-500 mt-1 font-mono">
-                    Chunk: {{ chunk.chunk_id || chunk.id || '-' }} · 相似度: <span class="font-bold" :class="(chunk.similarity ?? chunk.score ?? 0) >= 0.5 ? 'text-emerald-600' : 'text-amber-600'">{{ formatScore(chunk) }}</span>
-                  </p>
+                  <button class="px-2.5 py-1.5 rounded-lg border border-gray-200 text-xs hover:bg-gray-100 transition-colors shrink-0" @click="copyResult(chunk)">复制</button>
                 </div>
-                <button class="px-2.5 py-1.5 rounded-lg border border-gray-200 text-xs hover:bg-gray-100 transition-colors shrink-0" @click="copyResult(chunk)">复制</button>
-              </div>
-              <p class="text-sm text-gray-700 whitespace-pre-wrap bg-gray-50 rounded-xl p-4 leading-relaxed border border-gray-100">{{ chunk.content || chunk.text || '无内容片段' }}</p>
-            </article>
+                <div
+                  class="text-sm text-gray-700 whitespace-pre-wrap bg-gray-50 rounded-xl p-4 leading-relaxed border border-gray-100"
+                  v-html="highlightContent(chunk.content || chunk.text, query)"
+                ></div>
+              </article>
+            </div>
           </div>
+        </div>
+
+        <!-- 2. A/B 对照模式双栏并排列表 -->
+        <div v-else class="flex-1 flex divide-x divide-gray-150 min-h-0 overflow-hidden">
+          
+          <!-- Column A (Left) -->
+          <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
+            <!-- Header A -->
+            <div class="px-4 py-2 border-b border-gray-100 bg-gray-50/50 flex items-center justify-between shrink-0 select-none">
+              <span class="text-xs font-bold text-gray-700">对照组 A (K={{ topK }} · 阈值 {{ similarityThreshold }})</span>
+              <span v-if="results.length" class="text-[10px] bg-primary/10 text-primary font-bold px-1.5 py-0.5 rounded-full">{{ results.length }}</span>
+            </div>
+
+            <!-- Error A -->
+            <div v-if="errorMessage" class="mx-3 mt-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 shrink-0">
+              <div class="font-semibold truncate">A组错误：{{ errorMessage }}</div>
+            </div>
+
+            <!-- Body A -->
+            <div class="flex-1 overflow-y-auto custom-scrollbar">
+              <div v-if="loading" class="flex flex-col items-center justify-center h-full gap-2 text-gray-400 select-none py-10">
+                <span class="w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin"></span>
+                <span class="text-xs">A组正在检索...</span>
+              </div>
+              <div v-else-if="results.length === 0" class="flex flex-col items-center justify-center h-full gap-2 text-gray-400 select-none py-10">
+                <span class="text-xs">A组暂无召回数据</span>
+              </div>
+              <div v-else class="divide-y divide-gray-100">
+                <article v-for="(chunk, idx) in results" :key="'a-' + (chunk.chunk_id || chunk.id)" class="p-4 space-y-2 hover:bg-gray-50/50 transition-colors">
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-1.5">
+                        <span class="text-[10px] font-bold text-gray-400 font-mono shrink-0">#{{ idx + 1 }}</span>
+                        <h4 class="text-xs font-bold text-gray-800 truncate" :title="chunk.document_name || chunk.doc_name">{{ chunk.document_name || chunk.doc_name || '未知文档' }}</h4>
+                      </div>
+                      <p class="text-[10px] text-gray-400 font-mono mt-0.5 truncate">
+                        相似度: <span class="font-bold text-emerald-600">{{ formatScore(chunk) }}</span>
+                      </p>
+                    </div>
+                    <button class="px-2 py-1 rounded border border-gray-200 text-[10px] hover:bg-gray-100 transition-colors shrink-0" @click="copyResult(chunk)">复制</button>
+                  </div>
+                  <div
+                    class="text-xs text-gray-700 whitespace-pre-wrap bg-gray-50 rounded-xl p-3 leading-relaxed border border-gray-100"
+                    v-html="highlightContent(chunk.content || chunk.text, query)"
+                  ></div>
+                </article>
+              </div>
+            </div>
+          </div>
+
+          <!-- Column B (Right) -->
+          <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
+            <!-- Header B -->
+            <div class="px-4 py-2 border-b border-gray-100 bg-gray-50/50 flex items-center justify-between shrink-0 select-none">
+              <span class="text-xs font-bold text-gray-700">对照组 B (K={{ topK_B }} · 阈值 {{ similarityThreshold_B }})</span>
+              <span v-if="results_B.length" class="text-[10px] bg-primary/10 text-primary font-bold px-1.5 py-0.5 rounded-full">{{ results_B.length }}</span>
+            </div>
+
+            <!-- Error B -->
+            <div v-if="errorMessage_B" class="mx-3 mt-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 shrink-0">
+              <div class="font-semibold truncate">B组错误：{{ errorMessage_B }}</div>
+            </div>
+
+            <!-- Body B -->
+            <div class="flex-1 overflow-y-auto custom-scrollbar">
+              <div v-if="loading_B" class="flex flex-col items-center justify-center h-full gap-2 text-gray-400 select-none py-10">
+                <span class="w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin"></span>
+                <span class="text-xs">B组正在检索...</span>
+              </div>
+              <div v-else-if="results_B.length === 0" class="flex flex-col items-center justify-center h-full gap-2 text-gray-400 select-none py-10">
+                <span class="text-xs">B组暂无召回数据</span>
+              </div>
+              <div v-else class="divide-y divide-gray-100">
+                <article v-for="(chunk, idx) in results_B" :key="'b-' + (chunk.chunk_id || chunk.id)" class="p-4 space-y-2 hover:bg-gray-50/50 transition-colors">
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-1.5">
+                        <span class="text-[10px] font-bold text-gray-400 font-mono shrink-0">#{{ idx + 1 }}</span>
+                        <h4 class="text-xs font-bold text-gray-800 truncate" :title="chunk.document_name || chunk.doc_name">{{ chunk.document_name || chunk.doc_name || '未知文档' }}</h4>
+                      </div>
+                      <p class="text-[10px] text-gray-400 font-mono mt-0.5 truncate">
+                        相似度: <span class="font-bold text-emerald-600">{{ formatScore(chunk) }}</span>
+                      </p>
+                    </div>
+                    <button class="px-2 py-1 rounded border border-gray-200 text-[10px] hover:bg-gray-100 transition-colors shrink-0" @click="copyResult(chunk)">复制</button>
+                  </div>
+                  <div
+                    class="text-xs text-gray-700 whitespace-pre-wrap bg-gray-50 rounded-xl p-3 leading-relaxed border border-gray-100"
+                    v-html="highlightContent(chunk.content || chunk.text, query)"
+                  ></div>
+                </article>
+              </div>
+            </div>
+          </div>
+
         </div>
       </section>
     </div>
@@ -324,3 +585,66 @@ onMounted(fetchRagFlowConfig)
     />
   </div>
 </template>
+
+<style scoped>
+.whitespace-pre-wrap :deep(table) {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 10px 0;
+  font-size: 11px;
+  line-height: 1.5;
+  background-color: #ffffff;
+}
+
+.dark .whitespace-pre-wrap :deep(table) {
+  background-color: #1f2937;
+}
+
+.whitespace-pre-wrap :deep(th),
+.whitespace-pre-wrap :deep(td) {
+  border: 1px solid #e5e7eb;
+  padding: 6px 8px;
+  text-align: left;
+  word-break: break-all;
+}
+
+.dark .whitespace-pre-wrap :deep(th),
+.dark .whitespace-pre-wrap :deep(td) {
+  border-color: #374151;
+}
+
+.whitespace-pre-wrap :deep(th) {
+  background-color: #f3f4f6;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.dark .whitespace-pre-wrap :deep(th) {
+  background-color: #374151;
+  color: #f9fafb;
+}
+
+.whitespace-pre-wrap :deep(tr:nth-child(even)) {
+  background-color: #f9fafb;
+}
+
+.dark .whitespace-pre-wrap :deep(tr:nth-child(even)) {
+  background-color: rgba(31, 41, 55, 0.4);
+}
+
+.whitespace-pre-wrap :deep(caption) {
+  font-size: 10px;
+  color: #6b7280;
+  padding: 6px 4px;
+  font-weight: 700;
+  text-align: left;
+  background-color: rgba(243, 244, 246, 0.5);
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.dark .whitespace-pre-wrap :deep(caption) {
+  color: #9ca3af;
+  background-color: rgba(55, 65, 81, 0.5);
+  border-color: #4b5563;
+}
+</style>

--- a/frontend/src/views/KnowledgeRetrievalTest.vue
+++ b/frontend/src/views/KnowledgeRetrievalTest.vue
@@ -536,8 +536,8 @@ onMounted(fetchRagFlowConfig)
             </div>
 
             <!-- Error B -->
-            <div v-if="errorMessage_B" class="mx-3 mt-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 shrink-0">
-              <div class="font-semibold truncate">B组错误：{{ errorMessage_B }}</div>
+            <div v-if="friendlyRagFlowErrorB" class="mx-3 mt-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 shrink-0">
+              <div class="font-semibold truncate">B组错误：{{ friendlyRagFlowErrorB }}</div>
             </div>
 
             <!-- Body B -->

--- a/frontend/src/views/MetadataTables.vue
+++ b/frontend/src/views/MetadataTables.vue
@@ -666,6 +666,11 @@ defineExpose({ fetchMetrics })
       <SchemaGraph :dataset-id="datasetId" :tables="tables" />
     </div>
 
+    <!-- Content: Changelog -->
+    <div v-if="activeTab === 'changelog'">
+      <ChangelogList :dataset-id="datasetId" />
+    </div>
+
     <!-- Content: Permissions -->
     <div v-if="activeTab === 'permissions'" class="bg-white p-6 rounded-xl border border-gray-100 shadow-sm space-y-6">
       <div class="flex items-center justify-between border-b pb-4">

--- a/frontend/src/views/MetadataTables.vue
+++ b/frontend/src/views/MetadataTables.vue
@@ -84,12 +84,127 @@ const activeTab = ref('tables')
 const editingTable = ref<Table | null>(null)
 const deleteTableId = ref<string | null>(null)
 
+const datasetPermissions = ref<{ users: any[], roles: any[] }>({ users: [], roles: [] })
+const loadingPermissions = ref(false)
+
+const fetchDatasetPermissions = async () => {
+  loadingPermissions.value = true
+  datasetPermissions.value = { users: [], roles: [] }
+  try {
+    const res = await axios.get(`/api/portal/metadata/datasets/${datasetId}/permissions`)
+    datasetPermissions.value = res.data?.data || { users: [], roles: [] }
+  } catch (err) {
+    console.error('获取数据集授权权限失败:', err)
+  } finally {
+    loadingPermissions.value = false
+  }
+}
+
+// 权限管理交互逻辑
+const showAddPermissionModal = ref(false)
+const assignType = ref<'role' | 'user'>('role')
+const selectedCandidateIds = ref<number[]>([])
+const candidates = ref<{ roles: any[], users: any[] }>({ roles: [], users: [] })
+const savingPerms = ref(false)
+
+const hasEditPermission = computed(() => _isAdmin.value || hasPermission('element:metadata:edit'))
+
+const candidateSearchQuery = ref('')
+
+const availableRoles = computed(() => {
+  const grantedCodes = datasetPermissions.value.roles.map(r => r.code)
+  let filtered = candidates.value.roles.filter(r => !grantedCodes.includes(r.code))
+  if (candidateSearchQuery.value) {
+    const q = candidateSearchQuery.value.toLowerCase()
+    filtered = filtered.filter(r => 
+      (r.name && r.name.toLowerCase().includes(q)) || 
+      (r.code && r.code.toLowerCase().includes(q))
+    )
+  }
+  return filtered
+})
+
+const availableUsers = computed(() => {
+  const grantedNames = datasetPermissions.value.users.map(u => u.user_name)
+  let filtered = candidates.value.users.filter(u => !grantedNames.includes(u.user_name))
+  if (candidateSearchQuery.value) {
+    const q = candidateSearchQuery.value.toLowerCase()
+    filtered = filtered.filter(u => 
+      (u.real_name && u.real_name.toLowerCase().includes(q)) || 
+      (u.user_name && u.user_name.toLowerCase().includes(q))
+    )
+  }
+  return filtered
+})
+
+const openAddPermissionModal = async () => {
+  selectedCandidateIds.value = []
+  showAddPermissionModal.value = true
+  try {
+    const res = await axios.get('/api/portal/metadata/candidates')
+    candidates.value = res.data?.data || { roles: [], users: [] }
+  } catch (err) {
+    console.error('获取候选列表失败:', err)
+  }
+}
+
+const closeAddPermissionModal = () => {
+  showAddPermissionModal.value = false
+  selectedCandidateIds.value = []
+  candidateSearchQuery.value = ''
+}
+
+const toggleCandidateSelection = (id: number) => {
+  const idx = selectedCandidateIds.value.indexOf(id)
+  if (idx > -1) {
+    selectedCandidateIds.value.splice(idx, 1)
+  } else {
+    selectedCandidateIds.value.push(id)
+  }
+}
+
+const submitPermissions = async () => {
+  if (!selectedCandidateIds.value.length) return
+  savingPerms.value = true
+  try {
+    await axios.post(`/api/portal/metadata/datasets/${datasetId}/permissions`, {
+      target_type: assignType.value,
+      target_ids: selectedCandidateIds.value
+    })
+    showToast('分配授权成功', 'success')
+    closeAddPermissionModal()
+    await fetchDatasetPermissions()
+  } catch (err) {
+    showToast('分配授权失败', 'error')
+  } finally {
+    savingPerms.value = false
+  }
+}
+
+const removePermission = async (type: string, id: number) => {
+  try {
+    await axios.delete(`/api/portal/metadata/datasets/${datasetId}/permissions`, {
+      data: {
+        target_type: type,
+        target_id: id
+      }
+    })
+    showToast('取消授权成功', 'success')
+    await fetchDatasetPermissions()
+  } catch (err) {
+    showToast('取消授权失败', 'error')
+  }
+}
+
 const fetchDatasetInfo = async () => {
   loading.value = true
   try {
     const res = await metadataApi.getDataset(datasetId)
     dataset.value = res.data
     tables.value = res.data.tables || []
+    
+    // 同时异步获取数据集授权关系
+    fetchDatasetPermissions()
   } catch (e) {
     console.error('Failed to fetch dataset', e)
   } finally {
@@ -339,6 +454,35 @@ defineExpose({ fetchMetrics })
                     Updated {{ new Date(dataset.updated_at).toLocaleString() }}
                  </span>
               </div>
+
+              <!-- Permissions Info -->
+              <div v-if="datasetPermissions?.users?.length || datasetPermissions?.roles?.length" class="mt-3.5 pt-3 border-t border-gray-100 flex flex-wrap gap-x-4 gap-y-2 text-xs">
+                <div v-if="datasetPermissions.roles.length" class="flex items-center gap-1.5">
+                  <span class="text-gray-400 font-medium select-none">授权角色:</span>
+                  <div class="flex flex-wrap gap-1">
+                    <span 
+                      v-for="r in datasetPermissions.roles" 
+                      :key="r.code"
+                      class="px-2 py-0.5 rounded bg-indigo-50 text-indigo-700 font-semibold border border-indigo-100/50 flex items-center gap-1 select-none"
+                    >
+                      {{ r.name }}
+                    </span>
+                  </div>
+                </div>
+                
+                <div v-if="datasetPermissions.users.length" class="flex items-center gap-1.5">
+                  <span class="text-gray-400 font-medium select-none">授权用户:</span>
+                  <div class="flex flex-wrap gap-1">
+                    <span 
+                      v-for="u in datasetPermissions.users" 
+                      :key="u.user_name"
+                      class="px-2 py-0.5 rounded bg-emerald-50 text-emerald-700 font-semibold border border-emerald-100/50 flex items-center gap-1 select-none"
+                    >
+                      {{ u.real_name || u.user_name }}
+                    </span>
+                  </div>
+                </div>
+              </div>
            </div>
         </div>
       </div>
@@ -372,7 +516,7 @@ defineExpose({ fetchMetrics })
           @click="activeTab = 'tables'"
           :class="[activeTab === 'tables' ? 'border-primary text-primary' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300', 'whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors duration-200 ease-in-out flex items-center gap-2']"
         >
-          数据表 (Tables)
+          数据表
           <span 
             :class="[activeTab === 'tables' ? 'bg-blue-100 text-blue-600' : 'bg-gray-100 text-gray-400', 'ml-1 py-0.5 px-2 rounded-full text-[10px] font-bold transition-colors']"
           >{{ tables.length }}</span>
@@ -381,7 +525,7 @@ defineExpose({ fetchMetrics })
           @click="activeTab = 'metrics'"
           :class="[activeTab === 'metrics' ? 'border-amber-500 text-amber-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300', 'whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors duration-200 ease-in-out flex items-center gap-2']"
         >
-          业务指标 (Metrics)
+          业务指标
           <span 
              :class="[activeTab === 'metrics' ? 'bg-amber-100 text-amber-600' : 'bg-gray-100 text-gray-400', 'ml-1 py-0.5 px-2 rounded-full text-[10px] font-bold transition-colors']"
           >{{ dataset?.metric_count || 0 }}</span>
@@ -390,7 +534,7 @@ defineExpose({ fetchMetrics })
           @click="activeTab = 'relationships'"
           :class="[activeTab === 'relationships' ? 'border-purple-500 text-purple-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300', 'whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors duration-200 ease-in-out flex items-center gap-2']"
         >
-          实体关系 (Relationships)
+          实体关系
           <span 
              :class="[activeTab === 'relationships' ? 'bg-purple-100 text-purple-600' : 'bg-gray-100 text-gray-400', 'ml-1 py-0.5 px-2 rounded-full text-[10px] font-bold transition-colors']"
           >{{ dataset?.relationship_count || 0 }}</span>
@@ -400,14 +544,24 @@ defineExpose({ fetchMetrics })
           :class="[activeTab === 'visualization' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300', 'whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors duration-200 ease-in-out flex items-center gap-2']"
         >
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/></svg>
-          可视化 (Visual)
+          可视化
         </button>
         <button
           @click="activeTab = 'changelog'"
           :class="[activeTab === 'changelog' ? 'border-red-500 text-red-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300', 'whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors duration-200 ease-in-out flex items-center gap-2']"
         >
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-          变更日志 (Changelog)
+          变更日志
+        </button>
+        <button
+          @click="activeTab = 'permissions'"
+          :class="[activeTab === 'permissions' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300', 'whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors duration-200 ease-in-out flex items-center gap-2']"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
+          权限管理
+          <span 
+             :class="[activeTab === 'permissions' ? 'bg-emerald-100 text-emerald-600' : 'bg-gray-100 text-gray-400', 'ml-1 py-0.5 px-2 rounded-full text-[10px] font-bold transition-colors']"
+          >{{ datasetPermissions.users.length + datasetPermissions.roles.length }}</span>
         </button>
       </nav>
     </div>
@@ -512,9 +666,243 @@ defineExpose({ fetchMetrics })
       <SchemaGraph :dataset-id="datasetId" :tables="tables" />
     </div>
 
-    <!-- Content: Changelog -->
-    <div v-if="activeTab === 'changelog'">
-      <ChangelogList :dataset-id="datasetId" />
+    <!-- Content: Permissions -->
+    <div v-if="activeTab === 'permissions'" class="bg-white p-6 rounded-xl border border-gray-100 shadow-sm space-y-6">
+      <div class="flex items-center justify-between border-b pb-4">
+        <div>
+          <h2 class="text-lg font-bold text-gray-900 flex items-center gap-2 select-none">
+            <svg class="w-5 h-5 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+            数据集成员授权管理
+          </h2>
+          <p class="text-xs text-gray-400 mt-1 select-none">控制并配置当前数据集在云枢元数据平台中的访问分配关系。</p>
+        </div>
+
+        <div v-if="hasEditPermission" class="flex items-center gap-3">
+          <button 
+            @click="openAddPermissionModal"
+            class="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-xl text-xs font-semibold shadow-md shadow-emerald-500/10 transition-all flex items-center gap-1.5"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+            </svg>
+            分配授权成员
+          </button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <!-- 角色列表 -->
+        <div class="space-y-3">
+          <div class="flex items-center justify-between">
+            <h3 class="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-1 select-none">
+              🔑 已授权角色 ({{ datasetPermissions.roles.length }})
+            </h3>
+          </div>
+          
+          <div v-if="datasetPermissions.roles.length" class="border border-gray-150 rounded-xl overflow-hidden divide-y divide-gray-100 bg-gray-50/20">
+            <div 
+              v-for="r in datasetPermissions.roles" 
+              :key="r.code"
+              class="flex items-center justify-between p-3.5 hover:bg-white transition-all group"
+            >
+              <div class="flex items-center gap-3">
+                <div class="w-8 h-8 rounded-lg bg-indigo-50 flex items-center justify-center text-indigo-600 font-bold text-xs select-none">
+                  R
+                </div>
+                <div>
+                  <div class="text-sm font-semibold text-gray-800">{{ r.name }}</div>
+                  <div class="text-[10px] text-gray-400 font-mono mt-0.5 select-all">{{ r.code }}</div>
+                </div>
+              </div>
+              <button 
+                v-if="hasEditPermission"
+                @click="removePermission('role', r.id)"
+                class="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-50 text-gray-400 hover:text-red-600 rounded-lg transition-all"
+                title="取消此角色授权"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div v-else class="text-xs text-gray-400 italic py-6 text-center border border-dashed border-gray-200 rounded-xl bg-gray-50/30 select-none">
+            暂无角色授权。
+          </div>
+        </div>
+
+        <!-- 用户列表 -->
+        <div class="space-y-3">
+          <div class="flex items-center justify-between">
+            <h3 class="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-1 select-none">
+              👤 已授权用户 ({{ datasetPermissions.users.length }})
+            </h3>
+          </div>
+          
+          <div v-if="datasetPermissions.users.length" class="border border-gray-150 rounded-xl overflow-hidden divide-y divide-gray-100 bg-gray-50/20">
+            <div 
+              v-for="u in datasetPermissions.users" 
+              :key="u.user_name"
+              class="flex items-center justify-between p-3.5 hover:bg-white transition-all group"
+            >
+              <div class="flex items-center gap-3">
+                <div class="w-8 h-8 rounded-lg bg-emerald-50 flex items-center justify-center text-emerald-600 font-bold text-xs select-none">
+                  U
+                </div>
+                <div>
+                  <div class="text-sm font-semibold text-gray-800">{{ u.real_name || u.user_name }}</div>
+                  <div class="text-[10px] text-gray-400 font-mono mt-0.5 select-all">{{ u.user_name }}</div>
+                </div>
+              </div>
+              <button 
+                v-if="hasEditPermission"
+                @click="removePermission('user', u.id)"
+                class="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-50 text-gray-400 hover:text-red-600 rounded-lg transition-all"
+                title="取消此用户授权"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div v-else class="text-xs text-gray-400 italic py-6 text-center border border-dashed border-gray-200 rounded-xl bg-gray-50/30 select-none">
+            暂无用户授权。
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Add Permission Modal -->
+    <div v-if="showAddPermissionModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fade-in" @click.self="closeAddPermissionModal">
+      <div class="bg-white rounded-xl shadow-2xl w-full max-w-md overflow-hidden flex flex-col border border-gray-100">
+        <!-- Header -->
+        <div class="p-5 border-b border-gray-100 flex justify-between items-center bg-gray-50/50">
+          <h3 class="text-sm font-bold text-gray-800 select-none">分配数据集授权成员</h3>
+          <button @click="closeAddPermissionModal" class="text-gray-400 hover:text-gray-600 transition-all">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+          </button>
+        </div>
+
+        <!-- Body -->
+        <div class="p-5 space-y-4">
+          <!-- 切换类型 -->
+          <div>
+            <label class="block text-xs font-semibold text-gray-400 mb-1.5 select-none">成员授权类型</label>
+            <div class="grid grid-cols-2 gap-2 bg-gray-50 p-1 rounded-xl border border-gray-150">
+              <button 
+                type="button"
+                @click="assignType = 'role'; selectedCandidateIds = []"
+                class="py-2 text-xs font-semibold rounded-lg transition-all"
+                :class="assignType === 'role' ? 'bg-white shadow text-indigo-600' : 'text-gray-500 hover:text-gray-800'"
+              >
+                按角色授权 (Role)
+              </button>
+              <button 
+                type="button"
+                @click="assignType = 'user'; selectedCandidateIds = []"
+                class="py-2 text-xs font-semibold rounded-lg transition-all"
+                :class="assignType === 'user' ? 'bg-white shadow text-emerald-600' : 'text-gray-500 hover:text-gray-800'"
+              >
+                按平台成员授权 (User)
+              </button>
+            </div>
+          </div>
+
+          <!-- 搜索输入框 -->
+          <div class="relative">
+            <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-gray-400">
+               <svg class="h-4.5 w-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+               </svg>
+            </span>
+            <input 
+              v-model="candidateSearchQuery"
+              type="text"
+              class="block w-full pl-9 pr-3 py-2 border border-gray-200 rounded-xl leading-5 bg-gray-50 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary sm:text-xs transition-all focus:bg-white"
+              :placeholder="assignType === 'role' ? '搜索角色名称或代码...' : '搜索用户姓名或账号...'"
+            />
+          </div>
+
+          <!-- 候选人列表勾选 -->
+          <div class="space-y-2">
+            <label class="block text-xs font-semibold text-gray-400 select-none">
+              选择要添加的{{ assignType === 'role' ? '角色' : '用户' }} (可多选)
+            </label>
+            <div class="border border-gray-150 rounded-xl max-h-[30vh] overflow-y-auto divide-y divide-gray-100">
+              <!-- 候选角色 -->
+              <template v-if="assignType === 'role'">
+                <div 
+                  v-for="r in availableRoles" 
+                  :key="r.id"
+                  class="flex items-center gap-3 p-3 hover:bg-gray-50 transition-all select-none cursor-pointer"
+                  @click="toggleCandidateSelection(r.id)"
+                >
+                  <input 
+                    type="checkbox" 
+                    :checked="selectedCandidateIds.includes(r.id)"
+                    class="rounded text-indigo-600 border-gray-300 focus:ring-indigo-500" 
+                    @click.stop="toggleCandidateSelection(r.id)"
+                  />
+                  <div class="flex flex-col">
+                    <span class="text-sm font-semibold text-gray-800">{{ r.name }}</span>
+                    <span class="text-[10px] text-gray-400 font-mono mt-0.5">{{ r.code }}</span>
+                  </div>
+                </div>
+                <div v-if="!availableRoles.length" class="text-xs text-gray-400 text-center py-8 select-none">
+                  所有角色已完成分配授权。
+                </div>
+              </template>
+
+              <!-- 候选用户 -->
+              <template v-if="assignType === 'user'">
+                <div 
+                  v-for="u in availableUsers" 
+                  :key="u.id"
+                  class="flex items-center gap-3 p-3 hover:bg-gray-50 transition-all select-none cursor-pointer"
+                  @click="toggleCandidateSelection(u.id)"
+                >
+                  <input 
+                    type="checkbox" 
+                    :checked="selectedCandidateIds.includes(u.id)"
+                    class="rounded text-emerald-600 border-gray-300 focus:ring-emerald-500" 
+                    @click.stop="toggleCandidateSelection(u.id)"
+                  />
+                  <div class="flex flex-col">
+                    <span class="text-sm font-semibold text-gray-800">{{ u.real_name || u.user_name }}</span>
+                    <span class="text-[10px] text-gray-400 font-mono mt-0.5">{{ u.user_name }}</span>
+                  </div>
+                </div>
+                <div v-if="!availableUsers.length" class="text-xs text-gray-400 text-center py-8 select-none">
+                  所有活跃用户已完成分配授权。
+                </div>
+              </template>
+            </div>
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="p-5 border-t border-gray-100 flex justify-end gap-3 bg-gray-50/30">
+          <button 
+            type="button" 
+            class="px-4 py-2 border rounded-xl text-xs font-semibold hover:bg-gray-50 transition-all" 
+            @click="closeAddPermissionModal"
+          >
+            取消
+          </button>
+          <button 
+            type="button" 
+            class="px-4 py-2 rounded-xl text-xs font-semibold text-white transition-all shadow-md disabled:opacity-50"
+            :class="assignType === 'role' ? 'bg-indigo-600 hover:bg-indigo-700 shadow-indigo-500/10' : 'bg-emerald-600 hover:bg-emerald-700 shadow-emerald-500/10'"
+            :disabled="!selectedCandidateIds.length || savingPerms"
+            @click="submitPermissions"
+          >
+            {{ savingPerms ? '正在保存...' : '确认授权' }}
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Edit Table Modal -->

--- a/frontend/src/views/WidgetDebugger.vue
+++ b/frontend/src/views/WidgetDebugger.vue
@@ -4,7 +4,7 @@
       <div class="flex items-center gap-3 min-w-0">
         <h1 class="text-2xl font-bold text-gray-800 truncate">组件调试台</h1>
         <button
-          @click="showIntegrationGuide = true"
+          @click="openIntegrationGuide"
           class="h-8 w-8 inline-flex items-center justify-center rounded-full border border-blue-200 bg-blue-50 text-blue-600 hover:bg-blue-100 hover:border-blue-300 transition-colors flex-shrink-0"
           title="查看 EmbedChat 集成指南"
           aria-label="查看 EmbedChat 集成指南"
@@ -121,7 +121,7 @@
             <div class="px-5 py-4 border-b border-gray-100 flex items-center justify-between gap-4">
               <div class="min-w-0">
                 <h2 class="text-lg font-black text-gray-900">EmbedChat 集成指南</h2>
-                <p class="text-xs text-gray-500 mt-1">选择一种方式复制代码，然后在宿主系统中按需替换域名、Token 和 Agent ID。</p>
+                <p class="text-xs text-gray-500 mt-1">选择一种方式复制代码，示例会按当前登录态自动填入域名、API Key 和智能体模式。</p>
               </div>
               <button
                 @click="showIntegrationGuide = false"
@@ -135,13 +135,13 @@
               </button>
             </div>
 
-            <div class="border-b border-gray-100 px-4 overflow-x-auto">
-              <div class="flex gap-1 min-w-max">
+            <div class="border-b border-gray-100 px-4 overflow-x-auto shrink-0">
+              <div class="flex items-center gap-1 min-w-max h-12">
                 <button
                   v-for="tab in integrationTabs"
                   :key="tab.id"
                   @click="activeIntegrationTab = tab.id"
-                  class="px-4 py-3 text-sm font-bold border-b-2 transition-colors"
+                  class="h-12 px-4 inline-flex items-center whitespace-nowrap text-sm leading-none font-bold border-b-2 transition-colors flex-shrink-0"
                   :class="activeIntegrationTab === tab.id ? 'border-blue-600 text-blue-700' : 'border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-200'"
                 >
                   {{ tab.label }}
@@ -150,6 +150,47 @@
             </div>
 
             <div class="flex-1 overflow-y-auto p-5 bg-gray-50">
+              <div class="mb-5 bg-white border border-gray-200 rounded-lg p-4">
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                  <div class="min-w-0">
+                    <div class="text-xs font-black text-gray-400 uppercase tracking-wider mb-1">当前域名</div>
+                    <div class="font-mono text-xs text-gray-700 truncate bg-gray-50 border border-gray-100 rounded-md px-2 py-2">{{ integrationHost }}</div>
+                  </div>
+                  <div class="min-w-0">
+                    <div class="text-xs font-black text-gray-400 uppercase tracking-wider mb-1">API Key</div>
+                    <div
+                      class="font-mono text-xs truncate border rounded-md px-2 py-2"
+                      :class="integrationHasRealApiKey ? 'text-emerald-700 bg-emerald-50 border-emerald-100' : 'text-amber-700 bg-amber-50 border-amber-100'"
+                      :title="integrationHasRealApiKey ? integrationApiKey : '当前浏览器未读取到登录 API Key，将使用占位值'"
+                    >
+                      {{ integrationHasRealApiKey ? maskApiKey(integrationApiKey) : integrationApiKey }}
+                    </div>
+                  </div>
+                  <div class="min-w-0 lg:col-span-2">
+                    <div class="text-xs font-black text-gray-400 uppercase tracking-wider mb-1">智能体模式</div>
+                    <div class="grid grid-cols-1 sm:grid-cols-[9rem_minmax(0,1fr)] gap-2">
+                      <select v-model="integrationAgentMode" class="w-full min-w-0 text-xs border-gray-300 rounded-md h-9">
+                        <option value="auto">自动路由</option>
+                        <option value="agent">指定智能体</option>
+                      </select>
+                      <select
+                        v-model="selectedIntegrationAgentId"
+                        class="w-full min-w-0 max-w-full text-xs border-gray-300 rounded-md h-9 truncate"
+                        :disabled="integrationAgentMode === 'auto' || integrationAgents.length === 0"
+                      >
+                        <option v-if="integrationAgents.length === 0" value="">暂无可用智能体</option>
+                        <option v-for="agent in integrationAgents" :key="agent.id" :value="agent.id">
+                          {{ agent.display_name || agent.name }} ({{ agent.id }})
+                        </option>
+                      </select>
+                    </div>
+                  </div>
+                </div>
+                <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-gray-500">
+                  <span class="px-2 py-1 rounded bg-gray-50 border border-gray-100">当前生成：{{ integrationAgentMode === 'auto' ? '不传 agent_id，由平台自动路由' : `指定 ${selectedIntegrationAgentLabel}` }}</span>
+                  <span v-if="!integrationHasRealApiKey" class="px-2 py-1 rounded bg-amber-50 border border-amber-100 text-amber-700">未读到本地 API Key，复制前请先登录或手动替换占位值</span>
+                </div>
+              </div>
               <div class="grid grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] gap-5">
                 <aside class="space-y-3">
                   <div class="bg-white border border-gray-200 rounded-lg p-4">
@@ -236,6 +277,7 @@
                             </div>
                             <div class="absolute right-5 bottom-5 h-24 w-32 rounded-xl bg-white border border-blue-200 shadow-2xl overflow-hidden">
                               <div class="h-7 bg-blue-600 text-white px-2 flex items-center text-[10px] font-bold">AI Assistant</div>
+                              <div class="absolute right-1.5 top-1.5 h-4 w-4 rounded-full bg-white/20 text-white flex items-center justify-center text-[10px] font-black">-</div>
                               <div class="p-2 space-y-1">
                                 <div class="h-2 rounded bg-blue-100"></div>
                                 <div class="h-2 w-2/3 rounded bg-blue-100"></div>
@@ -277,6 +319,8 @@
 	
 	<script setup lang="ts">
 	import { computed, ref, reactive, onMounted, onUnmounted } from 'vue';
+    import axios from '../utils/axios';
+    import { useToast } from '../composables/useToast';
 
     interface IntegrationTab {
         id: string;
@@ -288,11 +332,18 @@
         code: string;
     }
 
+    interface IntegrationAgent {
+        id: string;
+        name: string;
+        display_name?: string;
+    }
+
 	const widgetFrame = ref<HTMLIFrameElement | null>(null);
 	const logs = ref<string[]>([]);
 	const iframeUrl = ref('');
     const showIntegrationGuide = ref(false);
     const activeIntegrationTab = ref('iframe');
+    const { showToast } = useToast();
 
 const config = reactive({
     token: '',
@@ -304,16 +355,74 @@ const config = reactive({
 const contextPayload = ref('{\n  "user_name": "陈小龙",\n  "user_dept": "数字化转型部",\n  "user_role": "系统管理员"\n}');
 	const commandInput = ref('/new');
 
-    const integrationTabs: IntegrationTab[] = [
+    const integrationAgentMode = ref<'auto' | 'agent'>('auto');
+    const integrationAgents = ref<IntegrationAgent[]>([]);
+    const selectedIntegrationAgentId = ref('');
+
+    const integrationHost = computed(() => {
+        return typeof window !== 'undefined' ? window.location.origin : '';
+    });
+    const integrationApiKey = computed(() => config.token.trim() || 'CURRENT_USER_API_KEY');
+    const integrationHasRealApiKey = computed(() => Boolean(config.token.trim()));
+    const selectedIntegrationAgent = computed(() => {
+        return integrationAgents.value.find((agent) => agent.id === selectedIntegrationAgentId.value);
+    });
+    const selectedIntegrationAgentLabel = computed(() => {
+        const agent = selectedIntegrationAgent.value;
+        if (!agent) return selectedIntegrationAgentId.value || '未选择智能体';
+        return `${agent.display_name || agent.name} (${agent.id})`;
+    });
+
+    const maskApiKey = (key: string) => {
+        if (key.length <= 12) return key;
+        return `${key.slice(0, 6)}...${key.slice(-4)}`;
+    };
+    const resolveStoredApiKey = () => {
+        const directKey = localStorage.getItem('api_key') || localStorage.getItem('yovole_token');
+        if (directKey) return directKey;
+        try {
+            const userInfo = JSON.parse(localStorage.getItem('user_info') || '{}') as { api_key?: string };
+            return userInfo.api_key || '';
+        } catch {
+            return '';
+        }
+    };
+
+    const escapeJsString = (value: string) => value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+    const buildAgentQueryParam = () => {
+        const agentId = buildAgentInitValue();
+        return agentId ? `&agent_id=${encodeURIComponent(agentId)}` : '';
+    };
+    const buildAgentInitValue = () => {
+        if (integrationAgentMode.value !== 'agent') return '';
+        return selectedIntegrationAgentId.value || integrationAgents.value[0]?.id || '';
+    };
+    const buildAgentInitLine = () => {
+        const agentEntry = { agent_id: buildAgentInitValue() };
+        return agentEntry.agent_id ? `\n      agent_id: '${escapeJsString(agentEntry.agent_id)}',` : '';
+    };
+
+    const integrationTabs = computed<IntegrationTab[]>(() => {
+        const host = integrationHost.value;
+        const token = integrationApiKey.value;
+        const encodedToken = encodeURIComponent(token);
+        const theme = config.theme || 'light';
+        const agentQueryParam = buildAgentQueryParam();
+        const agentInitLine = buildAgentInitLine();
+        const tokenPoint = integrationHasRealApiKey.value ? '已带入当前登录用户 API Key' : '当前浏览器没有明文 API Key 时会保留占位值';
+
+        return [
         {
             id: 'iframe',
             label: '快速 IFrame',
             title: '直接通过 URL 参数嵌入',
             caption: '适合内网测试、Demo 页面或快速验证 Agent 能否打开。',
-            summary: '把 /embed/chat 放进 iframe，并通过 URL 参数传递 token、agent_id、theme。',
-            points: ['实现最快', '便于在静态页面中验证', '生产环境不推荐在 URL 中暴露 Token'],
+            summary: integrationAgentMode.value === 'auto'
+                ? '把 /embed/chat 放进 iframe，仅传 token 和 theme，由平台自动路由智能体。'
+                : '把 /embed/chat 放进 iframe，通过 URL 参数传递 token、agent_id、theme。',
+            points: ['实现最快', tokenPoint, integrationAgentMode.value === 'auto' ? '不传 agent_id 时自动路由' : '已传入当前选中的真实 Agent ID', '生产环境不推荐在 URL 中暴露 Token'],
             code: `<iframe
-  src="https://your-yunshu-domain/embed/chat?token=YOUR_TOKEN&agent_id=sys-agent-chatbi&theme=light"
+  src="${host}/embed/chat?token=${encodedToken}${agentQueryParam}&theme=${encodeURIComponent(theme)}"
   width="100%"
   height="640"
   frameborder="0"
@@ -326,10 +435,10 @@ const contextPayload = ref('{\n  "user_name": "陈小龙",\n  "user_dept": "数�
             title: '安全初始化和双向通信',
             caption: '推荐生产使用：iframe src 不带敏感 token，等组件 ready 后发送 INIT_CONFIG。',
             summary: '宿主页面监听 YUNSHU_WIDGET_READY，再通过 postMessage 发送鉴权、智能体、用户和页面上下文。',
-            points: ['Token 不进入 URL', '支持用户身份和业务上下文注入', '可以响应组件 resize、过期、连接状态事件'],
+            points: ['Token 不进入 URL', tokenPoint, integrationAgentMode.value === 'auto' ? 'INIT_CONFIG 不传 agent_id 时自动路由' : 'INIT_CONFIG 指定当前选中的智能体', '可以响应组件 resize、过期、连接状态事件'],
             code: `<iframe
   id="yunshu-agent-frame"
-  src="https://your-yunshu-domain/embed/chat?instance_id=ops-assistant"
+  src="${host}/embed/chat?instance_id=ops-assistant"
   width="100%"
   height="640"
   frameborder="0"
@@ -337,7 +446,7 @@ const contextPayload = ref('{\n  "user_name": "陈小龙",\n  "user_dept": "数�
 
 <script>
 const frame = document.getElementById('yunshu-agent-frame');
-const targetOrigin = 'https://your-yunshu-domain';
+const targetOrigin = '${host}';
 
 window.addEventListener('message', (event) => {
   if (event.origin !== targetOrigin) return;
@@ -348,9 +457,8 @@ window.addEventListener('message', (event) => {
     frame.contentWindow.postMessage({
       type: 'INIT_CONFIG',
       instance_id: 'ops-assistant',
-      token: 'YOUR_TOKEN',
-      agent_id: 'sys-agent-chatbi',
-      theme: 'light',
+      token: '${escapeJsString(token)}',${agentInitLine}
+      theme: '${escapeJsString(theme)}',
       user_info: {
         user_id: 'U10001',
         real_name: '张三',
@@ -378,12 +486,13 @@ window.addEventListener('message', (event) => {
             title: '右下角悬浮助手',
             caption: '适合接入已有业务系统，默认收起，点击后展开完整对话窗口。',
             summary: '宿主系统控制 iframe 容器的展开/收起，让助手像客服入口一样固定在页面右下角。',
-            points: ['不占用业务页面主布局', '适合门户、控制台、报表页', '移动端可以切换为全屏覆盖'],
+            points: ['不占用业务页面主布局', tokenPoint, '展开后可点击收起按钮恢复悬浮入口', integrationAgentMode.value === 'auto' ? '展开后仍由平台自动路由' : '展开后固定进入指定智能体'],
             code: `<div id="yunshu-widget-shell" class="yunshu-widget-shell collapsed">
   <button id="yunshu-widget-toggle" class="yunshu-widget-toggle">AI</button>
+  <button id="yunshu-widget-collapse" class="yunshu-widget-collapse" title="收起助手" aria-label="收起助手">−</button>
   <iframe
     id="yunshu-agent-frame"
-    src="https://your-yunshu-domain/embed/chat?instance_id=floating-ai"
+    src="${host}/embed/chat?instance_id=floating-ai"
     frameborder="0"
   ></iframe>
 </div>
@@ -414,6 +523,24 @@ window.addEventListener('message', (event) => {
 .yunshu-widget-shell.collapsed iframe {
   display: none;
 }
+.yunshu-widget-collapse {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 2;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, .72);
+  color: #fff;
+  font-size: 18px;
+  line-height: 28px;
+  cursor: pointer;
+}
+.yunshu-widget-shell.collapsed .yunshu-widget-collapse {
+  display: none;
+}
 .yunshu-widget-toggle {
   display: none;
   width: 100%;
@@ -431,9 +558,30 @@ window.addEventListener('message', (event) => {
 
 <script>
 const shell = document.getElementById('yunshu-widget-shell');
+const frame = document.getElementById('yunshu-agent-frame');
+const targetOrigin = '${host}';
+
 document.getElementById('yunshu-widget-toggle').onclick = () => {
   shell.classList.remove('collapsed');
 };
+document.getElementById('yunshu-widget-collapse').onclick = () => {
+  shell.classList.add('collapsed');
+};
+
+window.addEventListener('message', (event) => {
+  if (event.origin !== targetOrigin) return;
+  const data = event.data || {};
+  if (data.source !== 'yunshu-agent-embed') return;
+
+  if (data.type === 'YUNSHU_WIDGET_READY') {
+    frame.contentWindow.postMessage({
+      type: 'INIT_CONFIG',
+      instance_id: 'floating-ai',
+      token: '${escapeJsString(token)}',${agentInitLine}
+      theme: '${escapeJsString(theme)}'
+    }, targetOrigin);
+  }
+});
 <\/script>`,
         },
         {
@@ -442,9 +590,9 @@ document.getElementById('yunshu-widget-toggle').onclick = () => {
             title: '同步业务上下文和多实例隔离',
             caption: '适合页面上有多个助手，或需要让 Agent 感知当前业务对象的场景。',
             summary: '为每个组件设置 instance_id，并在页面状态变化时发送 UPDATE_CONTEXT 或 SEND_COMMAND。',
-            points: ['多 iframe 不串消息', 'Agent 可读取当前页面、工单、资产等上下文', '业务按钮可以直接触发组件内部指令'],
+            points: ['多 iframe 不串消息', 'Agent 可读取当前页面、工单、资产等上下文', integrationAgentMode.value === 'auto' ? '适合让平台按上下文自动调度专家' : '适合让指定专家读取当前业务对象'],
             code: `const frame = document.getElementById('yunshu-agent-frame');
-const targetOrigin = 'https://your-yunshu-domain';
+const targetOrigin = '${host}';
 const instanceId = 'ticket-sidebar-ai';
 
 function postToAgent(message) {
@@ -481,10 +629,11 @@ function resetAgentSession(newToken) {
   });
 }`,
         },
-    ];
+        ];
+    });
 
     const activeIntegrationTabData = computed<IntegrationTab>(() => {
-        return integrationTabs.find((tab) => tab.id === activeIntegrationTab.value) || integrationTabs[0]!;
+        return integrationTabs.value.find((tab) => tab.id === activeIntegrationTab.value) || integrationTabs.value[0]!;
     });
 
 // Simulate Host Size control
@@ -496,12 +645,36 @@ const isExpanded = ref(true);
 	    logs.value.unshift(`[${new Date().toLocaleTimeString()}] ${msg}`);
 	};
 
+    const fetchIntegrationAgents = async () => {
+        try {
+            const res = await axios.get<IntegrationAgent[]>('/api/portal/agents/allowed');
+            integrationAgents.value = Array.isArray(res.data) ? res.data : [];
+            if (!selectedIntegrationAgentId.value && integrationAgents.value.length > 0) {
+                selectedIntegrationAgentId.value = integrationAgents.value[0]!.id;
+            }
+        } catch {
+            integrationAgents.value = [];
+            log('Warn: Failed to load allowed agents for guide');
+        }
+    };
+
+    const openIntegrationGuide = () => {
+        const storedKey = resolveStoredApiKey();
+        if (storedKey && !config.token) {
+            config.token = storedKey;
+        }
+        showIntegrationGuide.value = true;
+        void fetchIntegrationAgents();
+    };
+
     const copyGuideCode = async () => {
         try {
             await navigator.clipboard.writeText(activeIntegrationTabData.value.code);
             log(`Copied guide: ${activeIntegrationTabData.value.label}`);
+            showToast('集成代码已复制到剪贴板', 'success');
         } catch {
             log('Error: Copy guide failed');
+            showToast('复制失败，请手动复制代码', 'error');
         }
     };
 
@@ -590,10 +763,11 @@ const handleMessage = (event: MessageEvent) => {
 onMounted(() => {
     window.addEventListener('message', handleMessage);
     // Auto-load token from current user session
-    const storedKey = localStorage.getItem('api_key');
+    const storedKey = resolveStoredApiKey();
     if (storedKey) {
         config.token = storedKey;
     }
+    void fetchIntegrationAgents();
     connect();
 });
 

--- a/tests/frontend/test_widget_debugger_integration_guide.py
+++ b/tests/frontend/test_widget_debugger_integration_guide.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+pytestmark = pytest.mark.no_infrastructure
+
+
+def _source(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_widget_debugger_guide_uses_runtime_origin_and_current_api_key():
+    source = _source("frontend/src/views/WidgetDebugger.vue")
+
+    assert "window.location.origin" in source
+    assert "integrationHost" in source
+    assert "integrationApiKey" in source
+    assert "YOUR_TOKEN" not in source
+    assert "https://your-yunshu-domain" not in source
+
+
+def test_widget_debugger_guide_supports_auto_and_explicit_agent_modes():
+    source = _source("frontend/src/views/WidgetDebugger.vue")
+
+    assert "integrationAgentMode" in source
+    assert "selectedIntegrationAgentId" in source
+    assert "/api/portal/agents/allowed" in source
+    assert "buildAgentQueryParam" in source
+    assert "agent_id: buildAgentInitValue()" in source
+
+
+def test_widget_debugger_copy_guide_shows_toast_feedback():
+    source = _source("frontend/src/views/WidgetDebugger.vue")
+
+    assert "useToast" in source
+    assert "const { showToast } = useToast()" in source
+    assert "showToast('集成代码已复制到剪贴板', 'success')" in source
+    assert "showToast('复制失败，请手动复制代码', 'error')" in source
+
+
+def test_widget_debugger_floating_guide_can_collapse_after_opening():
+    source = _source("frontend/src/views/WidgetDebugger.vue")
+
+    assert "yunshu-widget-collapse" in source
+    assert "shell.classList.add('collapsed')" in source
+    assert "收起助手" in source


### PR DESCRIPTION


## 概要 (Overview)
本次 PR 主要完成智能体数据集详情页“权限管理 (Permissions)”Tab 的新增，打通了角色/用户的分配与取消授权的完整链路，并支持前台模糊搜索和 Redis 缓存清理。同时，重构并优化了网页挂件集成引导 (WidgetDebugger)，引入多路由模式与动态密钥配置，修复了多处由于接口异常、样式错位、变量未定义或数据竞态导致的前端空白/报错问题。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)
- [x] **数据集及权限管理Tab**：为数据集详情页新增“权限管理” Tab，展示角色和用户的授权明细，支持分配/取消授权、前端即时模糊检索，以及在权限变更后物理清理受影响用户的 Redis 及左侧菜单缓存。
- [x] **悬浮助手与集成引导重构**：优化 WidgetDebugger 调试面板，支持动态输入 host 和 token，增设“自动路由” (auto) 和“显式指定” (explicit) 双重挂件接入模式，支持选择智能体并动态获取列表；右下角悬浮挂件增加了“收起助手”按钮，并完善了 host 端与 iframe 组件的 `INIT_CONFIG` 双向通信逻辑。
- [x] **环境诊断意图调优**：优化了运行环境诊断意图识别及相关工具触发策略，并补充单元测试。

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)
- [x] **自定义模态框升级**：将技能管理页面原生的浏览器 `confirm` 弹窗全部替换为自定义 `ConfirmModal` 组件。
- [x] **界面杂音消除**：剔除详情 Tab 和头部卡片中英文括号后缀；针对知识库删除行为增设了“同步清除授权记录”防呆警示弹窗。

### 3. 🐞 关键修复 (Bug Fixes)
- [x] **定位及遮罩样式修复**：修复 `AgentDebug` 和 `EmbedChat` 在右侧 pinned 抽屉开启状态下，生成报告/保存报告模态框遮罩层右偏 28rem 的定位偏离问题。
- [x] **RAGFlow 接口限制与加载修复**：
  - 兼容并适配了 RAGFlow OpenAPI `page_size` 最大为 100 的物理限制，对超过限制的分页请求自动在后端切片拉取并合并。
  - 修复 `RagFlowClient` 实例化时漏传 `config_prefix` 导致加载错误配置项的 Bug。
- [x] **授权 ID 缺失报 400 修复**：在元数据和知识库授权接口的返回中补齐了 `Role.id` 和 `User.id` 的数据库主键输出，防止前端因传入 undefined `target_id` 触发后端 Pydantic 校验 400 Bad Request 异常。
- [x] **前端多处隐式 Bug 治理**：
  - 修复变更日志 Tab 内容渲染块遗漏导致页面空白的问题。
  - 修复知识库上传多文件循环时缺少防空校验以及定时状态轮询中因竞态导致 `selectedDocument.value` 偶尔为 `null` 抛出 undefined ID 的异常。
  - 修复知识检索测试模块（KnowledgeRetrievalTest）B组错误绑定了未定义变量 `errorMessage_B` 导致无法渲染出错误详情的 Bug。

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| b9b7fbc | feat(widget,rag): 优化网页悬浮助手集成引导，支持多模式并修复前端故障 |
| 0f1406c | fix(metadata): 修复变更日志Tab内容渲染块遗漏导致页面空白的故障 |
| 9eeecbe | fix(metadata): 修复因从模块直接导入类静态方法导致的ImportError |
| 0b822fb | fix(metadata,rag): 修复从数据集取消授权报400的Bug并同步返回主键ID |
| 5203eab | feat(metadata,rag): 智能体数据集新增权限管理Tab及增删搜索功能 & 知识库删除同步清理授权关系 |
| d7c1931 | fix(ragflow): 兼容 RAGFlow OpenAPI 的 page_size 最大 100 的限制，对超额请求自动进行分批次拉取并合并 |
| 5827d61 | fix(ragflow): 修复知识库管理模块实例化 RagFlowClient 时未指定 config_prefix 导致读取错误配置 Key 的 Bug |
| bce2340 | style: 替换技能管理页面中的原生confirm弹窗为自定义ConfirmModal组件 |
| 984d590 | feat(router): 优化运行环境诊断意图识别及工具促发策略并更新测试与清单 |

---

## 测试覆盖 (Testing)
- [x] **UI 兼容性**: 验证了 WidgetDebugger、数据集权限 Tab、Agent 调试生成报告等多模块在 Chrome/Safari 下的展示效果。
- [x] **核心功能**: 挂件复制、按智能体获取引导代码、收起交互、分配与取消授权、轮询状态等功能已全部手动联调完毕。
- [x] **自动化测试**: 新增 [test_widget_debugger_integration_guide.py](file:///Users/chenxiaolong/workspace/yovole-yunshu-ai-agent-platform/tests/frontend/test_widget_debugger_integration_guide.py) 测试文件对集成引导的配置解析、路由模式、复制状态与收起按钮行为进行了完整覆盖，并且全量测试均已通过。

---

## 其他备注 (Notes)
本次变更涉及数据集授权接口返回的 Schema 补齐，重新编译前端代码后启动即可直接查看。
```
