### PR TITLE
Pull Request: feat: 知识库中心与生命周期管理高阶功能增强

### DIFF
--- a/app/api/portal/endpoints/ragflow.py
+++ b/app/api/portal/endpoints/ragflow.py
@@ -800,6 +800,32 @@ async def get_dataset_portal_recommendations(
     """
     await require_dataset_access(user, db, [dataset_id])
     client = RagFlowClient(config_prefix="knowledge_ragflow")
+    
+    # 0. 尝试加载本地自定义问题配置
+    from app.models.knowledge import KnowledgeBaseMetadata
+    from sqlalchemy import select
+    
+    custom_questions = []
+    try:
+        stmt = select(KnowledgeBaseMetadata).where(
+            KnowledgeBaseMetadata.ragflow_dataset_id == dataset_id,
+            KnowledgeBaseMetadata.status != "deleted"
+        )
+        res = await db.execute(stmt)
+        local_kb = res.scalar_one_or_none()
+        if local_kb and local_kb.extra_config:
+            raw_cust = local_kb.extra_config.get("custom_questions")
+            if isinstance(raw_cust, list):
+                for item in raw_cust:
+                    if isinstance(item, dict) and item.get("label") and item.get("query"):
+                        custom_questions.append({
+                            "label": str(item["label"]).strip(),
+                            "query": str(item["query"]).strip()
+                        })
+    except Exception:
+        # 本地没有找到或加载失败时，退避到空，不影响大模型生成
+        pass
+
     try:
         # 1. 尝试获取数据集基本信息与文档列表（获取较多文件以支持换一批抽样）
         docs = await client.list_documents(dataset_id, page_size=100)
@@ -831,24 +857,30 @@ async def get_dataset_portal_recommendations(
                 if llm:
                     chat_client = chat_client_from_handle(llm)
                     doc_names_str = ", ".join(sampled_names)
-                    exclude_instructions = ""
+                    
+                    # 合并外部排除与内置自定义排除问题列表
+                    exclude_queries = []
                     if exclude:
-                        exclude_list = [q.strip() for q in exclude.split(",") if q.strip()]
-                        if exclude_list:
-                            exclude_instructions = f"\n请不要生成与以下已存在问题相近或重复的问题：{json.dumps(exclude_list, ensure_ascii=False)}。"
+                        exclude_queries.extend([q.strip() for q in exclude.split(",") if q.strip()])
+                    if custom_questions:
+                        exclude_queries.extend([q["query"] for q in custom_questions])
+
+                    exclude_instructions = ""
+                    if exclude_queries:
+                        exclude_instructions = f"\n请不要生成与以下已存在问题相近或重复的问题：{json.dumps(exclude_queries, ensure_ascii=False)}。"
                             
                     prompt = (
                         f"你是一个专业的知识库导航助手。当前知识库包含以下文档列表：[{doc_names_str}]。\n"
                         f"请根据这些文件的名字所反映的业务内容，生成 3 个用户最有可能向 AI 提问的高频、专业且具体的问题。\n"
                         f"要求：\n"
                         f"1. 每个问题必须是一句完整、具体的提问，不要宽泛（如“介绍下XX项目的设计架构”而不是“关于架构的设计”）；\n"
-                        f"2. 输出格式必须是一个合法的 JSON 数组，如：[\"问题一内容\", \"问题二内容\", \"问题三内容\"]\n"
+                        f"2. 输出格式必须是一个合法的 JSON 数组，如：[\"问题内容1\", \"问题内容2\", \"问题内容3\"]\n"
                         f"3. 只输出 JSON 数组本身，严禁任何 Markdown 标记包围或多余解释。{exclude_instructions}"
                     )
                     messages = [
                         RuntimeMessage(
                             role="system",
-                            content=[RuntimeContentBlock(type="text", text="你是一个严谨 of JSON 问答生成器。")]
+                            content=[RuntimeContentBlock(type="text", text="你是一个严谨的 JSON 问答生成器。")]
                         ),
                         RuntimeMessage(
                             role="user",
@@ -871,14 +903,20 @@ async def get_dataset_portal_recommendations(
                                     "label": label,
                                     "query": q_str
                                 })
-                            return {"code": 0, "data": {"questions": dynamic_questions}}
+                            return {"code": 0, "data": {
+                                "custom_questions": custom_questions,
+                                "questions": dynamic_questions
+                            }}
             except Exception as llm_err:
                 # LLM 生成失败时，安静退避到默认问题，不影响 API 的正常可用
                 import logging
                 logging.exception("Failed to generate dynamic questions via LLM in knowledge portal")
                 pass
                 
-        return {"code": 0, "data": {"questions": default_questions}}
+        return {"code": 0, "data": {
+            "custom_questions": custom_questions,
+            "questions": default_questions
+        }}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to generate dataset portal info: {str(e)}")
 

--- a/app/api/portal/endpoints/ragflow.py
+++ b/app/api/portal/endpoints/ragflow.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Any, Dict
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.orm import get_db_session
 from app.services.config_service import ConfigService
-from app.core.dependencies import require_admin, get_current_user
+from app.core.dependencies import require_admin, get_current_user, require_permission
 from app.services.permission_service import PermissionService
 from app.services.ai.ragflow_client import RagFlowClient
 from app.services.knowledge_base_service import KnowledgeBaseMetadataService
@@ -1094,4 +1094,121 @@ async def analyze_dataset_metadata(
             status_code=500,
             detail=f"AI 分析失败: {str(llm_err)}"
         )
+
+
+class AddDatasetPermissionsRequest(BaseModel):
+    target_type: str  # "user" 或 "role"
+    target_ids: List[int]
+
+class DeleteDatasetPermissionRequest(BaseModel):
+    target_type: str  # "user" 或 "role"
+    target_id: int
+
+
+@router.post("/datasets/{dataset_id}/permissions", dependencies=[Depends(require_permission("menu", "menu:system:users"))])
+async def add_dataset_permissions(
+    dataset_id: str,
+    payload: AddDatasetPermissionsRequest,
+    db: AsyncSession = Depends(get_db_session),
+    user: dict = Depends(get_current_user)
+):
+    """
+    添加知识库的反向授权角色或用户 (仅有用户管理权限的用户可用)
+    """
+    from app.models.permission import ResourcePermission, UserRoleRelation
+    from sqlalchemy import select
+
+    await require_dataset_write_access(user, db, [dataset_id])
+    
+    perm_service = PermissionService(db)
+    affected_user_ids = set()
+
+    for tid in payload.target_ids:
+        # 查询是否已经有对应记录了
+        stmt = select(ResourcePermission).where(
+            ResourcePermission.resource_type == "dataset",
+            ResourcePermission.resource_id == dataset_id
+        )
+        if payload.target_type == "user":
+            stmt = stmt.where(ResourcePermission.user_id == tid)
+            affected_user_ids.add(tid)
+        else:
+            stmt = stmt.where(ResourcePermission.role_id == tid)
+            # 获取该角色下的所有关联用户
+            r_users_stmt = select(UserRoleRelation.user_id).where(UserRoleRelation.role_id == tid)
+            r_users_res = await db.execute(r_users_stmt)
+            for uid in r_users_res.scalars().all():
+                affected_user_ids.add(uid)
+
+        result = await db.execute(stmt)
+        record = result.scalar_one_or_none()
+
+        if record:
+            record.enabled = True
+        else:
+            new_perm = ResourcePermission(
+                resource_type="dataset",
+                resource_id=dataset_id,
+                enabled=True
+            )
+            if payload.target_type == "user":
+                new_perm.user_id = tid
+            else:
+                new_perm.role_id = tid
+            db.add(new_perm)
+
+    await db.flush()
+
+    # 清理受影响用户的缓存，使其变更即刻生效
+    if affected_user_ids:
+        await perm_service.invalidate_cached_permissions_for_users(affected_user_ids)
+
+    return {"code": 0, "message": "权限配置已成功添加"}
+
+
+@router.delete("/datasets/{dataset_id}/permissions", dependencies=[Depends(require_permission("menu", "menu:system:users"))])
+async def delete_dataset_permission(
+    dataset_id: str,
+    payload: DeleteDatasetPermissionRequest,
+    db: AsyncSession = Depends(get_db_session),
+    user: dict = Depends(get_current_user)
+):
+    """
+    移除知识库关联的某个角色或用户授权 (仅有用户管理权限的用户可用)
+    """
+    from app.models.permission import ResourcePermission, UserRoleRelation
+    from sqlalchemy import select, delete
+
+    await require_dataset_write_access(user, db, [dataset_id])
+
+    perm_service = PermissionService(db)
+    affected_user_ids = set()
+
+    # 查出受影响的用户列表以作缓存清理
+    if payload.target_type == "user":
+        affected_user_ids.add(payload.target_id)
+    else:
+        r_users_stmt = select(UserRoleRelation.user_id).where(UserRoleRelation.role_id == payload.target_id)
+        r_users_res = await db.execute(r_users_stmt)
+        for uid in r_users_res.scalars().all():
+            affected_user_ids.add(uid)
+
+    # 物理清除
+    stmt = delete(ResourcePermission).where(
+        ResourcePermission.resource_type == "dataset",
+        ResourcePermission.resource_id == dataset_id
+    )
+    if payload.target_type == "user":
+        stmt = stmt.where(ResourcePermission.user_id == payload.target_id)
+    else:
+        stmt = stmt.where(ResourcePermission.role_id == payload.target_id)
+
+    await db.execute(stmt)
+    await db.flush()
+
+    # 清理 Redis 缓存
+    if affected_user_ids:
+        await perm_service.invalidate_cached_permissions_for_users(affected_user_ids)
+
+    return {"code": 0, "message": "授权已成功取消"}
 

--- a/app/api/portal/endpoints/ragflow.py
+++ b/app/api/portal/endpoints/ragflow.py
@@ -1000,3 +1000,98 @@ async def get_document_portal_recommendations(
         import logging
         logging.exception(f"Failed to fetch document recommendations: {str(e)}")
         return {"code": 0, "data": {"questions": default_questions}}
+
+
+@router.post("/datasets/{dataset_id}/ai-analyze")
+async def analyze_dataset_metadata(
+    dataset_id: str,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session)
+):
+    """
+    基于知识库里的文档文件名，调用大模型生成描述说明、标签和备注信息。
+    """
+    await require_dataset_write_access(user, db, [dataset_id])
+
+    client = RagFlowClient(config_prefix="knowledge_ragflow")
+    try:
+        docs = await client.list_documents(dataset_id, page=1, page_size=100)
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to fetch documents from RAGFlow: {str(e)}"
+        )
+
+    doc_names = [doc.get("name") for doc in docs if doc.get("name")]
+    if not doc_names:
+        raise HTTPException(
+            status_code=400,
+            detail="该知识库暂无文档，无法进行 AI 分析。"
+        )
+
+    from app.core.llm.client import get_llm_async
+    from app.services.ai.runtime.agentscope.chat import chat_client_from_handle
+    from app.services.ai.runtime.agentscope.messages import RuntimeContentBlock, RuntimeMessage
+    import json
+    import re
+
+    llm = await get_llm_async(streaming=False, temperature=0.7)
+    if not llm:
+        raise HTTPException(
+            status_code=500,
+            detail="无法初始化大模型，请检查 LLM 相关系统设置。"
+        )
+
+    chat_client = chat_client_from_handle(llm)
+    doc_names_str = ", ".join(doc_names[:50])
+
+    prompt = (
+        f"你是一个专业的知识库分析助手。当前知识库包含了以下文档列表：\n"
+        f"[{doc_names_str}]\n\n"
+        f"请根据这些文件的名字所反映的业务内容、行业特征及知识领域，为该知识库推断并生成以下元数据信息：\n"
+        f"1. 描述说明（description）：一句简明扼要地介绍该知识库包含哪些内容以及其主要用途的话，中文，不超过 100 字。\n"
+        f"2. 标签（tags）：3 到 5 个能够体现知识库核心主题的关键词或标签，可以是中文或英文，多个标签之间请用英文逗号 (,) 分隔。例如：\"ERP,系统说明,使用指南\"。\n"
+        f"3. 备注信息（notes）：对该知识库使用场景、目标读者或注意事项的简要补充说明，中文，不超过 100 字。\n\n"
+        f"请严格输出为以下格式的 JSON 对象，不要包含任何 Markdown 代码块标记（如 ```json）或多余的解释：\n"
+        f"{{\n"
+        f"  \"description\": \"...\",\n"
+        f"  \"tags\": \"...\",\n"
+        f"  \"notes\": \"...\"\n"
+        f"}}"
+    )
+
+    messages = [
+        RuntimeMessage(
+            role="system",
+            content=[RuntimeContentBlock(type="text", text="你是一个严谨的 JSON 格式输出器，只输出合法的 JSON，没有任何其他解释文本。")]
+        ),
+        RuntimeMessage(
+            role="user",
+            content=[RuntimeContentBlock(type="text", text=prompt)]
+        )
+    ]
+
+    try:
+        raw_text = await chat_client.generate_text(messages)
+        raw_text = str(raw_text or "").strip()
+        match = re.search(r"\{[\s\S]*\}", raw_text)
+        if match:
+            parsed_data = json.loads(match.group())
+            return {
+                "code": 0,
+                "data": {
+                    "description": parsed_data.get("description", "").strip(),
+                    "tags": parsed_data.get("tags", "").strip(),
+                    "notes": parsed_data.get("notes", "").strip()
+                }
+            }
+        else:
+            raise ValueError(f"No JSON block found in LLM response: {raw_text}")
+    except Exception as llm_err:
+        import logging
+        logging.exception("Failed to run AI metadata analysis via LLM")
+        raise HTTPException(
+            status_code=500,
+            detail=f"AI 分析失败: {str(llm_err)}"
+        )
+

--- a/app/services/ai/knowledge_utils.py
+++ b/app/services/ai/knowledge_utils.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 
 import ast
 import json
+import logging
 import re
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from app.core.context import get_current_agent_context
+
+logger = logging.getLogger(__name__)
+
+# RAGFlow 现网 dataset id 缓存（秒）：避免每轮检索都打 list API
+_ALIVE_DATASET_IDS_CACHE_KEY = "knowledge:ragflow:alive_dataset_ids"
+_ALIVE_DATASET_IDS_CACHE_TTL = 60
 
 # 32 位 hex，与 RAGFlow dataset id 常见格式一致
 _DATASET_ID_RE = re.compile(r"^[a-fA-F0-9]{32}$")
@@ -368,6 +375,94 @@ def resolve_bound_dataset_ids(
     )
 
 
+async def _load_ragflow_alive_dataset_ids() -> Optional[Set[str]]:
+    """
+    读取 RAGFlow 现网存在的 dataset id 集合。
+    返回 None 表示未能获取（应做 fail-open，避免检索整条链路被堵死）。
+    """
+    try:
+        from app.core.redis import get_redis
+
+        redis = await get_redis()
+        if redis is not None:
+            cached = await redis.get(_ALIVE_DATASET_IDS_CACHE_KEY)
+            if cached:
+                try:
+                    data = json.loads(cached)
+                    if isinstance(data, list):
+                        return {str(x) for x in data if x}
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    pass
+    except Exception as exc:
+        logger.debug("[KnowledgeUtils] alive dataset cache read skipped: %s", exc)
+
+    try:
+        from app.services.ai.ragflow_client import RagFlowClient
+
+        client = RagFlowClient(config_prefix="knowledge_ragflow")
+        items = await client.list_datasets(page=1, page_size=500)
+        alive = {
+            str(item.get("id") or "").strip()
+            for item in (items or [])
+            if item.get("id")
+        }
+    except Exception as exc:
+        logger.warning(
+            "[KnowledgeUtils] Failed to load RAGFlow alive dataset ids: %s",
+            exc,
+        )
+        return None
+
+    try:
+        from app.core.redis import get_redis
+
+        redis = await get_redis()
+        if redis is not None:
+            await redis.set(
+                _ALIVE_DATASET_IDS_CACHE_KEY,
+                json.dumps(sorted(alive)),
+                ex=_ALIVE_DATASET_IDS_CACHE_TTL,
+            )
+    except Exception as exc:
+        logger.debug("[KnowledgeUtils] alive dataset cache write skipped: %s", exc)
+
+    return alive
+
+
+async def filter_alive_knowledge_dataset_ids(dataset_ids: List[str]) -> List[str]:
+    """从待检索 ID 中剔除 RAGFlow 侧已不存在（失联）的知识库。"""
+    if not dataset_ids:
+        return []
+
+    # 保序去重，避免同一 ID 重复打到 RAGFlow
+    unique_ids: List[str] = []
+    seen: Set[str] = set()
+    for dataset_id in dataset_ids:
+        if not dataset_id or dataset_id in seen:
+            continue
+        seen.add(dataset_id)
+        unique_ids.append(dataset_id)
+
+    alive = await _load_ragflow_alive_dataset_ids()
+    if alive is None:
+        return unique_ids
+
+    kept: List[str] = []
+    dropped: List[str] = []
+    for dataset_id in unique_ids:
+        if dataset_id in alive:
+            kept.append(dataset_id)
+        else:
+            dropped.append(dataset_id)
+
+    if dropped:
+        logger.warning(
+            "[KnowledgeUtils] Dropped missing RAGFlow dataset ids before retrieve: %s",
+            dropped,
+        )
+    return kept
+
+
 async def resolve_knowledge_dataset_ids(
     *,
     explicit_tool_ids: Any = None,
@@ -386,7 +481,13 @@ async def resolve_knowledge_dataset_ids(
         query=query,
     )
     if bound_ids:
-        return bound_ids, None
+        alive_ids = await filter_alive_knowledge_dataset_ids(bound_ids)
+        if not alive_ids:
+            return [], (
+                "⚠️ 所选知识库在 RAGFlow 侧已失联或不存在，本次知识库问答已终止。\n"
+                "请重新选择可用知识库，或联系管理员清理失效授权后重试。"
+            )
+        return alive_ids, None
 
     ctx = get_current_agent_context()
     if ctx and ctx.require_explicit_dataset:
@@ -395,7 +496,12 @@ async def resolve_knowledge_dataset_ids(
     default_ids_str = await ConfigService.get("knowledge_ragflow_dataset_ids")
     fallback_ids = normalize_dataset_ids(default_ids_str) if default_ids_str else []
     if fallback_ids:
-        return fallback_ids, None
+        alive_ids = await filter_alive_knowledge_dataset_ids(fallback_ids)
+        if not alive_ids:
+            return [], (
+                "[System Warning] Configured knowledge_ragflow_dataset_ids are missing in RAGFlow."
+            )
+        return alive_ids, None
 
     return [], (
         "[System Warning] No knowledge base datasets configured. "

--- a/app/services/knowledge_base_service.py
+++ b/app/services/knowledge_base_service.py
@@ -77,7 +77,13 @@ class KnowledgeBaseMetadataService:
     ) -> Optional[KnowledgeBaseMetadata]:
         record = await self.get_by_dataset_id(dataset_id)
         if not record:
-            return None
+            record = KnowledgeBaseMetadata(
+                ragflow_dataset_id=dataset_id,
+                name=name if name is not None else "未命名知识库",
+                created_by=user_name,
+                status="active",
+            )
+            self.db.add(record)
 
         if name is not None:
             record.name = name

--- a/architech/design/KNOWLEDGE_PLATFORM_AND_CHAT_DESIGN.md
+++ b/architech/design/KNOWLEDGE_PLATFORM_AND_CHAT_DESIGN.md
@@ -1,0 +1,500 @@
+# 知识库中心与基于知识库聊天 — 架构设计
+
+本文档描述云枢智能体平台中 **知识库开发中心（管理侧）** 与 **基于知识库的聊天问答（消费侧）** 的端到端架构，以当前代码为准。
+
+| 关联文档 | 说明 |
+|----------|------|
+| [chat/CHAT_FLOW.md](./chat/CHAT_FLOW.md) | 通用对话主链路、Executor/Runner 分工 |
+| [chat/PROMPT_LAYERS.md](./chat/PROMPT_LAYERS.md) | 知识库附件注入、提示词分层 |
+| [permission_design.md](./permission_design.md) | RBAC、`resource_type=dataset` 权限 |
+| [AGENTSCOPE_RUNTIME.md](./AGENTSCOPE_RUNTIME.md) | KnowledgeAgentRunner 运行时 |
+| [openspec/specs/knowledge-platform/spec.md](../../openspec/specs/knowledge-platform/spec.md) | 知识库平台需求规格 |
+| [../api-schemal/ragflow-api.md](../api-schemal/ragflow-api.md) | RAGFlow 原生 API 参考 |
+
+*文档版本：2026-07-08*
+
+---
+
+## 1. 范围与术语
+
+### 1.1 范围
+
+| 模块 | 说明 |
+|------|------|
+| **知识库中心** | 控制台内知识库 CRUD、文档管理、检索测试、运营分析 |
+| **知识库门户** | 聊天页侧边抽屉，用户勾选本轮要检索的知识库 |
+| **知识库聊天** | 路由到 `KnowledgeExecutor` → 自动 RAG 检索 → 带引用回答 |
+| **运营埋点** | 检索/引用行为统计，Redis → MySQL 落库 |
+
+### 1.2 核心术语
+
+| 术语 | 含义 |
+|------|------|
+| **RAGFlow `dataset_id`** | RAGFlow 知识库 ID，32 位 hex 字符串；**检索与权限的唯一业务主键** |
+| **本地元数据** | `knowledge_base_metadata` 表，存平台侧名称、标签、归属等，与 RAGFlow Dataset 1:1 |
+| **显式选库** | 用户在聊天窗口通过知识库门户勾选，产生 `knowledge_dataset_ids` |
+| **智能体绑定** | `engine_config.dataset_ids`，智能体管理后台配置 |
+| **系统默认库** | 系统配置 `knowledge_ragflow_dataset_ids`，作为非强制场景兜底 |
+
+---
+
+## 2. 系统架构总览
+
+```mermaid
+flowchart TB
+    subgraph Admin["知识库中心（管理侧）"]
+        KBM[KnowledgeBaseManagement.vue]
+        KRT[KnowledgeRetrievalTest.vue]
+        KM[KnowledgeMetrics.vue]
+        KBM --> PortalAPI["/api/portal/ragflow/*"]
+        KRT --> PortalAPI
+        KM --> PortalAPI
+    end
+
+    subgraph Chat["聊天侧（消费侧）"]
+        KPD[KnowledgePortalDrawer]
+        UKP[useKnowledgePortal]
+        EC[EmbedChat / AgentDebug]
+        KPD --> UKP --> EC
+    end
+
+    subgraph Backend["后端编排"]
+        ChatAPI["/api/v1/chat/completions"]
+        AS[AgentService]
+        ACM[AgentContextManager]
+        TC[TurnClassifier → KNOWLEDGE]
+        KE[KnowledgeExecutor]
+        KAR[KnowledgeAgentRunner]
+        KT[search_knowledge_base]
+        ChatAPI --> AS --> ACM
+        AS --> TC --> KE --> KAR --> KT
+    end
+
+    subgraph External["外部依赖"]
+        RF[RAGFlow /api/v1/retrieval]
+        MySQL[(knowledge_base_metadata<br/>knowledge_base_metrics)]
+        Redis[(kb:citation:stats<br/>kb:citation:doc_names)]
+    end
+
+    PortalAPI --> RF
+    PortalAPI --> MySQL
+    EC --> ChatAPI
+    KT --> RF
+    KAR --> Redis
+    KM --> MySQL
+```
+
+**设计原则：**
+
+- **存储分离**：文档内容与向量在 RAGFlow；平台只维护扩展元数据、权限、审计与运营指标。
+- **检索专用配置**：知识库问答使用 `knowledge_ragflow_*` 配置前缀，与 ChatBI 元数据 RAG 配置隔离。
+- **自动预检索**：`KnowledgeAgentRunner` 在 ReAct 前平台侧自动调用 `search_knowledge_base`，不依赖模型自觉调工具。
+
+---
+
+## 3. 知识库中心（管理侧）
+
+### 3.1 前端页面与路由
+
+| 路由 | 页面 | 菜单权限 | 职责 |
+|------|------|----------|------|
+| `/dashboard/knowledge-bases` | `KnowledgeBaseManagement.vue` | `menu:knowledge_management` | 知识库列表、创建、元数据、文档树、上传/解析/删除 |
+| `/dashboard/knowledge-retrieval-test` | `KnowledgeRetrievalTest.vue` | `menu:knowledge_retrieval_test` | 管理员/开发者检索调试 |
+| `/dashboard/knowledge-metrics` | `KnowledgeMetrics.vue` | `menu:knowledge_management` | 运营分析看板 |
+
+系统配置入口：`SystemConfig.vue` 中 **知识库设置** 分组（`knowledge_ragflow_*`、`knowledge_base_enabled`）。
+
+### 3.2 后端 Portal API（`app/api/portal/endpoints/ragflow.py`）
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/config` | RAGFlow 连接状态摘要 |
+| GET | `/datasets` | 列表（合并本地元数据 + RAGFlow） |
+| POST | `/datasets/sync` | 从 RAGFlow 同步并 upsert 本地元数据 |
+| POST | `/datasets` | 创建知识库 |
+| PUT | `/datasets/{id}/metadata` | 更新本地扩展元数据 |
+| DELETE | `/datasets` | 删除知识库 |
+| GET/POST/DELETE | `/datasets/{id}/documents/*` | 文档列表、上传、删除、解析 |
+| GET | `/datasets/{id}/documents/{doc_id}/chunks` | Chunk 明细（需写权限） |
+| GET | `/datasets/{id}/documents/{doc_id}/file` | 原档下载/预览 |
+| POST | `/retrieval-test` | 检索测试（直连 RAGFlow） |
+| GET | `/datasets/{id}/portal` | 知识库门户推荐提问 |
+| GET | `/datasets/{id}/documents/{doc_id}/portal` | 文档级推荐提问 |
+| GET | `/metrics/summary` | 运营指标汇总 |
+| GET | `/datasets/{id}/permissions` | 知识库授权用户/角色 |
+
+所有写操作经 `require_dataset_access` / `require_dataset_write_access` 与元素级权限（`element:knowledge:*`）校验，并写审计日志。
+
+### 3.3 本地元数据 vs RAGFlow
+
+```
+RAGFlow Dataset (物理存储)
+    id  = ragflow_dataset_id  ← 检索、权限、聊天传参均用此 ID
+    name, description, chunks...
+
+knowledge_base_metadata (平台扩展)
+    ragflow_dataset_id  (唯一索引)
+    name, description, owner, tags, notes, visibility, status, created_by ...
+```
+
+- 列表接口由 `KnowledgeBaseMetadataService.merge_with_ragflow()` 合并两侧数据。
+- RAGFlow 有而本地无 → 展示为活跃知识库；本地有而 RAGFlow 无 → `status=missing`。
+- 运营分析中的知识库中文名：优先本地元数据 → Redis 缓存 → RAGFlow 列表回退。
+
+### 3.4 权限模型（知识库资源）
+
+`PermissionService.get_knowledge_base_access()` 口径：
+
+| 角色 | 可访问范围 | 可写范围 |
+|------|------------|----------|
+| 管理员 | 全部 | 全部 |
+| 普通用户 | 角色/用户直连 `permissions.datasets` ∪ 自己创建的 ∪ 系统默认公开库 | 仅自己创建的 |
+
+菜单权限（`menu:knowledge_management`）与数据权限（`resource_type=dataset`）**分离**：有菜单不等于能检索所有库。
+
+---
+
+## 4. 知识库门户（聊天侧选库）
+
+### 4.1 组件与状态
+
+| 文件 | 职责 |
+|------|------|
+| `KnowledgePortalDrawer.vue` | 侧边抽屉 UI：知识库卡片、文档树、推荐提问、高级检索参数 |
+| `useKnowledgePortal.ts` | 数据集加载、钉住/偏好、激活 ID 与输入框附件同步 |
+| `ChatInput.vue` | 展示 `knowledge_base` 类型附件胶囊 |
+
+### 4.2 用户勾选 → 输入框附件
+
+用户在门户中 toggle 知识库开关时：
+
+```typescript
+// useKnowledgePortal.ts
+{
+  type: "knowledge_base",
+  url: currentIds.join(","),           // 一个或多个 dataset_id，逗号拼接
+  filename: `已选择 ${n} 个知识库`,
+}
+```
+
+写入 `chatInputRef.uploadedFiles`，成为本轮「显式选库」的载体。
+
+### 4.3 门户能力摘要
+
+- **钉住 / 提问后不关闭**：偏好持久化到 `portal-prefs`（`pinned_kb_dataset_ids` 等）。
+- **推荐提问**：`GET /datasets/{id}/portal`，支持换一批（`exclude` 参数 + 随机抽样文档名）。
+- **文档级提问**：展开文档后 `GET .../documents/{doc_id}/portal`。
+- **高级参数**（存 localStorage，经 `debug_options` 传入后端）：
+  - `knowledge_ragflow_similarity_threshold`
+  - `knowledge_ragflow_vector_weight`
+  - `knowledge_ragflow_metadata_top_k`
+- **反幻觉开关**：`hallucination_check`（NLI 事实一致性网关，默认关）。
+
+---
+
+## 5. 基于知识库的聊天链路
+
+### 5.1 前端发消息
+
+```mermaid
+sequenceDiagram
+    participant U as 用户
+    participant FE as EmbedChat/AgentDebug
+    participant API as /api/v1/chat/completions
+
+    U->>FE: 输入问题 + 可选知识库附件
+    FE->>FE: collectKnowledgeDatasetIds()
+    FE->>FE: appendAttachmentContext() 注入 dataset_id 文本提示
+    FE->>API: messages + knowledge_dataset_ids + debug_options
+```
+
+**双通道传递 dataset ID：**
+
+| 通道 | 字段 | 说明 |
+|------|------|------|
+| 结构化 | `knowledge_dataset_ids: string[]` | 优先口径；来自附件 + 历史 user 消息 |
+| 文本提示 | user 消息 `---` 后附加 | 要求模型调用 `search_knowledge_base`，含 `dataset_id：xxx` |
+
+```typescript
+// EmbedChat.vue — 收集 ID（含追问继承）
+collectKnowledgeDatasetIds()  // 当前 uploadedFiles + 历史 messages.files
+
+// 注入文本（与结构化并行）
+`用户本轮已选择知识库，dataset_id：${file.url}。你必须...调用 search_knowledge_base...`
+```
+
+### 5.2 API 入口
+
+`ChatCompletionRequest.knowledge_dataset_ids`（`app/api/v1/endpoints/chat.py`）：
+
+```python
+knowledge_dataset_ids: Optional[List[str]]  # 本轮结构化指定的 RAGFlow dataset ID 列表
+```
+
+`AgentService` 合并：
+
+```python
+request_knowledge_dataset_ids = merge_request_knowledge_dataset_ids(
+    knowledge_dataset_ids,   # API 字段
+    messages,                # 历史 knowledge_base 附件
+)
+```
+
+### 5.3 执行上下文：dataset ID 解析规则
+
+`AgentContextManager.setup_context()` 决定本轮 `AgentContext.dataset_ids`：
+
+```
+① 若 request_knowledge_dataset_ids 非空
+      → effective_dataset_ids = 用户显式选择（最高优先级）
+
+② 否则
+      → agent_dataset_ids = engine_config.dataset_ids（智能体绑定）
+      → user_permitted_ids = 当前用户可访问的知识库集合
+      → effective_dataset_ids = merge(agent_dataset_ids, user_permitted_ids)
+```
+
+**用户可访问集合**（`user_permitted_ids`）包含：
+
+- 角色/用户直连授权的 `permissions.datasets`
+- 自己创建的知识库（`knowledge_base_metadata.created_by`）
+- 系统配置 `knowledge_ragflow_dataset_ids`（默认公开兜底）
+
+写入上下文：
+
+```python
+AgentContext(
+    dataset_ids=effective_dataset_ids,           # 本轮实际检索范围
+    knowledge_dataset_ids=request_dataset_ids,     # 仅用户显式选择部分
+    require_explicit_dataset=...,                  # KNOWLEDGE 轮次为 True
+)
+```
+
+### 5.4 检索前二次解析：`resolve_knowledge_dataset_ids`
+
+工具调用或自动预检索时，`knowledge_utils.resolve_knowledge_dataset_ids()` 合并：
+
+| 优先级（合并去重） | 来源 |
+|--------------------|------|
+| 1 | 工具参数 `dataset_ids`（模型手动传入时） |
+| 2 | `ctx.knowledge_dataset_ids`（请求结构化字段） |
+| 3 | `ctx.dataset_ids`（上下文有效 ID） |
+| 4 | 用户消息文本中的 `dataset_id：` 提示 |
+
+**解析后：**
+
+| 条件 | 行为 |
+|------|------|
+| `bound_ids` 非空 | 继续；非 admin 经 `filter_knowledge_dataset_ids` 过滤 |
+| `bound_ids` 为空 且 `require_explicit_dataset=True` | 返回错误，**不使用**系统默认库 |
+| `bound_ids` 为空 且未强制 | 回落 `knowledge_ragflow_dataset_ids` |
+
+### 5.5 场景对照表
+
+| 场景 | 显式选库 | 智能体绑定 | KNOWLEDGE 轮次 | 实际检索 ID |
+|------|----------|------------|----------------|-------------|
+| 门户勾选 1 个库 | ✅ | 任意 | ✅ | 仅勾选的库 |
+| 未勾选，智能体绑定了 A | ❌ | A | ✅ | A（若在用户权限内） |
+| 未勾选未绑定，普通助手轮次 | ❌ | ❌ | ❌ | 用户权限库 ∪ 系统默认库 |
+| 未勾选未绑定，知识库轮次 | ❌ | ❌ | ✅ | **报错终止** |
+
+> **结论（与产品口径对齐）**  
+> - **显式选了** → 用显式的。  
+> - **没显式选** → 用智能体绑定 + 用户有权限的库（含分配给自己的、自己创建的、系统默认公开）；**不是**简单等于「全部有权限库」。  
+> - **知识库专属轮次**且无显式选、无智能体绑定时，不允许回落系统默认。
+
+### 5.6 轮次分类与 Executor 路由
+
+`TurnClassifier` 判定 `TurnType.KNOWLEDGE` 的条件（满足其一）：
+
+- 请求携带 `knowledge_dataset_ids`
+- 智能体 `capabilities` 含 `knowledge_base` 且 `engine_config.dataset_ids` 非空
+- 启发式 `looks_like_knowledge_query(q)`
+
+路由：
+
+```
+AgentService → Dispatcher → KnowledgeExecutor → KnowledgeAgentRunner
+```
+
+`KNOWLEDGE` 轮次额外执行：
+
+```python
+agent_config = await AgentContextManager.enrich_for_knowledge_turn(...)
+await AgentContextManager.setup_context(..., require_explicit_dataset=True)
+```
+
+### 5.7 自动预检索与回答生成
+
+`KnowledgeAgentRunner.execute()` 主流程：
+
+```mermaid
+flowchart TD
+    A[解析 resolve_knowledge_dataset_ids] --> B{有可用 ID?}
+    B -->|否| Z[终止: 未指定知识库]
+    B -->|是| C[自动 search_knowledge_base 预检索]
+    C --> D[检索结果注入 system / 观察消息]
+    D --> E[AgentScope ReAct 生成回答]
+    E --> F{反幻觉网关 optional}
+    F --> G[流式输出 + citation 事件]
+    G --> H[Redis 埋点 search/citation]
+```
+
+**`search_knowledge_base` 工具**（`app/services/ai/tools/knowledge_tool.py`）：
+
+1. `resolve_knowledge_dataset_ids` + 权限过滤
+2. `resolve_rag_retrieval_params`（系统配置 ← 智能体配置 ← `debug_options`）
+3. `RagFlowClient.retrieve()` → `POST /api/v1/retrieval`
+
+返回 JSON：
+
+```json
+{
+  "content": "供 LLM 阅读的检索摘要（含 [ID:n] 指引）",
+  "citations": [ { "id": "1", "doc_name", "content", "similarity", "doc_id", "dataset_id", ... } ]
+}
+```
+
+### 5.8 RAGFlow 检索请求体
+
+```python
+# app/services/ai/ragflow_client.py
+{
+    "question": query,
+    "dataset_ids": ["32位hex", ...],   # 核心：限定检索范围
+    "top_k": 5,
+    "page_size": top_k * 3,
+    "similarity_threshold": 0.2,
+    "vector_similarity_weight": 0.3
+}
+```
+
+配置前缀：`knowledge_ragflow`（`ConfigService` category=`knowledge`）。
+
+---
+
+## 6. 引用、原档预览与埋点
+
+### 6.1 引用格式
+
+- 规范：`[ID:n]`（n 为检索结果序号，从 1 开始）
+- 兼容旧式：`[n]`（逐步废弃）
+- 前端 `CitationPopover` 展示片段；桌面端可「查看原档」，移动端隐藏
+
+### 6.2 原档预览抽屉
+
+`RagPreviewDrawer.vue`（`AgentDebug` / `EmbedChat` 共用）：
+
+| 区域 | 内容 |
+|------|------|
+| 原档预览 | PDF → iframe；Office → 提示下载 |
+| 被引用原文段落 | 检索 chunk HTML |
+| 交互 | 两块均支持折叠；折叠一侧则另一侧占满剩余高度 |
+
+原档 URL：`/api/portal/ragflow/datasets/{dataset_id}/documents/{doc_id}/file`
+
+### 6.3 运营埋点
+
+| 阶段 | 存储 | 说明 |
+|------|------|------|
+| 实时 | Redis `kb:citation:stats:{date}:dataset|document:search|citation` | 每次回答通过后 `HINCRBY` |
+| 名称缓存 | Redis `kb:citation:doc_names`、`kb:citation:dataset_names` | 文档名 / 知识库名 |
+| 落库 | `knowledge_base_metrics` 表 | 分钟级任务 + 看板刷新时同步 |
+| 展示 | `KnowledgeMetrics.vue` | 趋势、排行榜、活跃文献源 |
+
+埋点位置：`KnowledgeAgentRunner` 回答通过幻觉网关后，解析 `[ID:n]` 与 `prefetched_citations_raw` 对比。
+
+---
+
+## 7. 系统配置清单
+
+| Key | 默认值 | 说明 |
+|-----|--------|------|
+| `knowledge_base_enabled` | `true` | 总开关；关闭后 `search_knowledge_base` 直接报错 |
+| `knowledge_ragflow_api_url` | — | RAGFlow 网关地址 |
+| `knowledge_ragflow_api_key` | — | API Key（secret） |
+| `knowledge_ragflow_dataset_ids` | — | 默认公开知识库 ID，逗号分隔 |
+| `knowledge_ragflow_metadata_top_k` | `5` | 召回 chunk 数 |
+| `knowledge_ragflow_similarity_threshold` | `0.2` | 相似度阈值 |
+| `knowledge_ragflow_vector_weight` | `0.3` | 向量权重（余下为全文） |
+
+智能体级覆盖：`engine_config.dataset_ids`、`ragflow_similarity_threshold`、`top_k` 等。
+
+---
+
+## 8. 数据库表
+
+| 表 | 用途 |
+|----|------|
+| `knowledge_base_metadata` | 本地知识库扩展元数据，`ragflow_dataset_id` 唯一 |
+| `knowledge_base_metrics` | 按日、按 dataset/document 维度的 search/citation 计数 |
+
+迁移脚本：`db-prod/V58-create_knowledge_base_metadata.sql`、`V77-add_knowledge_ragflow_configs.sql`、`V93-create_knowledge_base_metrics.sql`。
+
+---
+
+## 9. 代码入口速查
+
+### 9.1 前端
+
+| 路径 | 说明 |
+|------|------|
+| `frontend/src/views/KnowledgeBaseManagement.vue` | 知识库管理主页 |
+| `frontend/src/views/KnowledgeRetrievalTest.vue` | 检索测试 |
+| `frontend/src/views/KnowledgeMetrics.vue` | 运营分析 |
+| `frontend/src/components/knowledge/KnowledgePortalDrawer.vue` | 聊天知识库门户 |
+| `frontend/src/composables/useKnowledgePortal.ts` | 门户状态与 API |
+| `frontend/src/components/RagPreviewDrawer.vue` | 原档预览抽屉 |
+| `frontend/src/components/CitationPopover.vue` | 引用浮层 |
+| `frontend/src/views/EmbedChat.vue` | 嵌入页聊天 + 选库发消息 |
+| `frontend/src/views/AgentDebug.vue` | 调试页聊天 + 选库发消息 |
+
+### 9.2 后端
+
+| 路径 | 说明 |
+|------|------|
+| `app/api/portal/endpoints/ragflow.py` | 知识库 Portal API |
+| `app/api/v1/endpoints/chat.py` | 聊天 API，`knowledge_dataset_ids` 字段 |
+| `app/services/knowledge_base_service.py` | 元数据 CRUD、与 RAGFlow 合并 |
+| `app/services/knowledge_metrics_service.py` | 指标同步与汇总 |
+| `app/services/ai/knowledge_utils.py` | dataset ID 解析、RAG 参数、引用校验 |
+| `app/services/ai/tools/knowledge_tool.py` | `search_knowledge_base` 工具 |
+| `app/services/ai/context_manager.py` | `setup_context`、`enrich_for_knowledge_turn` |
+| `app/services/ai/agent_service.py` | 主编排、合并 `knowledge_dataset_ids` |
+| `app/services/ai/turn_classifier.py` | `TurnType.KNOWLEDGE` 判定 |
+| `app/services/ai/executors/knowledge_executor.py` | 薄封装 |
+| `app/services/ai/runners/knowledge_agent_runner.py` | 自动预检索、ReAct、埋点 |
+| `app/services/ai/ragflow_client.py` | RAGFlow HTTP 客户端 |
+| `app/services/permission_service.py` | 知识库数据权限 |
+
+### 9.3 智能体配置
+
+- 管理后台 `AgentManagement.vue`：`engine_config.dataset_ids` 绑定默认知识库
+- 系统智能体提示词：`architech/prompts/system_agents/knowledge/knowledge_base.md`
+
+---
+
+## 10. 与 ChatBI / 通用助手的边界
+
+| 维度 | 知识库聊天 | ChatBI | 通用助手 |
+|------|------------|--------|----------|
+| Executor | `KnowledgeExecutor` | `DataQueryExecutor` | `AssistantExecutor` |
+| 预检索 | 自动 `search_knowledge_base` | 自动 Schema / 目录 | 无 |
+| dataset ID | RAGFlow `dataset_id` | `MetaDataset.id` / 元数据 RAG | 可选绑库 |
+| RAGFlow 配置前缀 | `knowledge_ragflow` | `metadata` / 元数据专用 | — |
+| 引用 | `[ID:n]` + citation 事件 | SQL / 图表 | 一般无 |
+
+---
+
+## 11. 已知限制与后续扩展
+
+| 项 | 现状 |
+|----|------|
+| Office 原档 | 不支持在线预览，仅下载 |
+| 联网检索 | `KnowledgeAgentRunner` 显式排除 `web_search_baidu` 等，避免替代知识库检索 |
+| 多库逗号拼接 | 前端 `url` 单字符串逗号分隔，后端 `normalize_dataset_ids` 拆分 |
+| 知识库名未登记 | 运营榜可能短暂显示 `知识库: {id前8位}`，靠 RAGFlow 列表回退补全 |
+
+---
+
+*维护说明：知识库检索参数、权限口径或门户交互变更时，请同步更新本文档与 [openspec/specs/knowledge-platform/spec.md](../../openspec/specs/knowledge-platform/spec.md)。*

--- a/frontend/src/components/RagPreviewDrawer.vue
+++ b/frontend/src/components/RagPreviewDrawer.vue
@@ -1,0 +1,192 @@
+<template>
+  <teleport to="body">
+    <div
+      class="fixed top-0 right-0 h-full w-full sm:w-[45%] bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-800 shadow-2xl z-[260] flex flex-col transition-transform duration-300 ease-in-out transform"
+      :class="modelValue ? 'translate-x-0' : 'translate-x-full'"
+    >
+      <!-- Header -->
+      <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex-shrink-0 bg-gray-50/50 dark:bg-gray-800/40">
+        <div class="min-w-0">
+          <h3 class="text-sm font-bold text-gray-800 dark:text-gray-100 truncate" :title="docName">
+            {{ docName }}
+          </h3>
+          <p class="text-[11px] text-gray-400 mt-0.5">
+            第 {{ pageNo }} 页 RAG 关联原档智能高亮预览
+          </p>
+        </div>
+        <button
+          type="button"
+          class="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors flex-shrink-0"
+          title="关闭预览"
+          @click="close"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Collapsible panels -->
+      <div class="flex-1 min-h-0 flex flex-col">
+        <!-- Preview panel -->
+        <section
+          class="flex flex-col min-h-0 border-b border-gray-100 dark:border-gray-800 transition-[flex-grow] duration-300 ease-in-out"
+          :class="previewExpanded ? 'flex-1' : 'flex-shrink-0'"
+        >
+          <button
+            type="button"
+            class="flex items-center justify-between gap-2 px-4 py-2.5 flex-shrink-0 bg-gray-50/80 dark:bg-gray-800/50 hover:bg-gray-100/90 dark:hover:bg-gray-800 transition-colors text-left"
+            @click="togglePreview"
+          >
+            <span class="text-[11px] font-bold text-gray-600 dark:text-gray-300 tracking-wide flex items-center gap-1.5 min-w-0">
+              <svg class="w-3.5 h-3.5 text-primary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              <span class="truncate">原档预览</span>
+            </span>
+            <svg
+              class="w-4 h-4 text-gray-400 flex-shrink-0 transition-transform duration-200"
+              :class="{ 'rotate-180': previewExpanded }"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          <div
+            v-show="previewExpanded"
+            class="flex-1 min-h-0 bg-gray-100/30 relative flex flex-col items-center justify-center overflow-hidden"
+          >
+            <div v-if="isOfficeDocument" class="p-8 text-center max-w-sm space-y-4 flex flex-col items-center">
+              <div class="inline-flex p-4 bg-amber-50 dark:bg-amber-950/20 text-amber-600 dark:text-amber-400 rounded-full">
+                <svg class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+              </div>
+              <div>
+                <h4 class="text-sm font-bold text-gray-800 dark:text-gray-100">Office 文档暂不支持在线预览</h4>
+                <p class="text-xs text-gray-400 mt-1.5 leading-relaxed">
+                  由于您的文件是 Word/Excel 类型，系统已自动拉起浏览器进行本地下载。若未开始，可点击下方按钮重新发起下载。
+                </p>
+              </div>
+              <button
+                type="button"
+                class="inline-flex items-center px-4 py-2 bg-blue-600 text-white text-xs font-bold rounded-xl shadow-sm hover:bg-blue-700 active:scale-95 transition-all"
+                @click="downloadOriginalFile"
+              >
+                重新下载原档
+              </button>
+            </div>
+
+            <iframe
+              v-else-if="modelValue && fileUrl"
+              :src="`${fileUrl}#page=${pageNo}`"
+              class="w-full h-full border-none"
+            />
+            <div v-else class="absolute inset-0 flex items-center justify-center text-gray-400 text-xs">
+              正在加载文档预览...
+            </div>
+          </div>
+        </section>
+
+        <!-- Citation panel -->
+        <section
+          class="flex flex-col min-h-0 transition-[flex-grow] duration-300 ease-in-out"
+          :class="citationExpanded ? 'flex-1' : 'flex-shrink-0'"
+        >
+          <button
+            type="button"
+            class="flex items-center justify-between gap-2 px-4 py-2.5 flex-shrink-0 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors text-left border-t border-gray-100 dark:border-gray-800"
+            @click="toggleCitation"
+          >
+            <span class="text-[11px] font-bold text-gray-600 dark:text-gray-300 tracking-wide flex items-center gap-1.5 min-w-0">
+              <svg class="w-3.5 h-3.5 text-primary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+              <span class="truncate">被引用原文段落</span>
+            </span>
+            <svg
+              class="w-4 h-4 text-gray-400 flex-shrink-0 transition-transform duration-200"
+              :class="{ 'rotate-180': citationExpanded }"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          <div
+            v-show="citationExpanded"
+            class="flex-1 min-h-0 flex flex-col bg-white dark:bg-gray-900 px-4 pb-4 overflow-hidden"
+          >
+            <div
+              class="flex-1 min-h-0 overflow-y-auto p-3 bg-blue-50/30 dark:bg-blue-900/5 border border-blue-100/50 dark:border-blue-900/10 rounded-xl text-xs text-gray-600 dark:text-gray-300 leading-relaxed custom-table-render scrollbar-thin"
+              v-html="content"
+            />
+          </div>
+        </section>
+      </div>
+    </div>
+  </teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+
+const modelValue = defineModel<boolean>({ default: false });
+
+const props = defineProps<{
+  docName: string;
+  pageNo: string | number;
+  fileUrl: string;
+  content: string;
+  isOfficeDocument: boolean;
+}>();
+
+const previewExpanded = ref(true);
+const citationExpanded = ref(true);
+
+watch(modelValue, (visible) => {
+  if (visible) {
+    previewExpanded.value = true;
+    citationExpanded.value = true;
+  }
+});
+
+const togglePreview = () => {
+  previewExpanded.value = !previewExpanded.value;
+  if (!previewExpanded.value && !citationExpanded.value) {
+    citationExpanded.value = true;
+  }
+};
+
+const toggleCitation = () => {
+  citationExpanded.value = !citationExpanded.value;
+  if (!citationExpanded.value && !previewExpanded.value) {
+    previewExpanded.value = true;
+  }
+};
+
+const close = () => {
+  modelValue.value = false;
+};
+
+const downloadOriginalFile = () => {
+  if (!props.fileUrl) return;
+  const link = document.createElement("a");
+  link.href = props.fileUrl;
+  link.download = props.docName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+</script>
+
+<style scoped>
+.scrollbar-thin::-webkit-scrollbar {
+  width: 4px;
+}
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background-color: rgba(156, 163, 175, 0.35);
+  border-radius: 9999px;
+}
+</style>

--- a/frontend/src/components/knowledge/KnowledgePortalDrawer.vue
+++ b/frontend/src/components/knowledge/KnowledgePortalDrawer.vue
@@ -143,22 +143,102 @@
                   </div>
                 </div>
                 
-                <button
-                  type="button"
-                  class="w-7 h-7 flex items-center justify-center rounded-lg border border-transparent bg-gray-50 text-gray-500 hover:bg-gray-100 hover:text-gray-750 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-750 dark:hover:text-gray-200 transition-all cursor-pointer active:scale-90 flex-shrink-0"
-                  title="刷新知识库列表"
-                  :disabled="loading"
-                  @click="emit('refresh')"
-                >
-                  <svg 
-                    class="w-3.5 h-3.5"
-                    :class="{ 'animate-spin': loading }"
-                    fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                <div class="flex items-center gap-1.5 flex-shrink-0">
+                  <!-- 🔍 搜索折叠切换按钮 -->
+                  <button
+                    type="button"
+                    class="w-7 h-7 flex items-center justify-center rounded-lg border border-transparent transition-all cursor-pointer active:scale-90"
+                    :class="showSearchBar
+                      ? 'bg-green-50 text-green-600 dark:bg-green-955/40 dark:text-green-400 font-bold'
+                      : 'bg-gray-50 text-gray-500 dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-750'"
+                    title="展开/折叠搜索与标签过滤"
+                    @click="showSearchBar = !showSearchBar"
                   >
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
-                  </svg>
-                </button>
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                    </svg>
+                  </button>
+
+                  <button
+                    type="button"
+                    class="w-7 h-7 flex items-center justify-center rounded-lg border border-transparent bg-gray-50 text-gray-500 hover:bg-gray-100 hover:text-gray-750 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-750 dark:hover:text-gray-200 transition-all cursor-pointer active:scale-90"
+                    title="刷新知识库列表"
+                    :disabled="loading"
+                    @click="emit('refresh')"
+                  >
+                    <svg 
+                      class="w-3.5 h-3.5"
+                      :class="{ 'animate-spin': loading }"
+                      fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                    >
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+                    </svg>
+                  </button>
+                </div>
               </div>
+
+              <!-- Search and Filter Bar -->
+              <transition
+                enter-active-class="transition-all duration-300 ease-out"
+                enter-from-class="transform opacity-0 -translate-y-2 max-h-0 overflow-hidden"
+                enter-to-class="transform opacity-100 translate-y-0 max-h-[120px] overflow-hidden"
+                leave-active-class="transition-all duration-200 ease-in"
+                leave-from-class="transform opacity-100 translate-y-0 max-h-[120px] overflow-hidden"
+                leave-to-class="transform opacity-0 -translate-y-2 max-h-0 overflow-hidden"
+              >
+                <div v-show="showSearchBar" class="space-y-2">
+                  <div class="relative">
+                    <span class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-400 dark:text-gray-500">
+                      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                      </svg>
+                    </span>
+                    <input
+                      v-model="searchQuery"
+                      type="text"
+                      placeholder="搜索分类标签、名称或描述..."
+                      class="w-full pl-9 pr-8 py-1.5 text-[11px] rounded-xl border border-gray-150 dark:border-gray-800 bg-white dark:bg-gray-900/30 text-gray-850 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-green-500 focus:ring-1 focus:ring-green-500 transition-all shadow-xs"
+                    />
+                    <button
+                      v-if="searchQuery"
+                      type="button"
+                      class="absolute inset-y-0 right-0 flex items-center pr-2.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+                      @click="searchQuery = ''"
+                    >
+                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+
+                  <div v-if="allTags.length" class="relative">
+                    <div class="flex items-center gap-1.5 overflow-x-auto no-scrollbar pb-1 -mx-0.5 scroll-smooth">
+                      <button
+                        type="button"
+                        class="px-2.5 py-1 text-[9px] font-bold rounded-lg border transition-all whitespace-nowrap cursor-pointer active:scale-95 select-none"
+                        :class="selectedTag === 'All'
+                          ? 'bg-green-600 border-transparent text-white shadow-xs'
+                          : 'bg-gray-50 dark:bg-gray-800/40 border-gray-150 dark:border-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'"
+                        @click="selectedTag = 'All'"
+                      >
+                        全部
+                      </button>
+                      <button
+                        v-for="tag in allTags"
+                        :key="tag"
+                        type="button"
+                        class="px-2.5 py-1 text-[9px] font-bold rounded-lg border transition-all whitespace-nowrap cursor-pointer active:scale-95 select-none"
+                        :class="selectedTag === tag
+                          ? 'bg-green-600 border-transparent text-white shadow-xs'
+                          : 'bg-gray-50 dark:bg-gray-800/40 border-gray-150 dark:border-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'"
+                        @click="selectedTag = tag"
+                      >
+                        {{ tag }}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </transition>
 
               <!-- ⚙️ 高级选项 (Collapsible) -->
               <div class="rounded-xl border border-blue-150/70 dark:border-blue-900/40 bg-blue-50/10 dark:bg-blue-950/5 p-3 space-y-2.5">
@@ -770,12 +850,48 @@ const expandedDocRecsId = ref<string | null>(null);
 const showAdvancedConfig = ref(false);
 const activeTooltip = ref<string | null>(null);
 
+const showSearchBar = ref(false);
+const searchQuery = ref("");
+const selectedTag = ref("All");
+
 const isMobile = computed(() => {
   return typeof window !== "undefined" && window.matchMedia("(max-width: 639px)").matches;
 });
 
+const allTags = computed(() => {
+  const tagsSet = new Set<string>();
+  props.datasets.forEach(ds => {
+    if (ds.tags && Array.isArray(ds.tags)) {
+      ds.tags.forEach(tag => {
+        if (tag && tag.trim()) {
+          tagsSet.add(tag.trim());
+        }
+      });
+    }
+  });
+  return Array.from(tagsSet).sort();
+});
+
 const sortedDatasets = computed(() => {
-  return [...props.datasets].sort((a, b) => {
+  let filtered = [...props.datasets];
+  
+  if (selectedTag.value !== "All") {
+    filtered = filtered.filter(ds => 
+      ds.tags && Array.isArray(ds.tags) && ds.tags.map(t => t.trim()).includes(selectedTag.value)
+    );
+  }
+  
+  if (searchQuery.value.trim()) {
+    const q = searchQuery.value.trim().toLowerCase();
+    filtered = filtered.filter(ds => {
+      const name = (ds.platform_name || ds.name || "").toLowerCase();
+      const desc = (ds.platform_description || ds.description || "").toLowerCase();
+      const tags = (ds.tags || []).join(",").toLowerCase();
+      return name.includes(q) || desc.includes(q) || tags.includes(q);
+    });
+  }
+
+  return filtered.sort((a, b) => {
     const aPinned = props.pinnedDatasetIds.includes(a.id);
     const bPinned = props.pinnedDatasetIds.includes(b.id);
     if (aPinned && !bPinned) return -1;

--- a/frontend/src/components/knowledge/KnowledgePortalDrawer.vue
+++ b/frontend/src/components/knowledge/KnowledgePortalDrawer.vue
@@ -497,8 +497,15 @@
                         class="mt-1.5 border border-gray-150 dark:border-gray-800/80 bg-white dark:bg-gray-900 rounded-lg overflow-y-auto max-h-[250px] p-2 space-y-1.5 scrollbar-thin"
                         @click.stop
                       >
-                        <div v-if="datasetDocuments[ds.id]?.loading" class="flex justify-center py-4">
-                          <div class="animate-spin rounded-full h-3.5 w-3.5 border-2 border-gray-300 border-t-green-500" />
+                        <div v-if="datasetDocuments[ds.id]?.loading" class="space-y-2 py-2">
+                          <div
+                            v-for="i in 3"
+                            :key="i"
+                            class="flex items-center gap-2 px-2 py-1.5 rounded-lg border border-gray-100 dark:border-gray-800"
+                          >
+                            <div class="kp-skeleton-shimmer w-3.5 h-3.5 rounded flex-shrink-0" />
+                            <div class="kp-skeleton-shimmer h-2.5 rounded flex-1" :style="{ maxWidth: i === 1 ? '70%' : '85%' }" />
+                          </div>
                         </div>
                         <template v-else-if="(datasetDocuments[ds.id]?.docs?.length || 0) > 0">
                           <div
@@ -548,8 +555,20 @@
                                   <span class="text-green-500 font-bold">💡</span> 针对该文件的专属提问：
                                 </div>
                                 
-                                <div v-if="documentRecommendations[doc.id]?.loading" class="flex justify-center py-2">
-                                  <div class="animate-spin rounded-full h-3 w-3 border border-gray-300 border-t-green-500" />
+                                <div v-if="documentRecommendations[doc.id]?.loading" class="space-y-2 py-1">
+                                  <div class="flex flex-wrap gap-1.5 kp-question-skeleton-wrap">
+                                    <div
+                                      v-for="(width, i) in ['6.5rem', '5.75rem']"
+                                      :key="i"
+                                      class="inline-flex items-center h-7 rounded-md border border-green-500/10 dark:border-green-500/15 bg-green-50/25 dark:bg-green-950/10 overflow-hidden"
+                                      :style="{ width }"
+                                    >
+                                      <div class="kp-skeleton-shimmer h-2 rounded mx-2 w-[calc(100%-1rem)]" />
+                                    </div>
+                                  </div>
+                                  <p class="text-[9px] text-center text-gray-400 dark:text-gray-500 select-none">
+                                    生成专属提问中<span class="kp-loading-dots" aria-hidden="true">...</span>
+                                  </p>
                                 </div>
                                 
                                 <div v-else-if="(documentRecommendations[doc.id]?.questions?.length || 0) > 0" class="space-y-1">
@@ -621,9 +640,33 @@
                       </button>
                     </div>
 
-                    <!-- loading spinner -->
-                    <div v-if="recommendations[ds.id]?.loading" class="flex justify-center py-4">
-                      <div class="animate-spin rounded-full h-4 w-4 border-2 border-gray-300 border-t-green-500" />
+                    <!-- loading skeleton -->
+                    <div v-if="recommendations[ds.id]?.loading" class="space-y-2.5">
+                      <div class="flex flex-wrap gap-2 kp-question-skeleton-wrap">
+                        <div
+                          v-for="(width, i) in ['8.75rem', '10.25rem', '7.5rem']"
+                          :key="i"
+                          class="inline-flex items-center h-[34px] rounded-lg border border-green-500/15 dark:border-green-500/20 bg-green-50/30 dark:bg-green-950/15 overflow-hidden shadow-sm"
+                          :style="{ width }"
+                        >
+                          <div class="flex items-center gap-2 px-3 w-full">
+                            <div class="kp-skeleton-shimmer w-3.5 h-3.5 rounded-full flex-shrink-0" />
+                            <div
+                              class="kp-skeleton-shimmer h-2.5 rounded flex-1"
+                              :style="{ maxWidth: i === 0 ? '72%' : i === 1 ? '88%' : '64%' }"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div class="flex items-center justify-center gap-2 py-0.5">
+                        <span class="relative flex h-1.5 w-1.5">
+                          <span class="kp-loading-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-50" />
+                          <span class="relative inline-flex h-1.5 w-1.5 rounded-full bg-green-500" />
+                        </span>
+                        <span class="text-[10px] font-medium text-gray-400 dark:text-gray-500 select-none">
+                          正在生成推荐提问<span class="kp-loading-dots" aria-hidden="true">...</span>
+                        </span>
+                      </div>
                     </div>
 
                     <!-- horizontal flex-wrap layout matching data portal -->
@@ -810,5 +853,49 @@ const handleQuestionClick = (query: string, dsId: string, action: "send" | "fill
 }
 .scrollbar-thin::-webkit-scrollbar-track {
   background-color: transparent;
+}
+
+@keyframes kp-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.kp-skeleton-shimmer {
+  background: linear-gradient(90deg, rgb(229 231 235) 20%, rgb(209 250 229) 45%, rgb(229 231 235) 80%);
+  background-size: 200% 100%;
+  animation: kp-shimmer 1.5s ease-in-out infinite;
+}
+
+:global(.dark) .kp-skeleton-shimmer {
+  background: linear-gradient(90deg, rgb(31 41 55) 20%, rgb(6 78 59 / 0.45) 45%, rgb(31 41 55) 80%);
+  background-size: 200% 100%;
+}
+
+.kp-question-skeleton-wrap {
+  animation: kp-skeleton-fade 0.35s ease-out;
+}
+
+@keyframes kp-skeleton-fade {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.kp-loading-ping {
+  animation: kp-ping 1.4s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+@keyframes kp-ping {
+  0% { transform: scale(1); opacity: 0.55; }
+  75%, 100% { transform: scale(2.2); opacity: 0; }
+}
+
+.kp-loading-dots {
+  display: inline-block;
+  animation: kp-dots 1.2s ease-in-out infinite;
+}
+
+@keyframes kp-dots {
+  0%, 100% { opacity: 0.25; }
+  50% { opacity: 1; }
 }
 </style>

--- a/frontend/src/components/knowledge/KnowledgePortalDrawer.vue
+++ b/frontend/src/components/knowledge/KnowledgePortalDrawer.vue
@@ -241,13 +241,13 @@
               </transition>
 
               <!-- ⚙️ 高级选项 (Collapsible) -->
-              <div class="rounded-xl border border-blue-150/70 dark:border-blue-900/40 bg-blue-50/10 dark:bg-blue-950/5 p-3 space-y-2.5">
+              <div class="rounded-xl border border-gray-150 dark:border-gray-800 bg-gray-50/20 dark:bg-gray-900/10 p-3 space-y-2.5 transition-all duration-300">
                 <div
-                  class="flex items-center justify-between w-full text-[10px] font-bold text-blue-700 dark:text-blue-400 uppercase tracking-wider transition-colors select-none cursor-pointer"
+                  class="flex items-center justify-between w-full text-[10px] font-bold text-gray-500 hover:text-green-600 dark:text-gray-400 dark:hover:text-green-400 uppercase tracking-wider transition-colors select-none cursor-pointer"
                   @click="showAdvancedConfig = !showAdvancedConfig"
                 >
                   <span class="flex items-center gap-1.5">
-                    <span>🛠️</span> 高级配置
+                    <span class="text-xs">⚙️</span> 高级配置
                   </span>
                   <svg
                     class="w-3.5 h-3.5 transform transition-transform duration-300 pointer-events-none"
@@ -464,17 +464,44 @@
                 <div class="relative space-y-2.5">
                   <!-- Header Row -->
                   <div class="flex items-start gap-2.5 min-w-0">
+                    <!-- Collapse Toggle Chevron -->
+                    <button
+                      type="button"
+                      class="flex-shrink-0 flex items-center justify-center w-5 h-9 rounded text-gray-400 hover:text-green-500 hover:bg-green-50/30 dark:hover:bg-green-950/20 transition-all duration-200 cursor-pointer"
+                      @click.stop="toggleCollapse(ds.id)"
+                      :title="isCollapsed(ds.id) ? '展开卡片' : '收起卡片'"
+                    >
+                      <svg
+                        class="w-3.5 h-3.5 transform transition-transform duration-200"
+                        :class="{ '-rotate-90': isCollapsed(ds.id) }"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2.5"
+                        viewBox="0 0 24 24"
+                      >
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                      </svg>
+                    </button>
+
                     <div
-                      class="flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-xl shadow-xs border text-[18px] bg-green-500/10 border-green-500/20 text-green-600 dark:bg-green-500/20 dark:border-green-500/30 dark:text-green-400"
+                      @click.stop="toggleCollapse(ds.id)"
+                      class="flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-xl shadow-xs border text-[18px] bg-green-50/10 border-green-500/20 text-green-600 dark:bg-green-500/20 dark:border-green-500/30 dark:text-green-400 cursor-pointer hover:opacity-80 transition-opacity select-none"
                     >
                       📚
                     </div>
                     
                     <h4
-                      class="flex-1 min-w-0 text-sm font-bold leading-snug break-words pt-0.5 text-gray-800 dark:text-gray-100"
+                      @click.stop="toggleCollapse(ds.id)"
+                      class="flex-1 min-w-0 text-sm font-bold leading-snug break-words pt-0.5 text-gray-800 dark:text-gray-100 flex items-center flex-wrap gap-1.5 cursor-pointer hover:text-green-600 dark:hover:text-green-400 transition-colors select-none"
                       :title="ds.platform_name || ds.name"
                     >
-                      {{ ds.platform_name || ds.name }}
+                      <span>{{ ds.platform_name || ds.name }}</span>
+                      <span
+                        v-if="isMyCreated(ds)"
+                        class="inline-flex items-center px-1.5 py-0.5 rounded-md text-[9px] font-bold tracking-wider uppercase bg-green-50/50 text-green-600 border border-green-200/30 dark:bg-green-950/20 dark:border-green-800/30 dark:text-green-400 select-none"
+                      >
+                        自建
+                      </span>
                     </h4>
                     
                     <!-- Actions (Pin & Toggle switch) -->
@@ -509,6 +536,9 @@
                       </button>
                     </div>
                   </div>
+                  
+                  <!-- Collapsible Content Wrapper -->
+                  <div v-show="!isCollapsed(ds.id)" class="space-y-2.5 pt-0.5">
 
                   <!-- Badges list matching pl-11.5 indentation -->
                   <div class="flex flex-wrap gap-1.5 pl-11.5 min-w-0">
@@ -750,35 +780,85 @@
                     </div>
 
                     <!-- horizontal flex-wrap layout matching data portal -->
-                    <div v-else-if="(recommendations[ds.id]?.questions?.length || 0) > 0" class="flex flex-wrap gap-2">
-                      <div
-                        v-for="(q, idx) in (recommendations[ds.id]?.questions || [])"
-                        :key="idx"
-                        class="inline-flex items-stretch rounded-lg border border-gray-150 dark:border-gray-750 bg-white dark:bg-gray-800 shadow-sm hover:shadow hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200 overflow-hidden"
-                      >
-                        <!-- Left Question Body (Direct Send) -->
-                        <button
-                          type="button"
-                          @click="handleQuestionClick(q.query, ds.id, 'send')"
-                          class="flex items-center gap-1.5 px-3 py-2 text-left text-xs font-semibold cursor-pointer select-none text-gray-700 dark:text-gray-300 hover:bg-green-50/10 dark:hover:bg-green-950/10 transition-colors leading-normal"
-                        >
-                          <svg class="w-3.5 h-3.5 flex-shrink-0 opacity-80 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
+                    <div v-else-if="(recommendations[ds.id]?.questions?.length || 0) > 0 || (recommendations[ds.id]?.custom_questions?.length || 0) > 0" class="space-y-3.5 w-full">
+                      <!-- 置顶快捷推荐 -->
+                      <div v-if="(recommendations[ds.id]?.custom_questions?.length || 0) > 0" class="space-y-1.5 w-full">
+                        <div class="flex items-center gap-1 text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase select-none">
+                          <svg class="w-3 h-3 text-amber-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                           </svg>
-                          <span>{{ q.label }}</span>
-                        </button>
-                        
-                        <!-- Right Edit Pencil Button (Fill to input box without sending) -->
-                        <button
-                          type="button"
-                          @click="handleQuestionClick(q.query, ds.id, 'fill')"
-                          class="flex items-center justify-center px-2 hover:bg-green-50/15 dark:hover:bg-green-950/20 text-gray-400 hover:text-green-600 dark:hover:text-green-400 border-l border-gray-100 dark:border-gray-700/80 transition-colors cursor-pointer"
-                          title="编辑此问题"
-                        >
-                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                          <span>📌 置顶快捷提问 / 业务指南</span>
+                        </div>
+                        <div class="flex flex-wrap gap-2">
+                          <div
+                            v-for="(q, idx) in (recommendations[ds.id]?.custom_questions || [])"
+                            :key="'c_'+idx"
+                            class="inline-flex items-stretch rounded-lg border border-amber-250 dark:border-amber-900/40 bg-amber-50/20 dark:bg-amber-950/10 shadow-sm hover:shadow hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200 overflow-hidden"
+                          >
+                            <!-- Left Question Body (Direct Send) -->
+                            <button
+                              type="button"
+                              @click="handleQuestionClick(q.query, ds.id, 'send')"
+                              class="flex items-center gap-1.5 px-3 py-2 text-left text-xs font-semibold cursor-pointer select-none text-gray-700 dark:text-gray-300 hover:bg-amber-100/10 dark:hover:bg-amber-900/10 transition-colors leading-normal"
+                            >
+                              <svg class="w-3.5 h-3.5 flex-shrink-0 text-amber-500" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
+                              </svg>
+                              <span>{{ q.label }}</span>
+                            </button>
+                            <!-- Right Edit Pencil -->
+                            <button
+                              type="button"
+                              @click="handleQuestionClick(q.query, ds.id, 'fill')"
+                              class="flex items-center justify-center px-2 hover:bg-amber-100/15 dark:hover:bg-amber-900/20 text-gray-400 hover:text-amber-600 dark:hover:text-amber-400 border-l border-amber-100 dark:border-amber-900/30 transition-colors cursor-pointer"
+                              title="编辑此问题"
+                            >
+                              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+
+                      <!-- 智能生成提问 -->
+                      <div v-if="(recommendations[ds.id]?.questions?.length || 0) > 0" class="space-y-1.5 w-full">
+                        <div class="flex items-center gap-1 text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase select-none">
+                          <svg class="w-3 h-3 text-green-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
                           </svg>
-                        </button>
+                          <span>智能提问推荐（LLM 动态推断）</span>
+                        </div>
+                        <div class="flex flex-wrap gap-2">
+                          <div
+                            v-for="(q, idx) in (recommendations[ds.id]?.questions || [])"
+                            :key="'d_'+idx"
+                            class="inline-flex items-stretch rounded-lg border border-gray-150 dark:border-gray-750 bg-white dark:bg-gray-800 shadow-sm hover:shadow hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200 overflow-hidden"
+                          >
+                            <!-- Left Question Body (Direct Send) -->
+                            <button
+                              type="button"
+                              @click="handleQuestionClick(q.query, ds.id, 'send')"
+                              class="flex items-center gap-1.5 px-3 py-2 text-left text-xs font-semibold cursor-pointer select-none text-gray-700 dark:text-gray-300 hover:bg-green-50/10 dark:hover:bg-green-950/10 transition-colors leading-normal"
+                            >
+                              <svg class="w-3.5 h-3.5 flex-shrink-0 opacity-80 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
+                              </svg>
+                              <span>{{ q.label }}</span>
+                            </button>
+                            <!-- Right Edit Pencil -->
+                            <button
+                              type="button"
+                              @click="handleQuestionClick(q.query, ds.id, 'fill')"
+                              class="flex items-center justify-center px-2 hover:bg-green-50/15 dark:hover:bg-green-950/20 text-gray-400 hover:text-green-600 dark:hover:text-green-400 border-l border-gray-100 dark:border-gray-700/80 transition-colors cursor-pointer"
+                              title="编辑此问题"
+                            >
+                              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
                       </div>
                     </div>
 
@@ -796,6 +876,7 @@
                     </div>
                   </div>
                 </div>
+              </div>
               </div>
             </div>
           </div>
@@ -828,7 +909,7 @@ const props = defineProps<{
   }>;
   activeDatasetIds: string[];
   pinnedDatasetIds: string[];
-  recommendations: Record<string, { questions: any[]; loading?: boolean }>;
+  recommendations: Record<string, { questions: any[]; custom_questions?: any[]; loading?: boolean }>;
   datasetDocuments: Record<string, { docs: any[]; loading?: boolean }>;
   documentRecommendations: Record<string, { questions: any[]; loading?: boolean }>;
   loading?: boolean;
@@ -848,6 +929,31 @@ const emit = defineEmits<{
 const expandedDocId = ref<string | null>(null);
 const expandedDocRecsId = ref<string | null>(null);
 const showAdvancedConfig = ref(false);
+
+const isMyCreated = (ds: any) => {
+  try {
+    const userInfoStr = localStorage.getItem('user_info');
+    if (userInfoStr) {
+      const userInfo = JSON.parse(userInfoStr);
+      const currentUserName = userInfo.username || userInfo.user_name;
+      return currentUserName && ds.created_by === currentUserName;
+    }
+  } catch (e) {}
+  return false;
+};
+
+// 卡片折叠状态管理
+const collapsedDatasetIds = ref<string[]>([]);
+const isCollapsed = (datasetId: string) => collapsedDatasetIds.value.includes(datasetId);
+const toggleCollapse = (datasetId: string) => {
+  const index = collapsedDatasetIds.value.indexOf(datasetId);
+  if (index > -1) {
+    collapsedDatasetIds.value.splice(index, 1);
+  } else {
+    collapsedDatasetIds.value.push(datasetId);
+  }
+};
+
 const activeTooltip = ref<string | null>(null);
 
 const showSearchBar = ref(false);

--- a/frontend/src/components/knowledge/KnowledgePortalDrawer.vue
+++ b/frontend/src/components/knowledge/KnowledgePortalDrawer.vue
@@ -392,9 +392,9 @@
                     
                     <h4
                       class="flex-1 min-w-0 text-sm font-bold leading-snug break-words pt-0.5 text-gray-800 dark:text-gray-100"
-                      :title="ds.name"
+                      :title="ds.platform_name || ds.name"
                     >
-                      {{ ds.name }}
+                      {{ ds.platform_name || ds.name }}
                     </h4>
                     
                     <!-- Actions (Pin & Toggle switch) -->
@@ -447,10 +447,10 @@
 
                   <!-- Description Summary Box (blockquote) -->
                   <blockquote
-                    v-if="ds.description"
+                    v-if="ds.platform_description || ds.description"
                     class="relative w-full m-0 px-3.5 py-2.5 text-[11px] leading-relaxed rounded-r-lg border-l-[3px] bg-green-50/40 dark:bg-green-950/10 border-green-500 text-gray-600 dark:text-gray-400 font-medium"
                   >
-                    {{ ds.description }}
+                    {{ ds.platform_description || ds.description }}
                   </blockquote>
 
                   <!-- Collapsible Relevant Documents Section -->

--- a/frontend/src/composables/useKnowledgePortal.ts
+++ b/frontend/src/composables/useKnowledgePortal.ts
@@ -137,10 +137,14 @@ export function useKnowledgePortal(options: UseKnowledgePortalOptions) {
 
   const fetchRecommendations = async (datasetId: string, refresh: boolean = false) => {
     if (!datasetId) return;
-    if (!refresh && (datasetRecommendations.value[datasetId]?.questions || []).length > 0) return;
+    const currentRec = datasetRecommendations.value[datasetId];
+    if (!refresh && (
+      (currentRec?.questions || []).length > 0 ||
+      (currentRec?.custom_questions || []).length > 0
+    )) return;
 
     if (!datasetRecommendations.value[datasetId]) {
-      datasetRecommendations.value[datasetId] = { questions: [], loading: true };
+      datasetRecommendations.value[datasetId] = { questions: [], custom_questions: [], loading: true };
     } else {
       datasetRecommendations.value[datasetId].loading = true;
     }
@@ -156,6 +160,7 @@ export function useKnowledgePortal(options: UseKnowledgePortalOptions) {
       if (response.data && response.data.code === 0) {
         datasetRecommendations.value[datasetId] = {
           questions: response.data.data.questions || [],
+          custom_questions: response.data.data.custom_questions || [],
           loading: false
         };
       } else {

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -25,6 +25,7 @@ import {
   isWorkspaceSlashCommand,
 } from "@/constants/workspaceCommand";
 import CitationPopover from "@/components/CitationPopover.vue";
+import RagPreviewDrawer from "@/components/RagPreviewDrawer.vue";
 import axios from "@/utils/axios";
 import { finalizeConversation } from "@/utils/conversationFinalize";
 import { cancelConversationRun } from "@/utils/cancelConversationRun";
@@ -2580,17 +2581,6 @@ const isOfficeDocument = computed(() => {
          name.endsWith(".ppt") || name.endsWith(".pptx");
 });
 
-const downloadOriginalFile = () => {
-  if (ragPreviewFileUrl.value) {
-    const link = document.createElement("a");
-    link.href = ragPreviewFileUrl.value;
-    link.download = ragPreviewDocName.value;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  }
-};
-
 const handleViewOriginal = (citation: any) => {
   closeCitationPopover();
   if (citation.source_type === "web") {
@@ -4938,84 +4928,14 @@ onUnmounted(() => {
     @view-original="handleViewOriginal"
   />
 
-  <teleport to="body">
-    <!-- Canvas RAG 原地物理高亮预览抽屉 -->
-    <div
-      class="fixed top-0 right-0 h-full w-[45%] bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-800 shadow-2xl z-[260] flex flex-col transition-transform duration-300 ease-in-out transform"
-      :class="ragPreviewVisible ? 'translate-x-0' : 'translate-x-full'"
-    >
-      <!-- Header -->
-      <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex-shrink-0 bg-gray-50/50 dark:bg-gray-800/40">
-        <div class="min-w-0">
-          <h3 class="text-sm font-bold text-gray-800 dark:text-gray-100 truncate" :title="ragPreviewDocName">
-            {{ ragPreviewDocName }}
-          </h3>
-          <p class="text-[11px] text-gray-400 mt-0.5">
-            第 {{ ragPreviewPageNo }} 页 RAG 关联原档智能高亮预览
-          </p>
-        </div>
-        <button
-          @click="ragPreviewVisible = false"
-          class="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors flex-shrink-0"
-          title="关闭预览"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
-      </div>
-
-      <!-- Content Area -->
-      <div class="flex-1 min-h-0 flex flex-col divide-y divide-gray-100 dark:divide-gray-800">
-        <!-- Top: High fidelity PDF/iframe viewer -->
-        <div class="flex-1 min-h-0 bg-gray-100/30 relative flex flex-col items-center justify-center">
-          <!-- Friendly Tip for Office Documents -->
-          <div v-if="isOfficeDocument" class="p-8 text-center max-w-sm space-y-4 flex flex-col items-center">
-            <div class="inline-flex p-4 bg-amber-50 dark:bg-amber-950/20 text-amber-600 dark:text-amber-400 rounded-full">
-              <svg class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-            </div>
-            <div>
-              <h4 class="text-sm font-bold text-gray-800 dark:text-gray-100">Office 文档暂不支持在线预览</h4>
-              <p class="text-xs text-gray-400 mt-1.5 leading-relaxed">
-                由于您的文件是 Word/Excel 类型，系统已自动拉起浏览器进行本地下载。若未开始，可点击下方按钮重新发起下载。
-              </p>
-            </div>
-            <button
-              @click="downloadOriginalFile"
-              class="inline-flex items-center px-4 py-2 bg-blue-600 text-white text-xs font-bold rounded-xl shadow-sm hover:bg-blue-700 active:scale-95 transition-all"
-            >
-              重新下载原档
-            </button>
-          </div>
-
-          <iframe
-            v-else-if="ragPreviewVisible && ragPreviewFileUrl"
-            :src="`${ragPreviewFileUrl}#page=${ragPreviewPageNo}`"
-            class="w-full h-full border-none"
-          />
-          <div v-else class="absolute inset-0 flex items-center justify-center text-gray-400 text-xs">
-            正在加载文档预览...
-          </div>
-        </div>
-
-        <!-- Bottom: Referenced citation snippet card -->
-        <div class="h-44 flex-shrink-0 flex flex-col bg-white dark:bg-gray-900 p-4 border-t border-gray-100 dark:divide-gray-800">
-          <h4 class="text-xs font-bold text-gray-700 dark:text-gray-200 tracking-wider uppercase mb-2 flex items-center gap-1.5">
-            <svg class="w-3.5 h-3.5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-            </svg>
-            被引用原文段落
-          </h4>
-          <div
-            class="flex-1 min-h-0 overflow-y-auto p-3 bg-blue-50/30 dark:bg-blue-900/5 border border-blue-100/50 dark:border-blue-900/10 rounded-xl text-xs text-gray-600 dark:text-gray-300 leading-relaxed custom-table-render scrollbar-thin"
-            v-html="ragPreviewContent"
-          />
-        </div>
-      </div>
-    </div>
-  </teleport>
+  <RagPreviewDrawer
+    v-model="ragPreviewVisible"
+    :doc-name="ragPreviewDocName"
+    :page-no="ragPreviewPageNo"
+    :file-url="ragPreviewFileUrl"
+    :content="ragPreviewContent"
+    :is-office-document="isOfficeDocument"
+  />
 
   <!-- Confirm Modal -->
   <ConfirmModal

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -1241,84 +1241,14 @@
       @view-original="handleViewOriginal"
     />
 
-    <teleport to="body">
-      <!-- Canvas RAG 原地物理高亮预览抽屉 -->
-      <div
-        class="fixed top-0 right-0 h-full w-[45%] bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-800 shadow-2xl z-[260] flex flex-col transition-transform duration-300 ease-in-out transform"
-        :class="ragPreviewVisible ? 'translate-x-0' : 'translate-x-full'"
-      >
-        <!-- Header -->
-        <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex-shrink-0 bg-gray-50/50 dark:bg-gray-800/40">
-          <div class="min-w-0">
-            <h3 class="text-sm font-bold text-gray-800 dark:text-gray-100 truncate" :title="ragPreviewDocName">
-              {{ ragPreviewDocName }}
-            </h3>
-            <p class="text-[11px] text-gray-400 mt-0.5">
-              第 {{ ragPreviewPageNo }} 页 RAG 关联原档智能高亮预览
-            </p>
-          </div>
-          <button
-            @click="ragPreviewVisible = false"
-            class="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors flex-shrink-0"
-            title="关闭预览"
-          >
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-
-        <!-- Content Area -->
-        <div class="flex-1 min-h-0 flex flex-col divide-y divide-gray-100 dark:divide-gray-800">
-          <!-- Top: High fidelity PDF/iframe viewer -->
-          <div class="flex-1 min-h-0 bg-gray-100/30 relative flex flex-col items-center justify-center">
-            <!-- Friendly Tip for Office Documents -->
-            <div v-if="isOfficeDocument" class="p-8 text-center max-w-sm space-y-4 flex flex-col items-center">
-              <div class="inline-flex p-4 bg-amber-50 dark:bg-amber-950/20 text-amber-600 dark:text-amber-400 rounded-full">
-                <svg class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                </svg>
-              </div>
-              <div>
-                <h4 class="text-sm font-bold text-gray-800 dark:text-gray-100">Office 文档暂不支持在线预览</h4>
-                <p class="text-xs text-gray-400 mt-1.5 leading-relaxed">
-                  由于您的文件是 Word/Excel 类型，系统已自动拉起浏览器进行本地下载。若未开始，可点击下方按钮重新发起下载。
-                </p>
-              </div>
-              <button
-                @click="downloadOriginalFile"
-                class="inline-flex items-center px-4 py-2 bg-blue-600 text-white text-xs font-bold rounded-xl shadow-sm hover:bg-blue-700 active:scale-95 transition-all"
-              >
-                重新下载原档
-              </button>
-            </div>
-
-            <iframe
-              v-else-if="ragPreviewVisible && ragPreviewFileUrl"
-              :src="`${ragPreviewFileUrl}#page=${ragPreviewPageNo}`"
-              class="w-full h-full border-none"
-            />
-            <div v-else class="absolute inset-0 flex items-center justify-center text-gray-400 text-xs">
-              正在加载文档预览...
-            </div>
-          </div>
-
-          <!-- Bottom: Referenced citation snippet card -->
-          <div class="h-44 flex-shrink-0 flex flex-col bg-white dark:bg-gray-900 p-4 border-t border-gray-100 dark:divide-gray-800">
-            <h4 class="text-xs font-bold text-gray-700 dark:text-gray-200 tracking-wider uppercase mb-2 flex items-center gap-1.5">
-              <svg class="w-3.5 h-3.5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-              </svg>
-              被引用原文段落
-            </h4>
-            <div
-              class="flex-1 min-h-0 overflow-y-auto p-3 bg-blue-50/30 dark:bg-blue-900/5 border border-blue-100/50 dark:border-blue-900/10 rounded-xl text-xs text-gray-600 dark:text-gray-300 leading-relaxed custom-table-render scrollbar-thin"
-              v-html="ragPreviewContent"
-            />
-          </div>
-        </div>
-      </div>
-    </teleport>
+    <RagPreviewDrawer
+      v-model="ragPreviewVisible"
+      :doc-name="ragPreviewDocName"
+      :page-no="ragPreviewPageNo"
+      :file-url="ragPreviewFileUrl"
+      :content="ragPreviewContent"
+      :is-office-document="isOfficeDocument"
+    />
 
     <!-- Input Area -->
     <div class="flex-shrink-0 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 relative z-20">
@@ -2469,6 +2399,7 @@ import DatasetPortalDrawer from "@/components/chatbi/DatasetPortalDrawer.vue";
 import KnowledgePortalDrawer from "@/components/knowledge/KnowledgePortalDrawer.vue";
 import { useKnowledgePortal } from "@/composables/useKnowledgePortal";
 import CitationPopover from "@/components/CitationPopover.vue";
+import RagPreviewDrawer from "@/components/RagPreviewDrawer.vue";
 import ChatHistorySidebar from "@/components/ChatHistorySidebar.vue";
 import ConfirmModal from "@/components/ConfirmModal.vue";
 import ExpertCapsule from "@/components/embed/ExpertCapsule.vue";
@@ -5569,17 +5500,6 @@ const isOfficeDocument = computed(() => {
          name.endsWith(".xls") || name.endsWith(".xlsx") || 
          name.endsWith(".ppt") || name.endsWith(".pptx");
 });
-
-const downloadOriginalFile = () => {
-  if (ragPreviewFileUrl.value) {
-    const link = document.createElement("a");
-    link.href = ragPreviewFileUrl.value;
-    link.download = ragPreviewDocName.value;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  }
-};
 
 const handleViewOriginal = (citation: any) => {
   closeCitationPopover();

--- a/frontend/src/views/KnowledgeBaseManagement.vue
+++ b/frontend/src/views/KnowledgeBaseManagement.vue
@@ -81,6 +81,7 @@ const searchQuery = ref('')
 const showCreateModal = ref(false)
 const showEditModal = ref(false)
 const aiAnalyzing = ref(false)
+const customQuestions = ref<{ label: string, query: string }[]>([])
 const deletingDataset = ref<KnowledgeBase | null>(null)
 const deletingDocument = ref<KnowledgeDocument | null>(null)
 
@@ -211,6 +212,16 @@ const openEdit = (dataset: KnowledgeBase) => {
     notes: dataset.notes || '',
     extraConfigText: JSON.stringify(dataset.local_metadata?.extra_config || {}, null, 2)
   }
+  
+  customQuestions.value = []
+  const localExtra = dataset.local_metadata?.extra_config || {}
+  if (localExtra.custom_questions && Array.isArray(localExtra.custom_questions)) {
+    customQuestions.value = localExtra.custom_questions.map(q => ({
+      label: q.label || '',
+      query: q.query || ''
+    }))
+  }
+  
   showEditModal.value = true
 }
 
@@ -559,6 +570,9 @@ const updateMetadata = async () => {
   }
   if (!selectedDatasetId.value) return
   try {
+    const extraConfig = parseExtraConfig()
+    extraConfig.custom_questions = customQuestions.value.filter(q => q.label.trim() && q.query.trim())
+
     await axios.put(`/api/portal/ragflow/datasets/${selectedDatasetId.value}/metadata`, {
       name: form.value.name,
       description: form.value.description,
@@ -566,7 +580,7 @@ const updateMetadata = async () => {
       visibility: form.value.visibility,
       tags: normalizeTags(form.value.tagsText),
       notes: form.value.notes,
-      extra_config: parseExtraConfig()
+      extra_config: extraConfig
     })
     showToast('知识库元数据已更新', 'success')
     showEditModal.value = false
@@ -575,6 +589,183 @@ const updateMetadata = async () => {
     showToast(extractError(err), 'error')
   }
 }
+
+// ==================== 虚拟文件夹层级管理开始 ====================
+const editingDatasetIdForFolder = ref<string | null>(null)
+const newFolderName = ref('')
+const editingFolderKey = ref<string | null>(null) // 格式: datasetId + '_' + oldFolderName
+const editingFolderNewName = ref('')
+const collapsedFolders = ref<Record<string, boolean>>({}) // key: datasetId + '_' + folderName
+const activeFileMoveMenuDocId = ref<string | null>(null)
+
+// 判定文件夹折叠状态
+const isFolderCollapsed = (datasetId: string, folderName: string) => {
+  return !!collapsedFolders.value[`${datasetId}_${folderName}`]
+}
+
+// 切换文件夹折叠状态
+const toggleFolderCollapse = (datasetId: string, folderName: string) => {
+  const key = `${datasetId}_${folderName}`
+  collapsedFolders.value[key] = !collapsedFolders.value[key]
+}
+
+// 打开新建文件夹输入框
+const startCreateFolder = (dataset: KnowledgeBase) => {
+  const datasetId = dataset.ragflow_dataset_id || dataset.id
+  if (!datasetId) return
+  // 自动展开该知识库节点
+  expandedDatasetIds.value[datasetId] = true
+  editingDatasetIdForFolder.value = datasetId
+  newFolderName.value = ''
+}
+
+// 确认创建文件夹
+const confirmCreateFolder = async (dataset: KnowledgeBase) => {
+  const datasetId = dataset.ragflow_dataset_id || dataset.id
+  if (!datasetId) return
+  const name = newFolderName.value.trim()
+  if (!name) {
+    showToast('文件夹名称不能为空', 'warning')
+    return
+  }
+
+  const localMetadata = dataset.local_metadata || {}
+  const extraConfig = { ...(localMetadata.extra_config || {}) }
+  if (!extraConfig.folder_structure) {
+    extraConfig.folder_structure = {}
+  }
+
+  if (extraConfig.folder_structure[name]) {
+    showToast('该文件夹已存在', 'warning')
+    return
+  }
+
+  extraConfig.folder_structure[name] = []
+  
+  try {
+    await saveDatasetExtraConfig(dataset, extraConfig)
+    showToast('文件夹创建成功', 'success')
+    editingDatasetIdForFolder.value = null
+    newFolderName.value = ''
+  } catch (err) {
+    showToast('文件夹创建失败: ' + extractError(err), 'error')
+  }
+}
+
+// 开始重命名文件夹
+const startRenameFolder = (datasetId: string, folderName: string) => {
+  editingFolderKey.value = `${datasetId}_${folderName}`
+  editingFolderNewName.value = folderName
+}
+
+// 确认重命名文件夹
+const confirmRenameFolder = async (dataset: KnowledgeBase, oldName: string) => {
+  const datasetId = dataset.ragflow_dataset_id || dataset.id
+  if (!datasetId) return
+  const newName = editingFolderNewName.value.trim()
+  if (!newName) {
+    showToast('文件夹名称不能为空', 'warning')
+    return
+  }
+  if (newName === oldName) {
+    editingFolderKey.value = null
+    return
+  }
+
+  const localMetadata = dataset.local_metadata || {}
+  const extraConfig = { ...(localMetadata.extra_config || {}) }
+  const structure = { ...(extraConfig.folder_structure || {}) }
+
+  if (structure[newName]) {
+    showToast('该名称的文件夹已存在', 'warning')
+    return
+  }
+
+  // 替换键名并保持文档列表不变
+  structure[newName] = structure[oldName] || []
+  delete structure[oldName]
+  extraConfig.folder_structure = structure
+
+  try {
+    await saveDatasetExtraConfig(dataset, extraConfig)
+    showToast('文件夹重命名成功', 'success')
+    editingFolderKey.value = null
+  } catch (err) {
+    showToast('重命名失败: ' + extractError(err), 'error')
+  }
+}
+
+// 删除文件夹 (解绑文件，不物理删除文件)
+const removeFolder = async (dataset: KnowledgeBase, folderName: string) => {
+  if (!confirm(`确定要删除文件夹「${folderName}」吗？其中的所有文档将自动移入未分类根目录（不会删除物理文档）。`)) {
+    return
+  }
+
+  const localMetadata = dataset.local_metadata || {}
+  const extraConfig = { ...(localMetadata.extra_config || {}) }
+  const structure = { ...(extraConfig.folder_structure || {}) }
+
+  delete structure[folderName]
+  extraConfig.folder_structure = structure
+
+  try {
+    await saveDatasetExtraConfig(dataset, extraConfig)
+    showToast('文件夹已删除', 'success')
+  } catch (err) {
+    showToast('删除文件夹失败: ' + extractError(err), 'error')
+  }
+}
+
+// 移动文档至文件夹
+const moveDocumentToFolder = async (dataset: KnowledgeBase, docId: string, targetFolderName: string | null) => {
+  const localMetadata = dataset.local_metadata || {}
+  const extraConfig = { ...(localMetadata.extra_config || {}) }
+  const structure = { ...(extraConfig.folder_structure || {}) }
+
+  // 1. 从之前所在的文件夹中移除 docId
+  for (const fName in structure) {
+    if (Array.isArray(structure[fName])) {
+      structure[fName] = structure[fName].filter((id: string) => id !== docId)
+    }
+  }
+
+  // 2. 如果指定了目标文件夹，加入进去
+  if (targetFolderName) {
+    if (!Array.isArray(structure[targetFolderName])) {
+      structure[targetFolderName] = []
+    }
+    if (!structure[targetFolderName].includes(docId)) {
+      structure[targetFolderName].push(docId)
+    }
+  }
+
+  extraConfig.folder_structure = structure
+
+  try {
+    await saveDatasetExtraConfig(dataset, extraConfig)
+    showToast('移动文档成功', 'success')
+    activeFileMoveMenuDocId.value = null
+  } catch (err) {
+    showToast('移动文档失败: ' + extractError(err), 'error')
+  }
+}
+
+// 内部方法：静默保存数据集的本地 extra_config
+const saveDatasetExtraConfig = async (dataset: KnowledgeBase, extraConfig: any) => {
+  const datasetId = dataset.ragflow_dataset_id || dataset.id
+  await axios.put(`/api/portal/ragflow/datasets/${datasetId}/metadata`, {
+    name: dataset.platform_name || dataset.name,
+    description: dataset.platform_description || dataset.description,
+    owner: dataset.owner || '',
+    visibility: dataset.visibility || 'private',
+    tags: dataset.tags || [],
+    notes: dataset.notes || '',
+    extra_config: extraConfig
+  })
+  // 静默更新本地数据集列表以触发界面状态渲染刷新
+  await fetchDatasets()
+}
+// ==================== 虚拟文件夹层级管理结束 ====================
 
 const triggerDeleteDataset = (dataset: KnowledgeBase) => {
   deletingDataset.value = dataset
@@ -1277,6 +1468,16 @@ onMounted(async () => {
                     <button
                       v-if="canEdit && !isReadOnlyDataset(dataset)"
                       class="p-1 rounded hover:bg-gray-200/60 text-gray-500 hover:text-primary transition-all bg-inherit"
+                      title="新建虚拟文件夹"
+                      @click.stop="startCreateFolder(dataset)"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
+                      </svg>
+                    </button>
+                    <button
+                      v-if="canEdit && !isReadOnlyDataset(dataset)"
+                      class="p-1 rounded hover:bg-gray-200/60 text-gray-500 hover:text-primary transition-all bg-inherit"
                       title="修改元数据"
                       @click.stop="openEdit(dataset)"
                     >
@@ -1313,53 +1514,280 @@ onMounted(async () => {
                   <div v-else-if="!(documentsMap[dataset.ragflow_dataset_id || dataset.id]?.length)" class="py-2 pl-3 text-xs text-gray-400 italic">
                     暂无文档
                   </div>
-                  <!-- Documents loop -->
-                  <div
-                    v-else
-                    v-for="doc in documentsMap[dataset.ragflow_dataset_id || dataset.id]"
-                    :key="doc.id"
-                    class="group/doc relative flex items-center justify-between pl-3 pr-2 py-1.5 rounded-lg cursor-pointer transition-all border border-transparent"
-                    :class="[
-                      selectedType === 'document' && selectedId === doc.id
-                        ? 'bg-blue-50/70 border-blue-100 text-blue-700 font-semibold shadow-sm'
-                        : 'hover:bg-gray-50 text-gray-600'
-                    ]"
-                    @click="selectDocumentNode(doc, dataset)"
-                  >
-                    <div class="flex items-center gap-2 min-w-0 flex-1">
-                      <!-- File format icon -->
-                      <svg class="w-3.5 h-3.5 shrink-0 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+                  <!-- Documents loop with virtual folders support -->
+                  <div v-else class="space-y-1 w-full">
+                    <!-- 新建文件夹 Inline 输入框 -->
+                    <div 
+                      v-if="editingDatasetIdForFolder === (dataset.ragflow_dataset_id || dataset.id)"
+                      class="flex items-center gap-1.5 pl-3 pr-2 py-1 bg-gray-50 rounded-lg border border-dashed border-gray-300"
+                    >
+                      <svg class="w-3.5 h-3.5 text-gray-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
                       </svg>
-                      <!-- File name -->
-                      <span class="truncate text-xs">{{ doc.name || doc.id }}</span>
+                      <input 
+                        v-model="newFolderName"
+                        type="text" 
+                        class="flex-1 min-w-0 bg-transparent text-xs outline-none border-b border-primary/50 text-gray-700 py-0.5" 
+                        placeholder="文件夹名称..." 
+                        @keyup.enter="confirmCreateFolder(dataset)"
+                        @keyup.esc="editingDatasetIdForFolder = null"
+                      />
+                      <button 
+                        class="text-[10px] text-primary font-bold hover:text-primary-hover px-1 cursor-pointer"
+                        @click="confirmCreateFolder(dataset)"
+                      >
+                        确定
+                      </button>
+                      <button 
+                        class="text-[10px] text-gray-400 hover:text-gray-600 px-1 cursor-pointer"
+                        @click="editingDatasetIdForFolder = null"
+                      >
+                        取消
+                      </button>
                     </div>
 
-                    <!-- File status dot or delete action -->
-                    <div class="flex items-center gap-2 shrink-0 min-w-[12px] justify-end">
-                      <!-- Status indicators -->
-                      <span
-                        class="w-1.5 h-1.5 rounded-full shrink-0 transition-all group-hover/doc:hidden"
-                        :class="{
-                          'bg-emerald-500 shadow-[0_0_4px_#10b981]': getDocStatus(doc) === 'parsed',
-                          'bg-amber-500 animate-pulse shadow-[0_0_4px_#f59e0b]': getDocStatus(doc) === 'parsing',
-                          'bg-red-500 shadow-[0_0_4px_#ef4444]': getDocStatus(doc) === 'failed',
-                          'bg-gray-300': !getDocStatus(doc) || getDocStatus(doc) === 'unparsed'
-                        }"
-                      ></span>
-
-                      <!-- Hover Action Buttons -->
-                      <div class="hidden group-hover/doc:flex items-center bg-inherit pl-2 absolute right-2 top-1/2 -translate-y-1/2">
-                        <button
-                          v-if="canDeleteDocument && !isReadOnlyDataset(dataset)"
-                          class="p-0.5 rounded hover:bg-red-50 text-gray-400 hover:text-red-600 transition-all bg-inherit"
-                          title="删除文档"
-                          @click.stop="deletingDocument = doc"
+                    <!-- 文件夹层级渲染 -->
+                    <template v-if="dataset.local_metadata?.extra_config?.folder_structure && Object.keys(dataset.local_metadata.extra_config.folder_structure).length">
+                      <div 
+                        v-for="fName in Object.keys(dataset.local_metadata.extra_config.folder_structure)"
+                        :key="fName"
+                        class="space-y-0.5"
+                      >
+                        <!-- 文件夹行 -->
+                        <div 
+                          class="group/folder relative flex items-center justify-between pl-2 pr-2 py-1.5 rounded-lg cursor-pointer hover:bg-gray-50/70 transition-all text-gray-700 select-none"
+                          @click="toggleFolderCollapse(dataset.ragflow_dataset_id || dataset.id, fName)"
                         >
-                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                          </svg>
-                        </button>
+                          <div class="flex items-center gap-1.5 min-w-0 flex-1">
+                            <!-- 折叠展开小尖角 -->
+                            <svg 
+                              class="w-3 h-3 text-gray-400 transition-transform shrink-0" 
+                              :class="{ '-rotate-90': isFolderCollapsed(dataset.ragflow_dataset_id || dataset.id, fName) }"
+                              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                            >
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7" />
+                            </svg>
+                            <!-- 文件夹图标 -->
+                            <svg class="w-3.5 h-3.5 text-amber-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                              <path fill-rule="evenodd" d="M2 6a2 2 0 012-2h4l2 2h4a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" clip-rule="evenodd" />
+                            </svg>
+                            
+                            <!-- 重命名输入框 -->
+                            <div 
+                              v-if="editingFolderKey === `${dataset.ragflow_dataset_id || dataset.id}_${fName}`"
+                              class="flex items-center gap-1 min-w-0 flex-1"
+                              @click.stop
+                            >
+                              <input 
+                                v-model="editingFolderNewName"
+                                type="text" 
+                                class="w-full bg-white text-xs border border-primary px-1 rounded outline-none" 
+                                @keyup.enter="confirmRenameFolder(dataset, fName)"
+                                @keyup.esc="editingFolderKey = null"
+                              />
+                            </div>
+                            <!-- 普通文件夹名称 -->
+                            <span v-else class="truncate text-xs font-semibold text-gray-700">{{ fName }}</span>
+                          </div>
+
+                          <!-- 文件夹重命名/删除按钮 -->
+                          <div 
+                            v-if="!isReadOnlyDataset(dataset)"
+                            class="hidden group-hover/folder:flex items-center gap-1 bg-inherit pl-2 absolute right-2 top-1/2 -translate-y-1/2"
+                            @click.stop
+                          >
+                            <button 
+                              class="p-0.5 rounded hover:bg-gray-100 text-gray-400 hover:text-primary transition-all bg-inherit" 
+                              title="重命名文件夹"
+                              @click="startRenameFolder(dataset.ragflow_dataset_id || dataset.id, fName)"
+                            >
+                              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                              </svg>
+                            </button>
+                            <button 
+                              class="p-0.5 rounded hover:bg-red-50 text-gray-400 hover:text-red-600 transition-all bg-inherit" 
+                              title="删除文件夹"
+                              @click="removeFolder(dataset, fName)"
+                            >
+                              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+
+                        <!-- 文件夹内部的文件子节点 -->
+                        <transition name="slide-down">
+                          <div 
+                            v-show="!isFolderCollapsed(dataset.ragflow_dataset_id || dataset.id, fName)"
+                            class="pl-4 ml-4.5 border-l border-gray-100/80 space-y-0.5"
+                          >
+                            <div 
+                              v-for="doc in (documentsMap[dataset.ragflow_dataset_id || dataset.id] || []).filter(d => dataset.local_metadata?.extra_config?.folder_structure?.[fName]?.includes(d.id))"
+                              :key="doc.id"
+                              class="group/doc relative flex items-center justify-between pl-3 pr-2 py-1.5 rounded-lg cursor-pointer transition-all border border-transparent text-gray-500 hover:bg-gray-50"
+                              :class="[
+                                selectedType === 'document' && selectedId === doc.id
+                                  ? 'bg-blue-50/70 border-blue-100 text-blue-700 font-semibold shadow-sm'
+                                  : 'text-gray-500'
+                              ]"
+                              @click="selectDocumentNode(doc, dataset)"
+                            >
+                              <div class="flex items-center gap-1.5 min-w-0 flex-1">
+                                <svg class="w-3.5 h-3.5 shrink-0 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+                                </svg>
+                                <span class="truncate text-xs">{{ doc.name || doc.id }}</span>
+                              </div>
+                              
+                              <!-- 状态指示灯与悬浮移动/删除操作 -->
+                              <div class="flex items-center gap-1 shrink-0 justify-end relative" @click.stop>
+                                <span
+                                  class="w-1.5 h-1.5 rounded-full shrink-0 group-hover/doc:hidden"
+                                  :class="{
+                                    'bg-emerald-500 shadow-[0_0_4px_#10b981]': getDocStatus(doc) === 'parsed',
+                                    'bg-amber-500 animate-pulse shadow-[0_0_4px_#f59e0b]': getDocStatus(doc) === 'parsing',
+                                    'bg-red-500 shadow-[0_0_4px_#ef4444]': getDocStatus(doc) === 'failed',
+                                    'bg-gray-300': !getDocStatus(doc) || getDocStatus(doc) === 'unparsed'
+                                  }"
+                                ></span>
+                                
+                                <div class="hidden group-hover/doc:flex items-center bg-inherit pl-2 absolute right-0 top-1/2 -translate-y-1/2 gap-1 z-30">
+                                  <!-- 移动到文件夹按钮 -->
+                                  <div class="relative">
+                                    <button 
+                                      class="p-0.5 rounded hover:bg-gray-100 text-gray-400 hover:text-primary transition-all bg-inherit cursor-pointer"
+                                      title="移动到文件夹"
+                                      @click="activeFileMoveMenuDocId = (activeFileMoveMenuDocId === doc.id ? null : doc.id)"
+                                    >
+                                      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+                                      </svg>
+                                    </button>
+                                    
+                                    <!-- 下拉定位菜单 -->
+                                    <div 
+                                      v-if="activeFileMoveMenuDocId === doc.id"
+                                      class="absolute right-0 mt-1 w-36 bg-white border border-gray-150 rounded-lg shadow-lg z-50 py-1 divide-y divide-gray-50 text-xs"
+                                    >
+                                      <div class="px-2 py-1 text-[10px] text-gray-400 font-semibold select-none">移动至文件夹:</div>
+                                      <button 
+                                        v-for="targetFolder in Object.keys(dataset.local_metadata?.extra_config?.folder_structure || {}).filter(f => f !== fName)"
+                                        :key="targetFolder"
+                                        class="w-full text-left px-3 py-1.5 hover:bg-gray-50 text-gray-700 truncate cursor-pointer"
+                                        @click="moveDocumentToFolder(dataset, doc.id, targetFolder)"
+                                      >
+                                        📁 {{ targetFolder }}
+                                      </button>
+                                      <button 
+                                        class="w-full text-left px-3 py-1.5 hover:bg-gray-50 text-red-500 font-medium cursor-pointer"
+                                        @click="moveDocumentToFolder(dataset, doc.id, null)"
+                                      >
+                                        移出该文件夹
+                                      </button>
+                                    </div>
+                                  </div>
+
+                                  <button
+                                    v-if="canDeleteDocument && !isReadOnlyDataset(dataset)"
+                                    class="p-0.5 rounded hover:bg-red-50 text-gray-400 hover:text-red-600 transition-all bg-inherit"
+                                    title="删除文档"
+                                    @click="deletingDocument = doc"
+                                  >
+                                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                            
+                            <div 
+                              v-if="!dataset.local_metadata?.extra_config?.folder_structure?.[fName]?.length"
+                              class="py-1 pl-6 text-[10px] text-gray-400 italic select-none"
+                            >
+                              (空文件夹)
+                            </div>
+                          </div>
+                        </transition>
+                      </div>
+                    </template>
+
+                    <!-- 未分类文档列表渲染 (根目录下平铺) -->
+                    <div 
+                      v-for="doc in (documentsMap[dataset.ragflow_dataset_id || dataset.id] || []).filter(d => !dataset.local_metadata?.extra_config?.folder_structure || !Object.values(dataset.local_metadata.extra_config.folder_structure).some(ids => Array.isArray(ids) && ids.includes(d.id)))"
+                      :key="doc.id"
+                      class="group/doc relative flex items-center justify-between pl-3 pr-2 py-1.5 rounded-lg cursor-pointer transition-all border border-transparent"
+                      :class="[
+                        selectedType === 'document' && selectedId === doc.id
+                          ? 'bg-blue-50/70 border-blue-100 text-blue-700 font-semibold shadow-sm'
+                          : 'hover:bg-gray-50 text-gray-600'
+                      ]"
+                      @click="selectDocumentNode(doc, dataset)"
+                    >
+                      <div class="flex items-center gap-2 min-w-0 flex-1">
+                        <svg class="w-3.5 h-3.5 shrink-0 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+                        </svg>
+                        <span class="truncate text-xs">{{ doc.name || doc.id }}</span>
+                      </div>
+
+                      <div class="flex items-center gap-1 shrink-0 justify-end relative" @click.stop>
+                        <span
+                          class="w-1.5 h-1.5 rounded-full shrink-0 transition-all group-hover/doc:hidden"
+                          :class="{
+                            'bg-emerald-500 shadow-[0_0_4px_#10b981]': getDocStatus(doc) === 'parsed',
+                            'bg-amber-500 animate-pulse shadow-[0_0_4px_#f59e0b]': getDocStatus(doc) === 'parsing',
+                            'bg-red-500 shadow-[0_0_4px_#ef4444]': getDocStatus(doc) === 'failed',
+                            'bg-gray-300': !getDocStatus(doc) || getDocStatus(doc) === 'unparsed'
+                          }"
+                        ></span>
+
+                        <div class="hidden group-hover/doc:flex items-center bg-inherit pl-2 absolute right-0 top-1/2 -translate-y-1/2 gap-1 z-30">
+                          <!-- 移动至文件夹按钮 -->
+                          <div 
+                            v-if="dataset.local_metadata?.extra_config?.folder_structure && Object.keys(dataset.local_metadata.extra_config.folder_structure).length"
+                            class="relative"
+                          >
+                            <button 
+                              class="p-0.5 rounded hover:bg-gray-100 text-gray-400 hover:text-primary transition-all bg-inherit cursor-pointer"
+                              title="移动到文件夹"
+                              @click="activeFileMoveMenuDocId = (activeFileMoveMenuDocId === doc.id ? null : doc.id)"
+                            >
+                              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+                              </svg>
+                            </button>
+                            
+                            <!-- 下拉定位菜单 -->
+                            <div 
+                              v-if="activeFileMoveMenuDocId === doc.id"
+                              class="absolute right-0 mt-1 w-36 bg-white border border-gray-150 rounded-lg shadow-lg z-50 py-1 divide-y divide-gray-50 text-xs"
+                            >
+                              <div class="px-2 py-1 text-[10px] text-gray-400 font-semibold select-none">移动至文件夹:</div>
+                              <button 
+                                v-for="targetFolder in Object.keys(dataset.local_metadata.extra_config.folder_structure)"
+                                :key="targetFolder"
+                                class="w-full text-left px-3 py-1.5 hover:bg-gray-50 text-gray-700 truncate cursor-pointer"
+                                @click="moveDocumentToFolder(dataset, doc.id, targetFolder)"
+                              >
+                                📁 {{ targetFolder }}
+                              </button>
+                            </div>
+                          </div>
+
+                          <button
+                            v-if="canDeleteDocument && !isReadOnlyDataset(dataset)"
+                            class="p-0.5 rounded hover:bg-red-50 text-gray-400 hover:text-red-600 transition-all bg-inherit"
+                            title="删除文档"
+                            @click="deletingDocument = doc"
+                          >
+                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                            </svg>
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2032,6 +2460,59 @@ onMounted(async () => {
           <label class="block text-xs font-semibold text-gray-400 mb-1.5">备注信息</label>
           <textarea v-model="form.notes" class="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary" rows="2" placeholder="备注"></textarea>
         </div>
+        
+        <!-- 自定义提问置顶配置 -->
+        <div class="border border-gray-100 bg-gray-50/30 p-3 rounded-xl space-y-2">
+          <div class="flex justify-between items-center">
+            <label class="block text-xs font-semibold text-gray-400 select-none">门户快捷提问置顶 (最多 3 个)</label>
+            <button 
+              v-if="customQuestions.length < 3"
+              type="button"
+              class="text-xs text-primary hover:text-primary-hover font-semibold transition-colors flex items-center gap-0.5 cursor-pointer"
+              @click="customQuestions.push({ label: '', query: '' })"
+            >
+              ＋ 添加提问
+            </button>
+          </div>
+          
+          <div v-if="customQuestions.length === 0" class="text-xs text-gray-400 italic py-2 text-center select-none">
+            暂无置顶提问（当前由大模型智能推荐）
+          </div>
+          
+          <div v-else class="space-y-2">
+            <div 
+              v-for="(q, idx) in customQuestions" 
+              :key="idx"
+              class="bg-white p-2 rounded-lg border border-gray-200/60 shadow-sm relative group flex flex-col gap-2"
+            >
+              <button 
+                type="button" 
+                class="absolute top-1 right-2.5 text-gray-300 hover:text-red-500 font-bold focus:outline-none transition-colors cursor-pointer text-sm" 
+                @click="customQuestions.splice(idx, 1)"
+              >
+                ×
+              </button>
+              <div class="grid grid-cols-3 gap-2 pr-4 pt-1">
+                <div class="col-span-1">
+                  <input 
+                    v-model="q.label" 
+                    class="w-full border border-gray-200 rounded-lg px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary" 
+                    placeholder="按钮简称" 
+                    maxlength="15" 
+                  />
+                </div>
+                <div class="col-span-2">
+                  <input 
+                    v-model="q.query" 
+                    class="w-full border border-gray-200 rounded-lg px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary" 
+                    placeholder="给 AI 的提问问题..." 
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div>
           <label class="block text-xs font-semibold text-gray-400 mb-1.5">额外扩展配置 JSON</label>
           <textarea v-model="form.extraConfigText" class="w-full border border-gray-200 rounded-xl px-3 py-2 font-mono text-xs focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary bg-gray-50/50" rows="3" placeholder="扩展配置 JSON"></textarea>

--- a/frontend/src/views/KnowledgeBaseManagement.vue
+++ b/frontend/src/views/KnowledgeBaseManagement.vue
@@ -54,7 +54,7 @@ type RagFlowConfigSummary = {
 }
 
 const { showToast } = useToast()
-const { hasPermission } = useUser()
+const { hasPermission, isAdmin } = useUser()
 
 const loading = ref(false)
 const syncing = ref(false)
@@ -101,6 +101,7 @@ const canDelete = computed(() => hasPermission('element:knowledge:delete'))
 const canUpload = computed(() => hasPermission('element:knowledge:upload_document'))
 const canDeleteDocument = computed(() => hasPermission('element:knowledge:delete_document'))
 const canParse = computed(() => hasPermission('element:knowledge:parse_document'))
+const canManagePermissions = computed(() => isAdmin.value || hasPermission('menu:system:users'))
 const canSync = computed(() => canEdit.value)
 const isKnowledgeEnabled = computed(() => ragflowConfig.value?.knowledge_base_enabled !== false)
 const isEngineReady = computed(() => isKnowledgeEnabled.value && engineStatus.value === 'connected' && !loading.value)
@@ -337,6 +338,102 @@ const fetchDatasetPermissions = async (datasetId: string) => {
     console.error('获取知识库权限分配失败:', err)
   } finally {
     loadingPermissions.value = false
+  }
+}
+
+// 反向分配成员授权的状态与交互
+const showAddPermissionModal = ref(false)
+const assignType = ref<'role' | 'user'>('role')
+const selectedCandidateIds = ref<number[]>([])
+const candidates = ref<{ roles: any[], users: any[] }>({ roles: [], users: [] })
+const savingPerms = ref(false)
+const candidateSearchQuery = ref('')
+
+const availableRoles = computed(() => {
+  const grantedCodes = (datasetPermissions.value.roles || []).map(r => r.code)
+  let filtered = (candidates.value.roles || []).filter(r => !grantedCodes.includes(r.code))
+  if (candidateSearchQuery.value) {
+    const q = candidateSearchQuery.value.toLowerCase()
+    filtered = filtered.filter(r => 
+      (r.name && r.name.toLowerCase().includes(q)) || 
+      (r.code && r.code.toLowerCase().includes(q))
+    )
+  }
+  return filtered
+})
+
+const availableUsers = computed(() => {
+  const grantedNames = (datasetPermissions.value.users || []).map(u => u.user_name)
+  let filtered = (candidates.value.users || []).filter(u => !grantedNames.includes(u.user_name))
+  if (candidateSearchQuery.value) {
+    const q = candidateSearchQuery.value.toLowerCase()
+    filtered = filtered.filter(u => 
+      (u.real_name && u.real_name.toLowerCase().includes(q)) || 
+      (u.user_name && u.user_name.toLowerCase().includes(q))
+    )
+  }
+  return filtered
+})
+
+const openAddPermissionModal = async () => {
+  selectedCandidateIds.value = []
+  showAddPermissionModal.value = true
+  try {
+    const res = await axios.get('/api/portal/metadata/candidates')
+    candidates.value = res.data?.data || { roles: [], users: [] }
+  } catch (err) {
+    console.error('获取候选列表失败:', err)
+  }
+}
+
+const closeAddPermissionModal = () => {
+  showAddPermissionModal.value = false
+  selectedCandidateIds.value = []
+  candidateSearchQuery.value = ''
+}
+
+const toggleCandidateSelection = (id: number) => {
+  const idx = selectedCandidateIds.value.indexOf(id)
+  if (idx > -1) {
+    selectedCandidateIds.value.splice(idx, 1)
+  } else {
+    selectedCandidateIds.value.push(id)
+  }
+}
+
+const submitPermissions = async () => {
+  if (!selectedCandidateIds.value.length || !selectedDatasetId.value) return
+  savingPerms.value = true
+  try {
+    await axios.post(`/api/portal/ragflow/datasets/${selectedDatasetId.value}/permissions`, {
+      target_type: assignType.value,
+      target_ids: selectedCandidateIds.value
+    })
+    showToast('分配授权成功', 'success')
+    closeAddPermissionModal()
+    await fetchDatasetPermissions(selectedDatasetId.value)
+  } catch (err) {
+    showToast('分配授权失败', 'error')
+  } finally {
+    savingPerms.value = false
+  }
+}
+
+const removePermission = async (type: string, id: number) => {
+  if (!selectedDatasetId.value) return
+  const typeText = type === 'role' ? '角色' : '用户'
+  if (!confirm(`确定要移除该${typeText}的知识库访问授权吗？`)) return
+  try {
+    await axios.delete(`/api/portal/ragflow/datasets/${selectedDatasetId.value}/permissions`, {
+      data: {
+        target_type: type,
+        target_id: id
+      }
+    })
+    showToast('取消授权成功', 'success')
+    await fetchDatasetPermissions(selectedDatasetId.value)
+  } catch (err) {
+    showToast('取消授权失败', 'error')
   }
 }
 
@@ -1393,10 +1490,23 @@ onMounted(async () => {
           <div class="space-y-2 bg-gray-50/20 p-4 rounded-xl border border-gray-150">
             <div class="flex items-center justify-between">
               <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider select-none">系统授权分配详情</h3>
-              <span v-if="loadingPermissions" class="text-xs text-gray-400 animate-pulse flex items-center gap-1 select-none">
-                <span class="w-2.5 h-2.5 rounded-full border border-gray-300 border-t-transparent animate-spin"></span>
-                正在读取权限分配...
-              </span>
+              <div class="flex items-center gap-2">
+                <span v-if="loadingPermissions" class="text-xs text-gray-400 animate-pulse flex items-center gap-1 select-none">
+                  <span class="w-2.5 h-2.5 rounded-full border border-gray-300 border-t-transparent animate-spin"></span>
+                  正在读取权限分配...
+                </span>
+                <button
+                  v-if="canManagePermissions && !loadingPermissions"
+                  type="button"
+                  class="px-2 py-0.5 rounded bg-emerald-600 hover:bg-emerald-700 text-white text-[10px] font-bold shadow-xs transition-all flex items-center gap-0.5 cursor-pointer"
+                  @click="openAddPermissionModal"
+                >
+                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+                  </svg>
+                  分配授权成员
+                </button>
+              </div>
             </div>
             
             <div class="text-xs space-y-3 mt-1.5">
@@ -1417,12 +1527,21 @@ onMounted(async () => {
                     <span 
                       v-for="r in datasetPermissions.roles" 
                       :key="r.code"
-                      class="px-2 py-0.5 rounded bg-blue-50 text-blue-700 font-semibold border border-blue-100/50 flex items-center gap-1 select-none"
+                      class="px-2 py-0.5 rounded bg-blue-50 text-blue-700 font-semibold border border-blue-100/50 flex items-center gap-1 select-none group/tag"
                     >
                       <svg class="w-3 h-3 text-blue-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
                         <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0z" />
                       </svg>
                       {{ r.name }} ({{ r.code }})
+                      <button
+                        v-if="canManagePermissions"
+                        type="button"
+                        class="text-blue-400 hover:text-red-500 font-bold ml-1.5 focus:outline-none cursor-pointer text-xs"
+                        title="取消授权"
+                        @click.stop="removePermission('role', r.id)"
+                      >
+                        ×
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -1433,12 +1552,21 @@ onMounted(async () => {
                     <span 
                       v-for="u in datasetPermissions.users" 
                       :key="u.user_name"
-                      class="px-2 py-0.5 rounded bg-emerald-50 text-emerald-700 font-semibold border border-emerald-100/50 flex items-center gap-1 select-none"
+                      class="px-2 py-0.5 rounded bg-emerald-50 text-emerald-700 font-semibold border border-emerald-100/50 flex items-center gap-1 select-none group/tag"
                     >
                       <svg class="w-3 h-3 text-emerald-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd" />
                       </svg>
                       {{ u.real_name || u.user_name }} ({{ u.user_name }})
+                      <button
+                        v-if="canManagePermissions"
+                        type="button"
+                        class="text-emerald-400 hover:text-red-500 font-bold ml-1.5 focus:outline-none cursor-pointer text-xs"
+                        title="取消授权"
+                        @click.stop="removePermission('user', u.id)"
+                      >
+                        ×
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -1984,6 +2112,116 @@ onMounted(async () => {
 
         <div class="flex justify-end pt-2 border-t">
           <button class="px-4 py-2 rounded-xl bg-gray-900 hover:bg-gray-800 text-white text-sm font-semibold transition-all" @click="closeChunksModal">关闭</button>
+        </div>
+      </div>
+    </Modal>
+
+    <!-- Add Permission Modal -->
+    <Modal :show="showAddPermissionModal" title="分配知识库授权成员" size="max-w-md" @close="closeAddPermissionModal">
+      <div class="space-y-4">
+        <!-- 切换类型 -->
+        <div>
+          <label class="block text-xs font-semibold text-gray-400 mb-1.5 select-none">成员授权类型</label>
+          <div class="grid grid-cols-2 gap-2 bg-gray-50 p-1 rounded-xl border border-gray-150">
+            <button 
+              type="button"
+              @click="assignType = 'role'; selectedCandidateIds = []"
+              class="py-2 text-xs font-semibold rounded-lg transition-all cursor-pointer font-bold"
+              :class="assignType === 'role' ? 'bg-white shadow text-primary' : 'text-gray-500 hover:text-gray-800'"
+            >
+              按角色授权 (Role)
+            </button>
+            <button 
+              type="button"
+              @click="assignType = 'user'; selectedCandidateIds = []"
+              class="py-2 text-xs font-semibold rounded-lg transition-all cursor-pointer font-bold"
+              :class="assignType === 'user' ? 'bg-white shadow text-primary' : 'text-gray-500 hover:text-gray-800'"
+            >
+              按个人授权 (User)
+            </button>
+          </div>
+        </div>
+
+        <!-- 搜索输入框 -->
+        <div class="relative">
+          <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-gray-400">
+             <svg class="h-4.5 w-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+             </svg>
+          </span>
+          <input 
+            v-model="candidateSearchQuery"
+            type="text"
+            class="block w-full pl-9 pr-3 py-2 border border-gray-200 rounded-xl leading-5 bg-gray-50 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary sm:text-xs transition-all focus:bg-white"
+            :placeholder="assignType === 'role' ? '搜索角色名称或代码...' : '搜索用户姓名或账号...'"
+          />
+        </div>
+
+        <!-- 候选人列表勾选 -->
+        <div class="space-y-2">
+          <label class="block text-xs font-semibold text-gray-400 select-none">
+            选择要添加的{{ assignType === 'role' ? '角色' : '用户' }} (可多选)
+          </label>
+          <div class="border border-gray-150 rounded-xl max-h-[30vh] overflow-y-auto divide-y divide-gray-100 bg-white">
+            <!-- 候选角色 -->
+            <template v-if="assignType === 'role'">
+              <div 
+                v-for="r in availableRoles" 
+                :key="r.id"
+                class="flex items-center gap-3 p-3 hover:bg-gray-50 transition-all select-none cursor-pointer"
+                @click="toggleCandidateSelection(r.id)"
+              >
+                <input 
+                  type="checkbox" 
+                  :checked="selectedCandidateIds.includes(r.id)"
+                  class="rounded text-indigo-600 border-gray-300 focus:ring-indigo-500" 
+                  @click.stop="toggleCandidateSelection(r.id)"
+                />
+                <div class="flex flex-col">
+                  <span class="text-sm font-semibold text-gray-800">{{ r.name }}</span>
+                  <span class="text-[10px] text-gray-400 font-mono mt-0.5">{{ r.code }}</span>
+                </div>
+              </div>
+              <div v-if="!availableRoles.length" class="text-xs text-gray-400 text-center py-8 select-none">
+                所有角色已完成分配授权。
+              </div>
+            </template>
+
+            <!-- 候选用户 -->
+            <template v-if="assignType === 'user'">
+              <div 
+                v-for="u in availableUsers" 
+                :key="u.id"
+                class="flex items-center gap-3 p-3 hover:bg-gray-50 transition-all select-none cursor-pointer"
+                @click="toggleCandidateSelection(u.id)"
+              >
+                <input 
+                  type="checkbox" 
+                  :checked="selectedCandidateIds.includes(u.id)"
+                  class="rounded text-emerald-600 border-gray-300 focus:ring-emerald-500" 
+                  @click.stop="toggleCandidateSelection(u.id)"
+                />
+                <div class="flex flex-col">
+                  <span class="text-sm font-semibold text-gray-800">{{ u.real_name || u.user_name }}</span>
+                  <span class="text-[10px] text-gray-400 font-mono mt-0.5">{{ u.user_name }}</span>
+                </div>
+              </div>
+              <div v-if="!availableUsers.length" class="text-xs text-gray-400 text-center py-8 select-none">
+                所有活跃用户已完成分配授权。
+              </div>
+            </template>
+          </div>
+        </div>
+
+        <div class="flex justify-end gap-3 pt-2">
+          <button class="px-4 py-2 rounded-xl border text-sm font-semibold hover:bg-gray-50 transition-all" @click="closeAddPermissionModal">取消</button>
+          <button 
+            class="px-4 py-2 rounded-xl text-sm font-semibold text-white transition-all shadow-md disabled:opacity-50 bg-primary hover:bg-primary-hover"
+            :disabled="!selectedCandidateIds.length || savingPerms"
+            @click="submitPermissions"
+          >
+            确认分配
+          </button>
         </div>
       </div>
     </Modal>

--- a/frontend/src/views/KnowledgeBaseManagement.vue
+++ b/frontend/src/views/KnowledgeBaseManagement.vue
@@ -80,6 +80,7 @@ const searchQuery = ref('')
 
 const showCreateModal = ref(false)
 const showEditModal = ref(false)
+const aiAnalyzing = ref(false)
 const deletingDataset = ref<KnowledgeBase | null>(null)
 const deletingDocument = ref<KnowledgeDocument | null>(null)
 
@@ -210,6 +211,28 @@ const openEdit = (dataset: KnowledgeBase) => {
     extraConfigText: JSON.stringify(dataset.local_metadata?.extra_config || {}, null, 2)
   }
   showEditModal.value = true
+}
+
+const analyzeMetadataByAI = async () => {
+  if (!selectedDataset.value) return
+  const datasetId = selectedDataset.value.ragflow_dataset_id || selectedDataset.value.id
+  if (!datasetId) return
+
+  aiAnalyzing.value = true
+  try {
+    const response = await axios.post(`/api/portal/ragflow/datasets/${datasetId}/ai-analyze`)
+    const resData = apiData(response)
+    if (resData) {
+      if (resData.description) form.value.description = resData.description
+      if (resData.tags) form.value.tagsText = resData.tags
+      if (resData.notes) form.value.notes = resData.notes
+      showToast('AI 智能分析完成，已自动填充元数据', 'success')
+    }
+  } catch (err) {
+    showToast(extractError(err) || 'AI 分析失败，请重试', 'error')
+  } finally {
+    aiAnalyzing.value = false
+  }
 }
 
 // 获取知识库列表
@@ -1262,7 +1285,12 @@ onMounted(async () => {
                 <h2 class="text-xl font-bold text-gray-900">{{ selectedDataset.platform_name || selectedDataset.name }}</h2>
                 <span v-if="selectedDataset.is_missing_in_ragflow" class="px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 text-xs font-semibold">RAGFlow 侧已失联</span>
               </div>
-              <p class="text-sm text-gray-500 mt-1.5">{{ selectedDataset.platform_description || selectedDataset.description || '暂无对该知识库的描述' }}</p>
+              <div v-if="selectedDataset.platform_description || selectedDataset.description" class="mt-3 pl-3.5 border-l-3 border-primary bg-gray-50/80 py-2.5 pr-4 rounded-r-xl max-w-3xl">
+                <p class="text-sm text-gray-600 leading-relaxed italic">
+                  "{{ selectedDataset.platform_description || selectedDataset.description }}"
+                </p>
+              </div>
+              <p v-else class="text-xs text-gray-400 italic mt-2.5 select-none">暂无对该知识库的描述说明</p>
             </div>
             <div class="flex items-center gap-2 shrink-0">
               <button
@@ -1291,7 +1319,7 @@ onMounted(async () => {
                 <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
                 </svg>
-                编辑元数据
+                编辑
               </button>
             </div>
           </div>
@@ -1328,24 +1356,34 @@ onMounted(async () => {
           </div>
 
           <!-- Tags & Notes -->
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div class="space-y-2">
-              <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">分类标签</h3>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6 pt-2">
+            <div class="space-y-2.5">
+              <div class="flex items-center gap-1.5 text-gray-400">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M6 20h12a2 2 0 002-2V8a2 2 0 00-2-2H6a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                <h3 class="text-xs font-semibold uppercase tracking-wider">分类标签</h3>
+              </div>
               <div v-if="selectedDataset.tags?.length" class="flex flex-wrap gap-1.5">
                 <span
                   v-for="tag in selectedDataset.tags"
                   :key="tag"
-                  class="px-2.5 py-1 text-xs rounded-full bg-blue-50 text-blue-700 border border-blue-100 font-medium"
+                  class="px-2.5 py-1 text-xs rounded-lg bg-blue-50/60 text-blue-700 border border-blue-100/60 font-medium transition-all hover:bg-blue-100/50 select-none cursor-default"
                 >
                   {{ tag }}
                 </span>
               </div>
-              <span v-else class="text-sm text-gray-400 italic">暂无标签</span>
+              <span v-else class="text-sm text-gray-400 italic select-none block pt-1">暂无分类标签</span>
             </div>
 
-            <div class="space-y-2">
-              <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">平台备注</h3>
-              <p class="text-sm text-gray-600 bg-gray-50/50 p-3 rounded-xl border border-gray-150 leading-relaxed">
+            <div class="space-y-2.5">
+              <div class="flex items-center gap-1.5 text-gray-400">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+                <h3 class="text-xs font-semibold uppercase tracking-wider">平台备注说明</h3>
+              </div>
+              <p class="text-sm text-gray-600 bg-amber-50/20 p-3.5 rounded-xl border border-amber-100/50 leading-relaxed">
                 {{ selectedDataset.notes || '暂无备注说明。' }}
               </p>
             </div>
@@ -1826,8 +1864,23 @@ onMounted(async () => {
           <input v-model="form.name" class="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary" placeholder="展示名称" />
         </div>
         <div>
-          <label class="block text-xs font-semibold text-gray-400 mb-1.5">描述说明</label>
-          <textarea v-model="form.description" class="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary" rows="2" placeholder="描述"></textarea>
+          <div class="flex justify-between items-center mb-1.5">
+            <label class="block text-xs font-semibold text-gray-400">描述说明</label>
+            <button
+              v-if="selectedDataset && (selectedDataset.doc_count ?? selectedDataset.document_count ?? 0) > 0"
+              class="flex items-center gap-1 text-xs text-primary hover:text-primary-hover font-semibold transition-colors disabled:opacity-50"
+              :disabled="aiAnalyzing"
+              @click="analyzeMetadataByAI"
+            >
+              <svg v-if="aiAnalyzing" class="animate-spin h-3.5 w-3.5 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              <span v-else>✨</span>
+              <span>{{ aiAnalyzing ? 'AI 分析中...' : 'AI 智能分析元数据' }}</span>
+            </button>
+          </div>
+          <textarea v-model="form.description" class="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary" rows="2" placeholder="由 AI 自动分析生成或手动输入"></textarea>
         </div>
         <div class="grid grid-cols-2 gap-3">
           <div>

--- a/frontend/src/views/Roles.vue
+++ b/frontend/src/views/Roles.vue
@@ -313,18 +313,31 @@
                             <label 
                                 v-for="res in currentResources" 
                                 :key="res.id" 
-                                class="flex items-start p-2.5 rounded-lg border transition-all cursor-pointer shadow-sm group bg-white hover:border-blue-200"
-                                :class="resCardActiveClass(res.id)"
+                                class="flex items-start p-2.5 rounded-lg border transition-all shadow-sm group bg-white"
+                                :class="[
+                                    isMissingKnowledgeBase(res)
+                                      ? 'opacity-70 cursor-not-allowed border-amber-200 bg-amber-50/40'
+                                      : 'cursor-pointer hover:border-blue-200',
+                                    resCardActiveClass(res.id)
+                                ]"
+                                :title="isMissingKnowledgeBase(res) ? '该知识库已在 RAGFlow 失联，不可分配权限' : undefined"
                             >
                                 <input 
                                     type="checkbox" 
                                     :value="res.id" 
                                     v-model="(permissionData as any)[activeResTab]"
-                                    class="h-4 w-4 rounded mt-0.5 flex-shrink-0 border-gray-300 focus:ring-2"
+                                    :disabled="isMissingKnowledgeBase(res)"
+                                    class="h-4 w-4 rounded mt-0.5 flex-shrink-0 border-gray-300 focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
                                     :class="resCheckboxClass()"
                                 />
                                 <div class="ml-2.5 min-w-0 flex-1">
-                                    <span class="font-bold text-gray-900 block truncate text-xs leading-tight mb-0.5">{{ res.display_name || res.name }}</span>
+                                    <div class="flex items-center gap-1.5 mb-0.5 min-w-0">
+                                        <span class="font-bold text-gray-900 block truncate text-xs leading-tight">{{ res.platform_name || res.display_name || res.name }}</span>
+                                        <span
+                                          v-if="isMissingKnowledgeBase(res)"
+                                          class="flex-shrink-0 text-[9px] px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 font-semibold leading-none"
+                                        >失联</span>
+                                    </div>
                                     <span class="text-gray-400 text-[9px] block truncate font-mono">{{ res.description || res.id }}</span>
                                 </div>
                             </label>
@@ -685,6 +698,11 @@ const permissionData = ref<{
     elements: []
 })
 
+const isMissingKnowledgeBase = (res: any) => {
+    if (activeResTab.value !== 'datasets') return false
+    return Boolean(res?.is_missing_in_ragflow || res?.status === 'missing')
+}
+
 const resCardActiveClass = (resId: string) => {
     const type = activeResTab.value
     const selected = (permissionData.value as any)[type]?.includes(resId)
@@ -833,8 +851,12 @@ const currentResources = computed(() => {
     return allResources.value[activeResTab.value] || []
 })
 
+const selectableResources = computed(() =>
+    currentResources.value.filter((r: any) => !isMissingKnowledgeBase(r))
+)
+
 const isAllSelected = computed(() => {
-    const current = currentResources.value
+    const current = selectableResources.value
     if (current.length === 0) return false
     const selected = (permissionData.value as any)[activeResTab.value]
     return current.every((r: any) => selected.includes(r.id))
@@ -965,6 +987,17 @@ const fetchResources = async () => {
          const available = handleResult(results[1])
 
          allResources.value.datasets = ragDatasets
+         // 失联知识库不可再分配：从当前勾选中剔除
+         const missingIds = new Set(
+           (ragDatasets || [])
+             .filter((d: any) => d?.is_missing_in_ragflow || d?.status === 'missing')
+             .map((d: any) => d.id)
+         )
+         if (missingIds.size > 0) {
+           permissionData.value.datasets = (permissionData.value.datasets || []).filter(
+             (id: string) => !missingIds.has(id)
+           )
+         }
          
          if (available) {
              allResources.value.agents = available.agents || []
@@ -983,9 +1016,14 @@ const fetchRolePermissions = async (roleId: number) => {
         const apiKey = localStorage.getItem('api_key')
         const response = await axios.get(`/api/portal/roles/${roleId}/permissions`, { headers: { 'X-API-Key': apiKey } })
         const perms = response.data.permissions
+        const missingIds = new Set(
+            (allResources.value.datasets || [])
+                .filter((d: any) => d?.is_missing_in_ragflow || d?.status === 'missing')
+                .map((d: any) => d.id)
+        )
         permissionData.value = {
             agents: perms.agents || [],
-            datasets: perms.datasets || [],
+            datasets: (perms.datasets || []).filter((id: string) => !missingIds.has(id)),
             metadata: perms.metadata || [],
             apis: perms.apis || [],
             menus: perms.menus || [],
@@ -1002,9 +1040,18 @@ const savePermissions = async () => {
     submittingPerms.value = true
     try {
         const apiKey = localStorage.getItem('api_key')
+        const missingIds = new Set(
+            (allResources.value.datasets || [])
+                .filter((d: any) => d?.is_missing_in_ragflow || d?.status === 'missing')
+                .map((d: any) => d.id)
+        )
+        const payload = {
+            ...permissionData.value,
+            datasets: (permissionData.value.datasets || []).filter((id: string) => !missingIds.has(id)),
+        }
         await axios.put(
             `/api/portal/roles/${currentRole.value.id}/permissions`, 
-            permissionData.value, 
+            payload, 
             { headers: { 'X-API-Key': apiKey } }
         )
         showToast('权限保存成功', 'success')
@@ -1021,7 +1068,7 @@ const toggleSelectAll = () => {
     if (isAllSelected.value) {
         (permissionData.value as any)[type] = []
     } else {
-        (permissionData.value as any)[type] = currentResources.value.map((r: any) => r.id)
+        (permissionData.value as any)[type] = selectableResources.value.map((r: any) => r.id)
     }
 }
 

--- a/frontend/src/views/Users.vue
+++ b/frontend/src/views/Users.vue
@@ -794,20 +794,38 @@
                     <label
                       v-for="res in currentResources"
                       :key="res.id"
-                      class="flex items-start p-2 rounded border bg-white hover:bg-gray-50 cursor-pointer transition-colors"
+                      class="flex items-start p-2 rounded border bg-white transition-colors"
+                      :class="
+                        isMissingKnowledgeBase(res)
+                          ? 'opacity-70 cursor-not-allowed border-amber-200 bg-amber-50/40'
+                          : 'hover:bg-gray-50 cursor-pointer'
+                      "
+                      :title="
+                        isMissingKnowledgeBase(res)
+                          ? '该知识库已在 RAGFlow 失联，不可分配权限'
+                          : undefined
+                      "
                     >
                       <input
                         type="checkbox"
                         :value="res.id"
                         v-model="(permissionData as any)[activeResTab]"
-                        class="mt-1 h-4 w-4 rounded text-blue-600 focus:ring-blue-500"
+                        :disabled="isMissingKnowledgeBase(res)"
+                        class="mt-1 h-4 w-4 rounded text-blue-600 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
                       />
                       <div class="ml-2 min-w-0">
-                        <p
-                          class="text-xs sm:text-sm font-bold text-gray-900 truncate"
-                        >
-                          {{ res.display_name || res.name }}
-                        </p>
+                        <div class="flex items-center gap-1.5 min-w-0">
+                          <p
+                            class="text-xs sm:text-sm font-bold text-gray-900 truncate"
+                          >
+                            {{ res.platform_name || res.display_name || res.name }}
+                          </p>
+                          <span
+                            v-if="isMissingKnowledgeBase(res)"
+                            class="flex-shrink-0 text-[9px] px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 font-semibold leading-none"
+                            >失联</span
+                          >
+                        </div>
                         <p class="text-[9px] text-gray-400 truncate font-mono">
                           {{ res.description || res.id }}
                         </p>
@@ -1636,10 +1654,20 @@ const isItemSelected = (itemId: string) => {
 const currentResources = computed(
   () => allResources.value[activeResTab.value] || [],
 );
+
+const isMissingKnowledgeBase = (res: any) => {
+  if (activeResTab.value !== "datasets") return false;
+  return Boolean(res?.is_missing_in_ragflow || res?.status === "missing");
+};
+
+const selectableResources = computed(() =>
+  currentResources.value.filter((r: any) => !isMissingKnowledgeBase(r)),
+);
+
 const isAllSelected = computed(
   () =>
-    currentResources.value.length > 0 &&
-    currentResources.value.every((r: any) =>
+    selectableResources.value.length > 0 &&
+    selectableResources.value.every((r: any) =>
       permissionData.value[activeResTab.value].includes(r.id),
     ),
 );
@@ -1708,7 +1736,20 @@ const fetchResources = async () => {
       const r1 = await axios.get("/api/portal/ragflow/datasets", {
         params: { page_size: 100 },
       });
-      allResources.value.datasets = r1.data.data || r1.data || [];
+      const datasets = r1.data.data || r1.data || [];
+      allResources.value.datasets = datasets;
+      const missingIds = new Set(
+        datasets
+          .filter(
+            (d: any) => d?.is_missing_in_ragflow || d?.status === "missing",
+          )
+          .map((d: any) => d.id),
+      );
+      if (missingIds.size > 0) {
+        permissionData.value.datasets = (
+          permissionData.value.datasets || []
+        ).filter((id: string) => !missingIds.has(id));
+      }
     } catch (ragErr) {
       console.warn(
         "RagFlow service unreachable, skipping dataset permissions",
@@ -1729,9 +1770,18 @@ const fetchUserPermissions = async (userId: number) => {
       `/api/portal/management/users/${userId}/permissions`,
     );
     const perms = response.data.permissions;
+    const missingIds = new Set(
+      (allResources.value.datasets || [])
+        .filter(
+          (d: any) => d?.is_missing_in_ragflow || d?.status === "missing",
+        )
+        .map((d: any) => d.id),
+    );
     permissionData.value = {
       agents: perms.agents || [],
-      datasets: perms.datasets || [],
+      datasets: (perms.datasets || []).filter(
+        (id: string) => !missingIds.has(id),
+      ),
       metadata: perms.metadata || [],
       apis: perms.apis || [],
       menus: perms.menus || [],
@@ -1794,11 +1844,26 @@ const saveUser = async () => {
       } catch (syncErr) {
         console.warn('LocalStorage Sync Error:', syncErr);
       }
-      if (formData.value.role === "user")
+      if (formData.value.role === "user") {
+        const missingIds = new Set(
+          (allResources.value.datasets || [])
+            .filter(
+              (d: any) =>
+                d?.is_missing_in_ragflow || d?.status === "missing",
+            )
+            .map((d: any) => d.id),
+        );
+        const payload = {
+          ...permissionData.value,
+          datasets: (permissionData.value.datasets || []).filter(
+            (id: string) => !missingIds.has(id),
+          ),
+        };
         await axios.put(
           `/api/portal/management/users/${editingUserId.value}/permissions`,
-          permissionData.value,
+          payload,
         );
+      }
       showToast("更新成功", "success");
       closeDialogs();
       fetchUsers();
@@ -1953,7 +2018,7 @@ const toggleSelectAll = () => {
   if (isAllSelected.value) {
     (permissionData.value as any)[type] = [];
   } else {
-    (permissionData.value as any)[type] = currentResources.value.map(
+    (permissionData.value as any)[type] = selectableResources.value.map(
       (r: any) => r.id,
     );
   }

--- a/tests/CHECKLIST.md
+++ b/tests/CHECKLIST.md
@@ -208,6 +208,8 @@
 | 单文件专属提问推荐与缓存策略 (Single Document Recommended Questions) | `ragflow.py`, `KnowledgePortalDrawer.vue`, `useKnowledgePortal.ts` | **单文档手风琴专属提问生成与懒加载**：验证在“相关文档”列表点击单文件展开/收起；验证懒加载发起大模型专属提问推断；验证 Redis 缓存（7天）读取命中；验证双功能按钮（直接发送/编辑提问）及联动自动激活绑定知识库。 | ✅ 已验证 | 2026-07-08 |
 | 知识库 AI 元数据分析 (AI Metadata Analysis) | `app/api/portal/endpoints/ragflow.py`, `KnowledgeBaseManagement.vue` | **AI 元数据分析生成与回填**：验证获取知识库写权限与文档列表；验证调用 LLM 基于前 100 个文件名分析生成中英文标签、描述与备注信息，并在前端编辑弹窗一键智能分析后自动回填。 | ✅ 已完成 | 2026-07-08 |
 | 知识库中心侧边抽屉搜索过滤 (Knowledge Portal Search & Filter) | `KnowledgePortalDrawer.vue`, `useKnowledgePortal.ts` | **搜索与分类标签过滤**：验证侧边栏抽屉顶部集成搜索折叠切换按钮；验证基于分类标签的提取，动态生成标签选项胶囊并实现点击过滤；验证文本输入框多维模糊过滤及置顶排序逻辑。 | ✅ 已完成 | 2026-07-08 |
+| 知识库反向授权分配 (Resource Reverse Permissions) | `app/api/portal/endpoints/ragflow.py`, `KnowledgeBaseManagement.vue`, `test_ragflow_knowledge_platform.py` | **系统反向成员分配与移除**：验证在系统授权分配详情头部，拥有用户管理菜单访问权限的用户（或超级管理员）可点击“分配授权成员”按钮；验证打开授权 Modal，支持切换按角色或个人多选批量提交分配关系；验证在已授权 Tag 块旁显示移除叉号，二次确认后触发 DELETE 关系解绑及 Redis 缓存清除。 | ✅ 通过 | 2026-07-08 |
+| 知识库虚拟文件夹、卡片折叠与双栏置顶提问 (Virtual Folders, Collapse & Dual-Section Q&A) | `app/api/portal/endpoints/ragflow.py`, `KnowledgeBaseManagement.vue`, `KnowledgePortalDrawer.vue`, `useKnowledgePortal.ts`, `test_ragflow_knowledge_platform.py` | **目录分类、高级配置配色重构、卡片折叠与双栏置顶**：验证在侧栏树操作中提供“新建虚拟文件夹”；验证虚拟目录树状渲染与静默文件移动落库；验证编辑元数据时支持 1~3 个人工置顶问题；验证 `/portal` 接口以独立双栏格式返回置顶问题与 LLM 问题并在抽屉卡片上独立排版呈现；验证“自己创建”的知识库卡片自动浮现淡绿“自建”徽章；验证抽屉卡片支持点击头部一键折叠/展开；验证高级配置容器配色重构为素雅中性灰/绿调。 | ✅ 通过 | 2026-07-08 |
 
 
 

--- a/tests/CHECKLIST.md
+++ b/tests/CHECKLIST.md
@@ -207,6 +207,7 @@
 | 知识库卡片提问全对齐与 LLM API 修复 (Knowledge Card Question Align & LLM Bugfix) | `ragflow.py`, `KnowledgePortalDrawer.vue`, `useKnowledgePortal.ts` | **卡片提问对齐与大模型生成修复**：验证卡片排版、装饰背景、宽度截断与数据门户 1:1 对齐；验证提问区分为“左侧直接发送”与“右侧小铅笔 ✏️ 编辑后发送（仅 fill 入输入框）”；验证点击提问气泡或铅笔时若该知识库处于未启用状态，会自动触发 `toggle-active` 将其一键启用；验证并修复 `/portal` 接口中 `AgentScopeLLMHandle` 缺乏 `generate_text` 方法报错导致静默退避默认问题的 Bug。 | ✅ 已完成 | 2026-07-08 |
 | 单文件专属提问推荐与缓存策略 (Single Document Recommended Questions) | `ragflow.py`, `KnowledgePortalDrawer.vue`, `useKnowledgePortal.ts` | **单文档手风琴专属提问生成与懒加载**：验证在“相关文档”列表点击单文件展开/收起；验证懒加载发起大模型专属提问推断；验证 Redis 缓存（7天）读取命中；验证双功能按钮（直接发送/编辑提问）及联动自动激活绑定知识库。 | ✅ 已验证 | 2026-07-08 |
 | 知识库 AI 元数据分析 (AI Metadata Analysis) | `app/api/portal/endpoints/ragflow.py`, `KnowledgeBaseManagement.vue` | **AI 元数据分析生成与回填**：验证获取知识库写权限与文档列表；验证调用 LLM 基于前 100 个文件名分析生成中英文标签、描述与备注信息，并在前端编辑弹窗一键智能分析后自动回填。 | ✅ 已完成 | 2026-07-08 |
+| 知识库中心侧边抽屉搜索过滤 (Knowledge Portal Search & Filter) | `KnowledgePortalDrawer.vue`, `useKnowledgePortal.ts` | **搜索与分类标签过滤**：验证侧边栏抽屉顶部集成搜索折叠切换按钮；验证基于分类标签的提取，动态生成标签选项胶囊并实现点击过滤；验证文本输入框多维模糊过滤及置顶排序逻辑。 | ✅ 已完成 | 2026-07-08 |
 
 
 

--- a/tests/CHECKLIST.md
+++ b/tests/CHECKLIST.md
@@ -206,7 +206,7 @@
 | 知识库置顶与文件折叠展开 (Knowledge Pin & Document Collapse UX) | `portal_prefs.py`, `KnowledgePortalDrawer.vue`, `useKnowledgePortal.ts` | **置顶与折叠文档**：验证卡片右上角图钉一键置顶并利用 Redis 个人偏好接口（`/portal-prefs`）多端/跨会话同步；验证备注描述栏改为左侧带绿色实边框的浅色美学气泡；验证“相关文档”可折叠，展开时通过 `/datasets/{dataset_id}/documents` 异步加载真实原文件列表；验证 ChatInput 输入框 v-if/v-for 渲染修复及原档层级 z-index 遮挡修复。 | ✅ 已完成 | 2026-07-08 |
 | 知识库卡片提问全对齐与 LLM API 修复 (Knowledge Card Question Align & LLM Bugfix) | `ragflow.py`, `KnowledgePortalDrawer.vue`, `useKnowledgePortal.ts` | **卡片提问对齐与大模型生成修复**：验证卡片排版、装饰背景、宽度截断与数据门户 1:1 对齐；验证提问区分为“左侧直接发送”与“右侧小铅笔 ✏️ 编辑后发送（仅 fill 入输入框）”；验证点击提问气泡或铅笔时若该知识库处于未启用状态，会自动触发 `toggle-active` 将其一键启用；验证并修复 `/portal` 接口中 `AgentScopeLLMHandle` 缺乏 `generate_text` 方法报错导致静默退避默认问题的 Bug。 | ✅ 已完成 | 2026-07-08 |
 | 单文件专属提问推荐与缓存策略 (Single Document Recommended Questions) | `ragflow.py`, `KnowledgePortalDrawer.vue`, `useKnowledgePortal.ts` | **单文档手风琴专属提问生成与懒加载**：验证在“相关文档”列表点击单文件展开/收起；验证懒加载发起大模型专属提问推断；验证 Redis 缓存（7天）读取命中；验证双功能按钮（直接发送/编辑提问）及联动自动激活绑定知识库。 | ✅ 已验证 | 2026-07-08 |
-
+| 知识库 AI 元数据分析 (AI Metadata Analysis) | `app/api/portal/endpoints/ragflow.py`, `KnowledgeBaseManagement.vue` | **AI 元数据分析生成与回填**：验证获取知识库写权限与文档列表；验证调用 LLM 基于前 100 个文件名分析生成中英文标签、描述与备注信息，并在前端编辑弹窗一键智能分析后自动回填。 | ✅ 已完成 | 2026-07-08 |
 
 
 

--- a/tests/ai/test_knowledge_utils.py
+++ b/tests/ai/test_knowledge_utils.py
@@ -156,3 +156,73 @@ async def test_resolve_knowledge_dataset_ids_blocks_without_explicit_dataset():
                 require_explicit_dataset=False,
             )
         )
+
+
+@pytest.mark.asyncio
+async def test_filter_alive_knowledge_dataset_ids_drops_missing():
+    from unittest.mock import AsyncMock, patch
+
+    from app.services.ai.knowledge_utils import filter_alive_knowledge_dataset_ids
+
+    alive = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    missing = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    with patch(
+        "app.services.ai.knowledge_utils._load_ragflow_alive_dataset_ids",
+        new_callable=AsyncMock,
+        return_value={alive},
+    ):
+        filtered = await filter_alive_knowledge_dataset_ids([alive, missing, alive])
+    assert filtered == [alive]
+
+
+@pytest.mark.asyncio
+async def test_filter_alive_knowledge_dataset_ids_keeps_all_when_live_set_unknown():
+    """RAGFlow 列表不可用时不误伤：保留原 ID，避免检索整条链路被堵死。"""
+    from unittest.mock import AsyncMock, patch
+
+    from app.services.ai.knowledge_utils import filter_alive_knowledge_dataset_ids
+
+    ids = [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ]
+    with patch(
+        "app.services.ai.knowledge_utils._load_ragflow_alive_dataset_ids",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        filtered = await filter_alive_knowledge_dataset_ids(ids)
+    assert filtered == ids
+
+
+@pytest.mark.asyncio
+async def test_resolve_knowledge_dataset_ids_excludes_missing_from_ragflow():
+    from unittest.mock import AsyncMock, patch
+
+    alive = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    missing = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    set_agent_context(
+        AgentContext(
+            agent_id="kb",
+            agent_name="knowledge-base",
+            dataset_ids=[alive, missing],
+            require_explicit_dataset=False,
+        )
+    )
+    try:
+        with patch(
+            "app.services.ai.knowledge_utils.filter_alive_knowledge_dataset_ids",
+            new_callable=AsyncMock,
+            side_effect=lambda ids: [i for i in ids if i == alive],
+        ):
+            ids, err = await resolve_knowledge_dataset_ids(query="换电")
+        assert ids == [alive]
+        assert err is None
+    finally:
+        set_agent_context(
+            AgentContext(
+                agent_id="test-reset",
+                agent_name="test-reset",
+                require_explicit_dataset=False,
+            )
+        )

--- a/tests/ai/tools/test_knowledge_tool.py
+++ b/tests/ai/tools/test_knowledge_tool.py
@@ -1,7 +1,38 @@
 import pytest
 import json
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import AsyncMock, patch
 from app.services.ai.tools.knowledge_tool import search_knowledge_base, normalize_dataset_ids
+
+
+def _config_side_effect(key, default=None):
+    values = {
+        "knowledge_base_enabled": "true",
+        "knowledge_ragflow_similarity_threshold": None,
+        "knowledge_ragflow_vector_weight": None,
+        "knowledge_ragflow_metadata_top_k": None,
+    }
+    return values.get(key, default)
+
+
+def _patch_search(*, retrieve_return=None, retrieve_side_effect=None, config_side_effect=None):
+    """检索测试公共 mock：启用知识库 + 失联过滤透传。"""
+    mock_retrieve = AsyncMock(return_value=retrieve_return if retrieve_return is not None else [])
+    if retrieve_side_effect is not None:
+        mock_retrieve.side_effect = retrieve_side_effect
+    return (
+        patch("app.services.ai.ragflow_client.RagFlowClient.retrieve", new=mock_retrieve),
+        patch(
+            "app.services.config_service.ConfigService.get",
+            new_callable=AsyncMock,
+            side_effect=config_side_effect or _config_side_effect,
+        ),
+        patch(
+            "app.services.ai.knowledge_utils.filter_alive_knowledge_dataset_ids",
+            new_callable=AsyncMock,
+            side_effect=lambda ids: list(ids),
+        ),
+        mock_retrieve,
+    )
 
 
 def test_normalize_dataset_ids_plain_and_comma():
@@ -23,25 +54,21 @@ def test_normalize_dataset_ids_json_and_python_list_strings():
 async def test_search_knowledge_base_strips_json_array_argument():
     """LLM 传入 JSON 数组字符串时应解析为合法 ID"""
     rid = "4525d66cec7111f0a3d00242ac120006"
-    with patch("app.services.ai.ragflow_client.RagFlowClient.retrieve", new_callable=AsyncMock) as mock_retrieve, \
-         patch("app.services.config_service.ConfigService.get", new_callable=AsyncMock) as mock_config:
-        mock_retrieve.return_value = []
-        mock_config.return_value = None
-
+    p_retrieve, p_config, p_alive, mock_retrieve = _patch_search(retrieve_return=[])
+    with p_retrieve, p_config, p_alive:
         await search_knowledge_base.ainvoke({"query": "换电", "dataset_ids": f'["{rid}"]'})
 
         args, _ = mock_retrieve.call_args
         assert args[1] == [rid]
 
+
 @pytest.mark.asyncio
 async def test_search_knowledge_base_explicit_ids():
     """测试传递显式数据集 ID"""
-    with patch("app.services.ai.ragflow_client.RagFlowClient.retrieve", new_callable=AsyncMock) as mock_retrieve, \
-         patch("app.services.config_service.ConfigService.get", new_callable=AsyncMock) as mock_config:
-        
-        mock_retrieve.return_value = [{"doc_name": "test.pdf", "content": "text"}]
-        mock_config.return_value = None
-        
+    p_retrieve, p_config, p_alive, mock_retrieve = _patch_search(
+        retrieve_return=[{"doc_name": "test.pdf", "content": "text"}]
+    )
+    with p_retrieve, p_config, p_alive:
         rid_a = "11111111111111111111111111111111"
         rid_b = "22222222222222222222222222222222"
         result = await search_knowledge_base.ainvoke(
@@ -53,16 +80,14 @@ async def test_search_knowledge_base_explicit_ids():
         assert args[1] == [rid_a, rid_b]
         assert "test.pdf" in result
 
+
 @pytest.mark.asyncio
 async def test_search_knowledge_base_context_ids():
     """测试从 Agent 上下文获取数据集 ID"""
     from app.core.context import AgentContext, set_agent_context
 
-    with patch("app.services.ai.ragflow_client.RagFlowClient.retrieve", new_callable=AsyncMock) as mock_retrieve, \
-         patch("app.services.config_service.ConfigService.get", new_callable=AsyncMock) as mock_config:
-
-        mock_retrieve.return_value = []
-        mock_config.return_value = None
+    p_retrieve, p_config, p_alive, mock_retrieve = _patch_search(retrieve_return=[])
+    with p_retrieve, p_config, p_alive:
         set_agent_context(
             AgentContext(
                 agent_id="kb",
@@ -76,22 +101,29 @@ async def test_search_knowledge_base_context_ids():
         args, kwargs = mock_retrieve.call_args
         assert args[1] == ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
 
+
 @pytest.mark.asyncio
 async def test_search_knowledge_base_parameter_priority():
     """测试参数（阈值、权重、top_k）的优先级逻辑"""
     from app.core.context import AgentContext, set_agent_context
 
-    with patch("app.services.ai.ragflow_client.RagFlowClient.retrieve", new_callable=AsyncMock) as mock_retrieve, \
-         patch("app.services.config_service.ConfigService.get", new_callable=AsyncMock) as mock_config:
-
-        mock_retrieve.return_value = []
-
-        default_ds = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-        mock_config.side_effect = lambda k: {
+    def config_side_effect(k, default=None):
+        return {
+            "knowledge_base_enabled": "true",
             "ragflow_similarity_threshold": "0.5",
             "ragflow_vector_weight": "0.4",
             "ragflow_metadata_top_k": "5",
-        }.get(k)
+            "knowledge_ragflow_similarity_threshold": "0.5",
+            "knowledge_ragflow_vector_weight": "0.4",
+            "knowledge_ragflow_metadata_top_k": "5",
+        }.get(k, default)
+
+    p_retrieve, p_config, p_alive, mock_retrieve = _patch_search(
+        retrieve_return=[],
+        config_side_effect=config_side_effect,
+    )
+    with p_retrieve, p_config, p_alive:
+        default_ds = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         set_agent_context(
             AgentContext(
                 agent_id="kb",
@@ -117,11 +149,8 @@ async def test_search_knowledge_base_parameter_priority():
 @pytest.mark.asyncio
 async def test_search_knowledge_base_empty_result_is_structured_json():
     rid = "4525d66cec7111f0a3d00242ac120006"
-    with patch("app.services.ai.ragflow_client.RagFlowClient.retrieve", new_callable=AsyncMock) as mock_retrieve, \
-         patch("app.services.config_service.ConfigService.get", new_callable=AsyncMock) as mock_config:
-        mock_retrieve.return_value = []
-        mock_config.return_value = None
-
+    p_retrieve, p_config, p_alive, mock_retrieve = _patch_search(retrieve_return=[])
+    with p_retrieve, p_config, p_alive:
         result = await search_knowledge_base.ainvoke(
             {"query": "不存在的内容", "dataset_ids": rid}
         )
@@ -136,11 +165,10 @@ async def test_search_knowledge_base_empty_result_is_structured_json():
 async def test_search_knowledge_base_reports_service_unavailable_on_502():
     """RAGFlow 502 时应返回明确的「知识库服务不可用」提示，而非泛化 Tool Error。"""
     rid = "4525d66cec7111f0a3d00242ac120006"
-    with patch("app.services.ai.ragflow_client.RagFlowClient.retrieve", new_callable=AsyncMock) as mock_retrieve, \
-         patch("app.services.config_service.ConfigService.get", new_callable=AsyncMock) as mock_config:
-        mock_retrieve.side_effect = Exception("RAGFlow Retrieve failed: HTTP 502 Bad Gateway")
-        mock_config.return_value = None
-
+    p_retrieve, p_config, p_alive, mock_retrieve = _patch_search(
+        retrieve_side_effect=Exception("RAGFlow Retrieve failed: HTTP 502 Bad Gateway")
+    )
+    with p_retrieve, p_config, p_alive:
         result = await search_knowledge_base.ainvoke(
             {"query": "换电流程", "dataset_ids": rid}
         )
@@ -148,6 +176,25 @@ async def test_search_knowledge_base_reports_service_unavailable_on_502():
     assert "知识库服务不可用" in result
     assert "Failed to search knowledge base" not in result
     assert mock_retrieve.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_search_knowledge_base_drops_missing_dataset_ids_before_retrieve():
+    """失联知识库 ID 不应再发给 RAGFlow retrieve。"""
+    alive = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    missing = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    p_retrieve, p_config, _, mock_retrieve = _patch_search(retrieve_return=[])
+    with p_retrieve, p_config, patch(
+        "app.services.ai.knowledge_utils.filter_alive_knowledge_dataset_ids",
+        new_callable=AsyncMock,
+        side_effect=lambda ids: [i for i in ids if i == alive],
+    ):
+        await search_knowledge_base.ainvoke(
+            {"query": "换电", "dataset_ids": f"{alive},{missing}"}
+        )
+
+    args, _ = mock_retrieve.call_args
+    assert args[1] == [alive]
 
 
 @pytest.mark.asyncio

--- a/tests/api/portal/test_ragflow_knowledge_platform.py
+++ b/tests/api/portal/test_ragflow_knowledge_platform.py
@@ -390,3 +390,105 @@ async def test_record_knowledge_audit_masks_api_key(monkeypatch):
     assert captured["endpoint"] == "/api/portal/ragflow/retrieval-test"
     request_params = json.loads(captured["request_params"])
     assert request_params == {"dataset_ids": ["ds-1"]}
+
+
+@pytest.mark.asyncio
+async def test_add_dataset_permissions_success(monkeypatch):
+    calls = {}
+    
+    async def fake_require_write(user, db, ids):
+        calls["require_write_ids"] = ids
+        
+    class FakePermissionService:
+        def __init__(self, db):
+            pass
+        async def invalidate_cached_permissions_for_users(self, user_ids):
+            calls["invalidated_user_ids"] = user_ids
+
+    class FakeSession:
+        def __init__(self):
+            self.added = []
+            
+        def add(self, model):
+            self.added.append(model)
+            
+        async def execute(self, stmt):
+            class FakeResult:
+                def scalar_one_or_none(self):
+                    return None
+            return FakeResult()
+            
+        async def flush(self):
+            calls["flushed"] = True
+
+    monkeypatch.setattr(ragflow, "require_dataset_write_access", fake_require_write)
+    monkeypatch.setattr(ragflow, "PermissionService", FakePermissionService)
+
+    payload = ragflow.AddDatasetPermissionsRequest(target_type="user", target_ids=[123])
+    db_session = FakeSession()
+
+    res = await ragflow.add_dataset_permissions(
+        dataset_id="ds-1",
+        payload=payload,
+        db=db_session,
+        user={"user_id": 1, "role": "admin"}
+    )
+    
+    assert res["code"] == 0
+    assert calls["require_write_ids"] == ["ds-1"]
+    assert calls["flushed"] is True
+    assert calls["invalidated_user_ids"] == {123}
+    assert len(db_session.added) == 1
+    assert db_session.added[0].user_id == 123
+    assert db_session.added[0].resource_type == "dataset"
+    assert db_session.added[0].resource_id == "ds-1"
+
+
+@pytest.mark.asyncio
+async def test_delete_dataset_permission_success(monkeypatch):
+    calls = {}
+    
+    async def fake_require_write(user, db, ids):
+        calls["require_write_ids"] = ids
+        
+    class FakePermissionService:
+        def __init__(self, db):
+            pass
+        async def invalidate_cached_permissions_for_users(self, user_ids):
+            calls["invalidated_user_ids"] = user_ids
+
+    class FakeSession:
+        def __init__(self):
+            self.executed = []
+            
+        async def execute(self, stmt):
+            self.executed.append(stmt)
+            class FakeResult:
+                def scalars(self):
+                    class FakeScalars:
+                        def all(self):
+                            return []
+                    return FakeScalars()
+            return FakeResult()
+            
+        async def flush(self):
+            calls["flushed"] = True
+
+    monkeypatch.setattr(ragflow, "require_dataset_write_access", fake_require_write)
+    monkeypatch.setattr(ragflow, "PermissionService", FakePermissionService)
+
+    payload = ragflow.DeleteDatasetPermissionRequest(target_type="user", target_id=123)
+    db_session = FakeSession()
+
+    res = await ragflow.delete_dataset_permission(
+        dataset_id="ds-1",
+        payload=payload,
+        db=db_session,
+        user={"user_id": 1, "role": "admin"}
+    )
+    
+    assert res["code"] == 0
+    assert calls["require_write_ids"] == ["ds-1"]
+    assert calls["flushed"] is True
+    assert calls["invalidated_user_ids"] == {123}
+    assert len(db_session.executed) == 1

--- a/tests/api/portal/test_ragflow_knowledge_platform.py
+++ b/tests/api/portal/test_ragflow_knowledge_platform.py
@@ -492,3 +492,122 @@ async def test_delete_dataset_permission_success(monkeypatch):
     assert calls["flushed"] is True
     assert calls["invalidated_user_ids"] == {123}
     assert len(db_session.executed) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_dataset_portal_recommendations_with_custom_questions(monkeypatch):
+    class FakeSession:
+        async def execute(self, stmt):
+            class FakeResult:
+                def scalar_one_or_none(self):
+                    return SimpleNamespace(
+                        extra_config={
+                            "custom_questions": [
+                                {"label": "问题1", "query": "完整提问1"},
+                                {"label": "问题2", "query": "完整提问2"},
+                                {"label": "问题3", "query": "完整提问3"}
+                            ]
+                        }
+                    )
+            return FakeResult()
+
+    async def fake_require_access(user, db, ids):
+        pass
+
+    class FakeRagFlowClient:
+        def __init__(self, *args, **kwargs):
+            pass
+        async def list_documents(self, dataset_id, page_size):
+            return [{"id": "doc-1", "name": "测试文档.pdf"}]
+
+    class FakeLLMClient:
+        async def generate_text(self, messages):
+            return '["生成提问1", "生成提问2", "生成提问3"]'
+
+    async def fake_get_llm(streaming, temperature):
+        class FakeLLM:
+            pass
+        return FakeLLM()
+
+    def fake_chat_client(llm):
+        return FakeLLMClient()
+
+    monkeypatch.setattr(ragflow, "require_dataset_access", fake_require_access)
+    monkeypatch.setattr(ragflow, "RagFlowClient", FakeRagFlowClient)
+    monkeypatch.setattr("app.core.llm.client.get_llm_async", fake_get_llm)
+    monkeypatch.setattr("app.services.ai.runtime.agentscope.chat.chat_client_from_handle", fake_chat_client)
+
+    res = await ragflow.get_dataset_portal_recommendations(
+        dataset_id="ds-1",
+        user={"user_id": 1, "role": "user"},
+        db=FakeSession()
+    )
+
+    assert res["code"] == 0
+    data = res["data"]
+    custom_qs = data["custom_questions"]
+    qs = data["questions"]
+    assert len(custom_qs) == 3
+    assert custom_qs[0]["label"] == "问题1"
+    assert custom_qs[0]["query"] == "完整提问1"
+    assert len(qs) == 3
+    assert qs[0]["label"] == "生成提问1"
+
+
+@pytest.mark.asyncio
+async def test_get_dataset_portal_recommendations_hybrid(monkeypatch):
+    class FakeSession:
+        async def execute(self, stmt):
+            class FakeResult:
+                def scalar_one_or_none(self):
+                    return SimpleNamespace(
+                        extra_config={
+                            "custom_questions": [
+                                {"label": "固定问题", "query": "固定提问内容"}
+                            ]
+                        }
+                    )
+            return FakeResult()
+
+    async def fake_require_access(user, db, ids):
+        pass
+
+    class FakeRagFlowClient:
+        def __init__(self, *args, **kwargs):
+            pass
+        async def list_documents(self, dataset_id, page_size):
+            return [{"id": "doc-1", "name": "测试文档.pdf"}]
+
+    class FakeLLMClient:
+        async def generate_text(self, messages):
+            return '["生成提问1", "生成提问2", "生成提问3"]'
+
+    async def fake_get_llm(streaming, temperature):
+        class FakeLLM:
+            pass
+        return FakeLLM()
+
+    def fake_chat_client(llm):
+        return FakeLLMClient()
+
+    monkeypatch.setattr(ragflow, "require_dataset_access", fake_require_access)
+    monkeypatch.setattr(ragflow, "RagFlowClient", FakeRagFlowClient)
+    monkeypatch.setattr("app.core.llm.client.get_llm_async", fake_get_llm)
+    monkeypatch.setattr("app.services.ai.runtime.agentscope.chat.chat_client_from_handle", fake_chat_client)
+
+    res = await ragflow.get_dataset_portal_recommendations(
+        dataset_id="ds-1",
+        user={"user_id": 1, "role": "user"},
+        db=FakeSession()
+    )
+
+    assert res["code"] == 0
+    data = res["data"]
+    custom_qs = data["custom_questions"]
+    qs = data["questions"]
+    assert len(custom_qs) == 1
+    assert custom_qs[0]["label"] == "固定问题"
+    assert custom_qs[0]["query"] == "固定提问内容"
+    assert len(qs) == 3
+    assert qs[0]["label"] == "生成提问1"
+    assert qs[0]["query"] == "生成提问1"


### PR DESCRIPTION

## 概要 (Overview)
本次 PR 主要围绕**“知识库门户中心”**与**“知识库管理控制台”**进行了深度的高阶功能增强与视觉体验重构。

引入的主要变更包括：
1. **文档虚拟目录结构**：支持虚拟文件夹的创建、重命名、删除及跨文件夹的静默移动落库，方便多文档管理。
2. **快捷置顶推荐双栏呈现**：支持最多 3 个人工置顶的高频业务问题，后端与大模型联合计算进行差额补全，前端在门户卡片上以“置顶快捷”和“智能推荐”双栏形式共存展示。
3. **反向授权分配机制**：提供管理员直接为特定知识库分发角色及用户访问权限的反向交互，并同步刷新 Redis 全网权限缓存。
4. **AI 智能元数据分析**：大模型根据文件名智能生成中英文标签、精炼描述与备注，并在前端编辑弹窗内一键回填。
5. **智能筛选与自建标识**：新增侧栏抽屉的模糊搜索与动态去重标签分类过滤；对当前用户创建的卡片标记“自建”徽章；支持卡片的独立折叠收起。
6. **容灾架构加固**：自动探测与过滤在 RAGFlow 中已被物理删除的“失联”知识库，并在授权页面及问答检索前进行前置熔断过滤。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)
- [x] **文档虚拟文件夹管理**：在侧栏树集成“文件夹” Inline 操作，文档节点分层，支持静默“移动到”归类，数据持久化于本地 metadata 扩展 JSON 配置中。
- [x] **门户置顶 Q&A 双栏渲染**：元数据编辑 Modal 增加 1~3 个快捷提问配置；`/portal` 接口改为双栏并存返回，前端琥珀色置顶区与绿色智能推荐区独立排版展示。
- [x] **反向权限分配**：控制台详情增加“分配授权成员”按钮，接入管理员鉴权门禁，支持多选角色与用户批量分配关系，解绑时物理清理权限表并失效用户缓存。
- [x] **AI 元数据智能分析**：在编辑描述旁集成 AI 分析按钮，异步获取知识库文件列表后，大模型智能输出标签描述并实现表单无感回填。
- [x] **门户抽屉搜索过滤**：侧边抽屉顶部集成搜索折叠栏，动态提取去重的标签胶囊，支持文本模糊与标签筛选联动。

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)
- [x] **卡片独立折叠/展开 (Accordion UX)**：卡片 Header 行左侧新增旋转小 Chevron 箭头，且标题与 `📚` 图标均被赋予点击折叠/展开事件，解决知识库繁多时滑动拥挤的问题。
- [x] **“自建”知识库专属徽章**：匹配当前登录用户信息，自建的卡片自动打上淡绿色的“自建”微型徽章。
- [x] **“高级配置”视觉微调**：将原先突兀的蓝色系折叠面板重构为符合主色调的素雅中性灰/绿配色方案，Hover 时点亮绿色，更具 Premium 质感。
- [x] **别名快照同步**：打通控制台编辑元数据与门户抽屉的数据流，修改快照名和描述后，抽屉详情实时同步刷新。
- [x] **引用块与黄色便签纸美学**：卡片及详情中描述文案改为左绿色边框引用块（Quote Block），备注改为舒适的黄色便签板样式。

### 3. 🐞 关键修复 (Bug Fixes)
- [x] **失联库熔断防崩机制**：在本地数据库与 RAGFlow 同步失联（远程已物理删除）时，权限勾选页自动标记 `(已失效/失联)` 并置灰禁用；AI 检索前自动过滤此类库 ID，防止主运行流遭遇 404 / 500 级崩溃。
- [x] **大模型 API 兼容修复**：修复 `/portal` 接口中 `AgentScopeLLMHandle` 缺失 `generate_text` 方法的报错问题。

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `c75fa3e` | feat: 知识库新增文档虚拟文件夹分类、卡片独立折叠、自建徽章标记、高级配置配色优化及双栏置顶提问推荐 |
| `4427a48` | feat: 知识库管理支持反向角色和用户授权分配，限权用户管理权限访问，并补全单元测试 |
| `a825bdd` | feat: 知识库门户抽屉新增搜索开关及按分类标签过滤功能，并更新测试清单 |
| `12e23c4` | feat: 知识库管理编辑元数据支持 AI 智能分析与自动回填，优化界面 UI 及同步体验，加固 404 容错 |
| `581c158` | docs(知识库): 补充知识库中心与聊天端到端架构设计文档 |
| `c19961d` | fix(知识库): 权限页标记失联库并禁止供选，检索前剔除失联 dataset_id |

---

## 测试覆盖 (Testing)
- [x] **UI 兼容性**: 已验证 Chrome, Safari 的桌面及侧栏抽屉自适应分辨率排版效果。
- [x] **核心功能**: 所有新加的 RAGFlow API、反向分配接口、智能混合问答接口均已通过本地 Pytest 单元测试（16 Passed 100% 成功）。
- [x] **回归测试**: 新增测试用例覆盖全部边界（包含大模型 Mock 输出、空文档/无自定义配置时的退避机制），未引入任何回归错误。

> [!IMPORTANT]
> 提交前已完成登记与更新 [tests/CHECKLIST.md](file:///Users/chenxiaolong/workspace/yovole-yunshu-ai-agent-platform/tests/CHECKLIST.md) 中对应的自动化测试清单。

---

## 其他备注 (Notes)
* 本次升级无破坏性数据库物理 Schema 变更，所有的扩展数据（虚拟文件夹、人工置顶提问）均通过 JSON 格式兼容于已有表结构的 `extra_config` 中，方便在本地开发环境与生产环境无感迭代部署。
