### PR TITLE
Pull Request: 智能导入绑定数据源、画像式展示与弹窗布局优化

### DIFF
--- a/frontend/src/components/metadata/DatabaseImportModal.vue
+++ b/frontend/src/components/metadata/DatabaseImportModal.vue
@@ -8,8 +8,11 @@ const props = withDefaults(defineProps<{
   show: boolean
   /** 当前数据集内已存在的物理表名，用于禁用重复导入 */
   importedTableNames?: string[]
+  /** 追加导入时锁定为数据集已绑定的数据源 name，跳过选数据源步骤 */
+  lockedDataSourceName?: string
 }>(), {
   importedTableNames: () => [],
+  lockedDataSourceName: '',
 })
 
 const emit = defineEmits(['close', 'confirm', 'confirm-profile'])
@@ -23,6 +26,20 @@ const loading = ref(false)
 const testing = ref(false)
 const testPassed = ref(false)
 const connError = ref('')
+const initializingLocked = ref(false)
+
+const isDataSourceLocked = computed(() => !!props.lockedDataSourceName?.trim())
+
+const selectedConfigName = computed(() => {
+  if (!selectedConfigId.value) return ''
+  return savedConfigs.value.find((c) => c.id === selectedConfigId.value)?.name || ''
+})
+
+const lockedConfig = computed(() => {
+  const lockedName = props.lockedDataSourceName?.trim()
+  if (!lockedName) return null
+  return savedConfigs.value.find((c) => c.name === lockedName) || null
+})
 
 // ─── 当前导入连接（由已保存数据源填充） ─────────────────────────────────────────────
 const config = ref({
@@ -44,8 +61,10 @@ onMounted(async () => {
 })
 
 watch(() => props.show, async (show) => {
-  if (show) {
-    await fetchSavedConfigs()
+  if (!show) return
+  await fetchSavedConfigs()
+  if (isDataSourceLocked.value) {
+    await enterLockedDataSourceFlow()
   }
 })
 
@@ -54,7 +73,7 @@ const fetchSavedConfigs = async () => {
   try {
     const res = await metadataApi.listDbConnectionConfigs()
     savedConfigs.value = res.data.data || []
-    if (!selectedConfigId.value && savedConfigs.value.length > 0) {
+    if (!isDataSourceLocked.value && !selectedConfigId.value && savedConfigs.value.length > 0) {
       applyDataSource(savedConfigs.value[0]!)
     }
   } catch {
@@ -89,6 +108,33 @@ const applyDataSource = (c: DbConnectionConfig) => {
   connError.value = ''
 }
 
+const enterLockedDataSourceFlow = async () => {
+  const lockedName = props.lockedDataSourceName?.trim()
+  if (!lockedName) return
+
+  initializingLocked.value = true
+  connError.value = ''
+  step.value = 1
+
+  const matched = savedConfigs.value.find((c) => c.name === lockedName)
+  if (!matched) {
+    connError.value = `数据集绑定的数据源「${lockedName}」在数据源管理中不存在，请先创建同名配置或修改数据集的数据源 ID`
+    initializingLocked.value = false
+    return
+  }
+
+  applyDataSource(matched)
+  testPassed.value = true
+  try {
+    await handleNext()
+  } catch (e: any) {
+    connError.value = e.response?.data?.detail || e.message || '加载表列表失败'
+    showToast('加载表列表失败', 'error')
+  } finally {
+    initializingLocked.value = false
+  }
+}
+
 // ─── 测试连接 ─────────────────────────────────────────────────────────────────
 const handleTestConnection = async () => {
   testing.value = true
@@ -120,6 +166,39 @@ const searchQuery = ref('')
 const importFilter = ref<'all' | 'unimported'>('unimported')
 const selectedTables = ref<string[]>([])
 let profileSearchDebounce: ReturnType<typeof setTimeout> | null = null
+
+const expandedProfileTables = ref<Record<string, boolean>>({})
+const profileDetailsCache = ref<Record<string, any>>({})
+const loadingProfileDetails = ref<Record<string, boolean>>({})
+
+const toggleProfileExpand = async (tableName: string) => {
+  const next = !expandedProfileTables.value[tableName]
+  expandedProfileTables.value[tableName] = next
+  if (!next || profileDetailsCache.value[tableName] || !selectedConfigId.value) return
+
+  loadingProfileDetails.value[tableName] = true
+  try {
+    const res = await metadataApi.getDbTableProfileDetail(selectedConfigId.value, tableName)
+    profileDetailsCache.value[tableName] = res.data
+  } catch {
+    showToast('加载字段详情失败', 'error')
+    expandedProfileTables.value[tableName] = false
+  } finally {
+    loadingProfileDetails.value[tableName] = false
+  }
+}
+
+const getProfileColumns = (profile: any) => {
+  const detail = profileDetailsCache.value[profile.table_name]
+  if (detail?.columns_profile) return detail.columns_profile
+  return []
+}
+
+const getProfileColumnChips = (profile: any) => {
+  const cols = getProfileColumns(profile)
+  if (cols.length) return cols
+  return []
+}
 
 const profileSortParams = computed(() => {
   if (profilesSort.value === 'confidence_desc') {
@@ -186,6 +265,13 @@ const toggleProfileTag = async (tag: string) => {
       isTagsExpanded.value = true
     }
   }
+  profilesPage.value = 1
+  await loadTableProfiles()
+}
+
+const clearProfileTag = async () => {
+  if (!selectedProfileTag.value) return
+  selectedProfileTag.value = null
   profilesPage.value = 1
   await loadTableProfiles()
 }
@@ -350,14 +436,20 @@ const handleConfirm = async () => {
         selectedConfigId.value,
         selectedTables.value
       )
-      emit('confirm-profile', res.data.data)
+      emit('confirm-profile', {
+        preview: res.data.data,
+        dataSourceName: selectedConfigName.value,
+      })
       showToast('已复用摸排画像，将跳过重复 AI 分析', 'success')
       handleClose()
       return
     }
 
     const res = await metadataApi.getDbDdl(config.value, selectedTables.value)
-    emit('confirm', res.data.data)
+    emit('confirm', {
+      ddl: res.data.data,
+      dataSourceName: selectedConfigName.value,
+    })
     handleClose()
   } catch (e: any) {
     showToast(e.response?.data?.detail || (activeTab.value === 'profile' ? '复用摸排画像失败' : '抓取 DDL 失败'), 'error')
@@ -397,6 +489,10 @@ const handleClose = () => {
   importFilter.value = 'unimported'
   testPassed.value = false
   connError.value = ''
+  initializingLocked.value = false
+  expandedProfileTables.value = {}
+  profileDetailsCache.value = {}
+  loadingProfileDetails.value = {}
   emit('close')
 }
 
@@ -439,7 +535,7 @@ const dbTypeColor = (type: string) => {
       <div class="flex-1 overflow-y-auto p-6">
 
         <!-- Step 1: Data Source -->
-        <div v-if="step === 1" class="space-y-4">
+        <div v-if="step === 1 && !isDataSourceLocked" class="space-y-4">
 
           <div v-if="loadingConfigs" class="py-12 text-center text-sm text-gray-400">
             加载数据源中...
@@ -526,8 +622,45 @@ const dbTypeColor = (type: string) => {
           </div>
         </div>
 
+        <!-- 追加导入：锁定数据源加载中或配置缺失 -->
+        <div v-else-if="step === 1 && isDataSourceLocked" class="space-y-4">
+          <div v-if="initializingLocked" class="py-12 text-center text-sm text-gray-500">
+            <svg class="animate-spin h-8 w-8 mx-auto mb-3 text-primary" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
+            正在加载数据集数据源「{{ lockedDataSourceName }}」的表列表...
+          </div>
+          <div v-else-if="connError" class="py-8 px-6 text-center border border-red-100 rounded-2xl bg-red-50/60">
+            <p class="text-sm text-red-600 leading-relaxed">{{ connError }}</p>
+          </div>
+        </div>
+
         <!-- Step 2: Select Tables -->
         <div v-else class="h-full flex flex-col gap-4">
+          <div
+            v-if="isDataSourceLocked"
+            class="flex items-start gap-3 p-3.5 rounded-xl bg-blue-50 border border-blue-100 shrink-0"
+          >
+            <div class="w-9 h-9 rounded-lg bg-white border border-blue-100 flex items-center justify-center text-lg shrink-0">
+              {{ dbTypeIcon(lockedConfig?.db_type || config.type) }}
+            </div>
+            <div class="min-w-0 flex-1">
+              <div class="text-[10px] font-bold text-blue-800 uppercase tracking-wider">当前数据集数据源（已锁定）</div>
+              <div class="flex items-center gap-2 mt-1 flex-wrap">
+                <span class="text-sm font-bold text-blue-900 font-mono">{{ lockedDataSourceName }}</span>
+                <span
+                  v-if="lockedConfig?.db_type"
+                  class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase"
+                  :class="dbTypeColor(lockedConfig.db_type)"
+                >
+                  {{ lockedConfig.db_type }}
+                </span>
+              </div>
+              <p v-if="lockedConfig" class="text-[11px] text-blue-600/80 font-mono mt-1 truncate">
+                {{ lockedConfig.host }}:{{ lockedConfig.port }} / {{ lockedConfig.database_name }}
+              </p>
+              <p class="text-[11px] text-blue-600/70 mt-1">追加导入仅允许从该数据源选表，不可切换其他数据源。</p>
+            </div>
+          </div>
+
           <!-- 双 Tab 切换 -->
           <div class="flex border-b border-gray-100 shrink-0 text-sm">
             <button
@@ -615,11 +748,11 @@ const dbTypeColor = (type: string) => {
           <div v-if="activeTab === 'profile' && availableTags.length > 0" class="flex flex-wrap items-center gap-1.5 px-1 shrink-0">
             <span class="text-xs font-bold text-gray-400 mr-1.5 select-none">快速过滤:</span>
             <button
-              @click="selectedProfileTag = null"
+              @click="clearProfileTag"
               :class="['px-2.5 py-1 rounded-full text-xs font-medium border transition-all cursor-pointer flex items-center gap-1', !selectedProfileTag ? 'bg-primary text-white border-primary shadow-sm shadow-primary/20' : 'bg-gray-100 border-gray-200/50 hover:bg-gray-200/50 text-gray-600']"
             >
               <span>全部</span>
-                <span :class="['text-[9px] px-1 py-0.2 rounded-full font-bold', !selectedProfileTag ? 'bg-white/20 text-white' : 'bg-gray-200 text-gray-500']">{{ profilesTotal }}</span>
+                <span :class="['text-[9px] px-1 py-0.2 rounded-full font-bold', !selectedProfileTag ? 'bg-white/20 text-white' : 'bg-gray-200 text-gray-500']">{{ profileSuccessTotal }}</span>
             </button>
             <button
               v-for="tag in (isTagsExpanded ? availableTags : availableTags.slice(0, 8))"
@@ -639,7 +772,10 @@ const dbTypeColor = (type: string) => {
             </button>
           </div>
 
-          <div class="flex-1 overflow-y-auto border border-gray-100 rounded-xl divide-y divide-gray-50">
+          <div
+            class="flex-1 overflow-y-auto border border-gray-100 rounded-xl"
+            :class="activeTab === 'profile' ? 'p-3 bg-gray-50/40' : 'divide-y divide-gray-50'"
+          >
              <!-- Tab 1: 系统表直连 -->
              <template v-if="activeTab === 'system'">
                <div
@@ -695,102 +831,175 @@ const dbTypeColor = (type: string) => {
                  <p class="text-xs">请先前往数据源管理对该配置执行“智能摸排”，</p>
                  <p class="text-xs">分析完成后即可在此 Tab 快速浏览有中文业务释义的表资产。</p>
                </div>
-               <div
-                 v-else
-                 v-for="profile in filteredTableProfiles"
-                 :key="profile.table_name"
-                 @click="toggleTable(profile.table_name)"
-                 class="p-4 flex items-start gap-4 transition-colors"
-                 :class="isTableImported(profile.table_name)
-                   ? 'bg-gray-50/80 cursor-not-allowed opacity-70'
-                   : 'hover:bg-blue-50/30 cursor-pointer'"
-               >
-                  <div class="w-5 h-5 rounded border-2 flex items-center justify-center transition-all shrink-0 mt-0.5"
+               <div v-else class="space-y-3">
+                 <div
+                   v-for="profile in filteredTableProfiles"
+                   :key="profile.table_name"
+                   class="border border-gray-200/80 rounded-xl overflow-hidden shadow-sm transition-all"
+                   :class="[
+                     isTableImported(profile.table_name) ? 'opacity-70 bg-gray-50/60' : 'bg-white hover:border-gray-300',
+                     selectedTables.includes(profile.table_name) && !isTableImported(profile.table_name) ? 'ring-2 ring-primary/20 border-primary/30' : ''
+                   ]"
+                 >
+                   <div class="p-4 bg-gray-50/30 flex items-start gap-3">
+                     <div
+                       class="w-5 h-5 rounded border-2 flex items-center justify-center transition-all shrink-0 mt-1"
                        :class="isTableImported(profile.table_name)
-                         ? 'border-gray-200 bg-gray-100'
+                         ? 'border-gray-200 bg-gray-100 cursor-not-allowed'
                          : selectedTables.includes(profile.table_name)
-                           ? 'bg-primary border-primary'
-                           : 'border-gray-200 bg-white'">
-                     <svg v-if="!isTableImported(profile.table_name) && selectedTables.includes(profile.table_name)" class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
-                     <svg v-else-if="isTableImported(profile.table_name)" class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
-                  </div>
-                  <div class="flex flex-col gap-1 min-w-0 flex-1">
-                    <div class="flex items-center gap-2 flex-wrap">
-                      <span class="text-sm font-mono truncate font-bold" :class="isTableImported(profile.table_name) ? 'text-gray-400' : 'text-gray-700'">{{ profile.table_name }}</span>
-                      <span
-                        v-if="isTableImported(profile.table_name)"
-                        class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wider bg-gray-100 text-gray-500 border border-gray-200"
-                      >
-                        已导入
-                      </span>
-                      <span
-                        v-else-if="profile.table_type"
-                        class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wider"
-                        :class="profile.table_type === 'view' ? 'bg-amber-100 text-amber-700 border border-amber-200' : 'bg-blue-100 text-blue-700 border border-blue-200'"
-                      >
-                        {{ profile.table_type === 'view' ? '视图' : '表' }}
-                      </span>
-                      <span v-if="profile.status === 3" class="px-1.5 py-0.5 rounded text-[9px] bg-red-50 text-red-500 border border-red-100 font-bold" :title="profile.error_message">分析失败</span>
-                    </div>
-                    <div v-if="profile.ai_term" class="text-xs text-primary font-bold">
-                      💡 备注名：{{ profile.ai_term }}
-                    </div>
-                    <div
-                      v-if="profile.confidence_score != null"
-                      class="flex items-center gap-2 text-[11px] flex-wrap"
-                    >
-                      <div class="flex items-center gap-1 font-bold shrink-0">
-                        <span class="text-gray-400">业务可信度:</span>
-                        <span
-                          class="px-1 py-0.5 rounded text-[9px] font-black"
-                          :class="profile.confidence_score >= 80
-                            ? 'bg-emerald-50 text-emerald-700 border border-emerald-200/50'
-                            : profile.confidence_score >= 60
-                              ? 'bg-amber-50 text-amber-700 border border-amber-200/50'
-                              : 'bg-red-50 text-red-700 border border-red-200/50'"
-                        >
-                          {{ profile.confidence_score }} 分
-                        </span>
-                        <span
-                          v-if="profile.is_temporary === 1"
-                          class="px-1.5 py-0.5 rounded text-[9px] bg-amber-100 text-amber-800 font-bold border border-amber-200/40"
-                        >
-                          低价值临时表
-                        </span>
-                        <span
-                          v-if="profile.is_ignored === 1"
-                          class="px-1.5 py-0.5 rounded text-[9px] bg-orange-50 text-orange-700 font-bold border border-orange-200/60"
-                        >
-                          摸排建议忽略
-                        </span>
-                      </div>
-                      <span
-                        v-if="profile.confidence_reason"
-                        class="text-gray-400 line-clamp-1"
-                        :title="profile.confidence_reason"
-                      >
-                        原因: {{ profile.confidence_reason }}
-                      </span>
-                    </div>
-                    <p v-if="profile.ai_description" class="text-[11px] text-gray-500 leading-normal line-clamp-2">
-                      用途：{{ profile.ai_description }}
-                    </p>
-                    <div v-if="profile.ai_tags && profile.ai_tags.length > 0" class="flex flex-wrap gap-1 mt-1">
-                      <span 
-                        v-for="tag in profile.ai_tags" 
-                        :key="tag"
-                        @click.stop="toggleProfileTag(tag)"
-                        :class="['px-1.5 py-0.5 rounded text-[9px] font-medium transition-colors cursor-pointer', selectedProfileTag === tag ? 'bg-primary text-white' : 'bg-gray-100 text-gray-500 hover:bg-gray-200']"
-                      >
-                        {{ tag }}
-                      </span>
-                    </div>
-                  </div>
+                           ? 'bg-primary border-primary cursor-pointer'
+                           : 'border-gray-200 bg-white cursor-pointer hover:border-primary/40'"
+                       @click.stop="toggleTable(profile.table_name)"
+                     >
+                       <svg v-if="!isTableImported(profile.table_name) && selectedTables.includes(profile.table_name)" class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
+                       <svg v-else-if="isTableImported(profile.table_name)" class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
+                     </div>
+
+                     <div
+                       class="min-w-0 flex-1 space-y-1.5"
+                       :class="profile.status === 2 ? 'cursor-pointer' : 'cursor-default'"
+                       @click="profile.status === 2 && toggleProfileExpand(profile.table_name)"
+                     >
+                       <div class="flex items-center gap-2 flex-wrap">
+                         <span class="font-mono text-sm font-bold text-gray-900">{{ profile.table_name }}</span>
+                         <span
+                           v-if="isTableImported(profile.table_name)"
+                           class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wider bg-gray-100 text-gray-500 border border-gray-200"
+                         >
+                           已导入
+                         </span>
+                         <span
+                           v-else-if="profile.table_type"
+                           class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wider"
+                           :class="profile.table_type === 'view' ? 'bg-amber-100 text-amber-700 border border-amber-200' : 'bg-blue-100 text-blue-700 border border-blue-200'"
+                         >
+                           {{ profile.table_type === 'view' ? '视图' : '表' }}
+                         </span>
+                         <span v-if="profile.is_ignored === 1" class="px-1.5 py-0.5 rounded text-[9px] bg-orange-50 text-orange-700 font-bold border border-orange-200/60">
+                           摸排建议忽略
+                         </span>
+                       </div>
+
+                       <div v-if="profile.ai_term" class="text-xs text-primary font-bold">
+                         💡 业务备注：{{ profile.ai_term }}
+                       </div>
+
+                       <div v-if="profile.confidence_score != null" class="flex items-center gap-2 text-[11px] flex-wrap">
+                         <div class="flex items-center gap-1 font-bold shrink-0">
+                           <span class="text-gray-400">业务可信度:</span>
+                           <span
+                             class="px-1 py-0.5 rounded text-[9px] font-black"
+                             :class="profile.confidence_score >= 80
+                               ? 'bg-emerald-50 text-emerald-700 border border-emerald-200/50'
+                               : profile.confidence_score >= 60
+                                 ? 'bg-amber-50 text-amber-700 border border-amber-200/50'
+                                 : 'bg-red-50 text-red-700 border border-red-200/50'"
+                           >
+                             {{ profile.confidence_score }} 分
+                           </span>
+                           <span
+                             v-if="profile.is_temporary === 1"
+                             class="px-1.5 py-0.5 rounded text-[9px] bg-amber-100 text-amber-800 font-bold border border-amber-200/40"
+                           >
+                             低价值临时表
+                           </span>
+                         </div>
+                         <span
+                           v-if="profile.confidence_reason"
+                           class="text-gray-400 line-clamp-1"
+                           :title="profile.confidence_reason"
+                         >
+                           原因: {{ profile.confidence_reason }}
+                         </span>
+                       </div>
+
+                       <p v-if="profile.ai_description" class="text-xs text-gray-500 leading-relaxed">
+                         用途：{{ profile.ai_description }}
+                       </p>
+
+                       <div v-if="profile.ai_tags && profile.ai_tags.length > 0" class="flex flex-wrap gap-1">
+                         <span
+                           v-for="tag in profile.ai_tags"
+                           :key="tag"
+                           @click.stop="toggleProfileTag(tag)"
+                           :class="['px-1.5 py-0.5 rounded text-[9px] font-medium transition-colors cursor-pointer', selectedProfileTag === tag ? 'bg-primary text-white' : 'bg-gray-100 text-gray-500 hover:bg-gray-200']"
+                         >
+                           {{ tag }}
+                         </span>
+                       </div>
+
+                       <div v-if="getProfileColumnChips(profile).length > 0" class="flex flex-wrap gap-1.5 pt-1">
+                         <div
+                           v-for="col in getProfileColumnChips(profile).slice(0, 8)"
+                           :key="col.name"
+                           class="flex items-center gap-1 px-2 py-0.5 bg-slate-50 border border-slate-100 rounded-md text-[10px] font-mono"
+                         >
+                           <span class="text-slate-600 font-bold">{{ col.name }}</span>
+                           <span class="text-slate-300">/</span>
+                           <span class="text-blue-500">{{ col.term || '?' }}</span>
+                         </div>
+                         <div
+                           v-if="(profile.columns_count || getProfileColumnChips(profile).length) > 8"
+                           class="px-2 py-0.5 bg-gray-50 border border-gray-100 rounded-md text-[10px] text-gray-400 font-medium"
+                         >
+                           +{{ Math.max((profile.columns_count || getProfileColumnChips(profile).length) - 8, 0) }} 更多字段
+                         </div>
+                       </div>
+                       <p v-else-if="profile.columns_count" class="text-[10px] text-gray-400 pt-1">
+                         共 {{ profile.columns_count }} 个字段 · 点击右侧展开查看字段画像
+                       </p>
+                     </div>
+
+                     <button
+                       v-if="profile.status === 2"
+                       type="button"
+                       class="text-gray-400 ml-1 shrink-0 transition-transform duration-200 p-1 hover:text-gray-600"
+                       :class="expandedProfileTables[profile.table_name] ? 'rotate-90' : ''"
+                       @click.stop="toggleProfileExpand(profile.table_name)"
+                     >
+                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/>
+                       </svg>
+                     </button>
+                   </div>
+
+                   <div v-if="expandedProfileTables[profile.table_name]" class="border-t border-gray-100 p-4 bg-white space-y-2">
+                     <div class="text-xs font-bold text-gray-400 uppercase tracking-wider">
+                       字段画像定义 (Columns Profile)
+                       <span v-if="profile.columns_count" class="text-gray-300 font-normal ml-1">· {{ profile.columns_count }} 个字段</span>
+                     </div>
+
+                     <div v-if="loadingProfileDetails[profile.table_name]" class="text-xs text-gray-400 italic py-4 text-center">
+                       正在加载字段详情...
+                     </div>
+                     <div v-else-if="getProfileColumns(profile).length === 0" class="text-xs text-gray-400 italic">
+                       暂无字段分析信息
+                     </div>
+                     <div v-else class="border border-gray-100 rounded-xl overflow-hidden">
+                       <table class="w-full text-left border-collapse text-xs">
+                         <thead>
+                           <tr class="bg-gray-50 border-b border-gray-100 text-gray-400 font-bold uppercase">
+                             <th class="px-4 py-2 border-r border-gray-100 w-1/4">物理字段</th>
+                             <th class="px-4 py-2 border-r border-gray-100 w-1/4">业务术语/中文名</th>
+                             <th class="px-4 py-2">业务含义说明</th>
+                           </tr>
+                         </thead>
+                         <tbody class="divide-y divide-gray-100 text-gray-700">
+                           <tr v-for="col in getProfileColumns(profile)" :key="col.name" class="hover:bg-gray-50 bg-white">
+                             <td class="px-4 py-2 border-r border-gray-100 font-mono font-bold">{{ col.name }}</td>
+                             <td class="px-4 py-2 border-r border-gray-100 text-primary font-medium">{{ col.term || '-' }}</td>
+                             <td class="px-4 py-2 text-gray-500 leading-normal">{{ col.desc || '-' }}</td>
+                           </tr>
+                         </tbody>
+                       </table>
+                     </div>
+                   </div>
+                 </div>
                </div>
                <div v-if="profilesTotal > 0 && filteredTableProfiles.length === 0" class="p-12 text-center text-gray-400 text-sm italic">
                  {{ importFilter === 'unimported' ? '当前页暂无可导入的新表，请翻页或调整筛选' : '未找到匹配的表' }}
                </div>
-               <div v-if="profilesPages > 1" class="p-3 border-t border-gray-100 flex items-center justify-between bg-gray-50/50">
+               <div v-if="profilesPages > 1" class="p-3 border-t border-gray-100 flex items-center justify-between bg-gray-50/50 rounded-xl mt-3">
                  <span class="text-xs text-gray-400">第 {{ profilesPage }} / {{ profilesPages }} 页</span>
                  <div class="flex items-center gap-2">
                    <button
@@ -841,6 +1050,10 @@ const dbTypeColor = (type: string) => {
             <svg v-else-if="testPassed" class="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
             <span>{{ testing ? '正在连接...' : testPassed ? '连接成功' : '测试连接' }}</span>
           </button>
+        </div>
+        <div v-else-if="isDataSourceLocked" class="flex items-center gap-2 text-sm text-gray-500">
+          <span class="font-bold text-gray-700">数据集数据源</span>
+          <span class="px-2 py-1 rounded-lg bg-primary/10 text-primary font-mono text-xs border border-primary/20">{{ lockedDataSourceName }}</span>
         </div>
         <div v-else>
           <button @click="step = 1" class="text-sm font-bold text-gray-400 hover:text-gray-600 transition-all flex items-center gap-1">

--- a/frontend/src/components/metadata/DatabaseImportModal.vue
+++ b/frontend/src/components/metadata/DatabaseImportModal.vue
@@ -35,6 +35,22 @@ const selectedConfigName = computed(() => {
   return savedConfigs.value.find((c) => c.id === selectedConfigId.value)?.name || ''
 })
 
+const step1CanContinue = computed(() => {
+  return !!selectedConfigId.value && !!config.value.host && !!config.value.database
+})
+
+const step1ActionLabel = computed(() => {
+  if (!step1CanContinue.value) return '请选择数据源'
+  if (testing.value) return '正在验证连接...'
+  if (loading.value) return '正在加载表列表...'
+  if (testPassed.value) return '下一步 (浏览表)'
+  return '测试并继续'
+})
+
+const step1ActionDisabled = computed(() => {
+  return !step1CanContinue.value || testing.value || loading.value
+})
+
 const lockedConfig = computed(() => {
   const lockedName = props.lockedDataSourceName?.trim()
   if (!lockedName) return null
@@ -149,6 +165,15 @@ const handleTestConnection = async () => {
   } finally {
     testing.value = false
   }
+}
+
+const handleStep1Continue = async () => {
+  if (!step1CanContinue.value) return
+  if (!testPassed.value) {
+    await handleTestConnection()
+    if (!testPassed.value) return
+  }
+  await handleNext()
 }
 
 // ─── 加载表列表（Step 2） ──────────────────────────────────────────────────────
@@ -532,7 +557,7 @@ const dbTypeColor = (type: string) => {
       </div>
 
       <!-- Content -->
-      <div class="flex-1 overflow-y-auto p-6">
+      <div class="flex-1 overflow-y-auto" :class="step === 2 ? 'p-4' : 'p-6'">
 
         <!-- Step 1: Data Source -->
         <div v-if="step === 1 && !isDataSourceLocked" class="space-y-4">
@@ -559,7 +584,7 @@ const dbTypeColor = (type: string) => {
             <div class="flex items-start justify-between gap-4">
               <div>
                 <h3 class="text-sm font-bold text-gray-800">选择数据源</h3>
-                <p class="text-xs text-gray-500 mt-1">元数据导入会使用选中的数据源读取表列表和 DDL。</p>
+                <p class="text-xs text-gray-500 mt-1">选中后将验证连接，通过后即可浏览表列表。</p>
               </div>
               <button
                 @click="goDataSourceManagement"
@@ -581,9 +606,24 @@ const dbTypeColor = (type: string) => {
                   {{ dbTypeIcon(c.db_type) }}
                 </div>
                 <div class="flex-1 min-w-0">
-                  <div class="flex items-center gap-2">
+                  <div class="flex items-center gap-2 flex-wrap">
                     <span class="text-sm font-bold text-gray-800 truncate">{{ c.name }}</span>
                     <span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase" :class="dbTypeColor(c.db_type)">{{ c.db_type }}</span>
+                    <span
+                      v-if="selectedConfigId === c.id && testing"
+                      class="px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-blue-50 text-blue-600 border border-blue-100"
+                    >验证中...</span>
+                    <span
+                      v-else-if="selectedConfigId === c.id && testPassed"
+                      class="px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-green-50 text-green-600 border border-green-100 flex items-center gap-0.5"
+                    >
+                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
+                      已连接
+                    </span>
+                    <span
+                      v-else-if="selectedConfigId === c.id && connError"
+                      class="px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-red-50 text-red-600 border border-red-100"
+                    >连接失败</span>
                   </div>
                   <p class="text-[11px] text-gray-400 truncate font-mono mt-1">{{ c.host }}:{{ c.port }} / {{ c.database_name }}</p>
                   <p class="text-[11px] text-gray-400 truncate mt-1">用户：{{ c.db_user || '-' }}</p>
@@ -634,31 +674,29 @@ const dbTypeColor = (type: string) => {
         </div>
 
         <!-- Step 2: Select Tables -->
-        <div v-else class="h-full flex flex-col gap-4">
+        <div v-else class="h-full flex flex-col gap-2.5">
           <div
             v-if="isDataSourceLocked"
-            class="flex items-start gap-3 p-3.5 rounded-xl bg-blue-50 border border-blue-100 shrink-0"
+            class="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-blue-50 border border-blue-100 shrink-0 text-[11px] min-w-0"
+            title="追加导入仅允许从该数据源选表，不可切换其他数据源"
           >
-            <div class="w-9 h-9 rounded-lg bg-white border border-blue-100 flex items-center justify-center text-lg shrink-0">
-              {{ dbTypeIcon(lockedConfig?.db_type || config.type) }}
-            </div>
-            <div class="min-w-0 flex-1">
-              <div class="text-[10px] font-bold text-blue-800 uppercase tracking-wider">当前数据集数据源（已锁定）</div>
-              <div class="flex items-center gap-2 mt-1 flex-wrap">
-                <span class="text-sm font-bold text-blue-900 font-mono">{{ lockedDataSourceName }}</span>
-                <span
-                  v-if="lockedConfig?.db_type"
-                  class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase"
-                  :class="dbTypeColor(lockedConfig.db_type)"
-                >
-                  {{ lockedConfig.db_type }}
-                </span>
-              </div>
-              <p v-if="lockedConfig" class="text-[11px] text-blue-600/80 font-mono mt-1 truncate">
-                {{ lockedConfig.host }}:{{ lockedConfig.port }} / {{ lockedConfig.database_name }}
-              </p>
-              <p class="text-[11px] text-blue-600/70 mt-1">追加导入仅允许从该数据源选表，不可切换其他数据源。</p>
-            </div>
+            <span class="text-sm shrink-0 leading-none">{{ dbTypeIcon(lockedConfig?.db_type || config.type) }}</span>
+            <span class="font-bold text-blue-800 shrink-0">数据源已锁定</span>
+            <span class="text-blue-200 shrink-0">|</span>
+            <span class="font-mono font-bold text-blue-900 shrink-0">{{ lockedDataSourceName }}</span>
+            <span
+              v-if="lockedConfig?.db_type"
+              class="px-1 py-0.5 rounded text-[9px] font-bold uppercase shrink-0"
+              :class="dbTypeColor(lockedConfig.db_type)"
+            >
+              {{ lockedConfig.db_type }}
+            </span>
+            <span
+              v-if="lockedConfig"
+              class="text-blue-600/70 font-mono truncate min-w-0"
+            >
+              {{ lockedConfig.host }}:{{ lockedConfig.port }}/{{ lockedConfig.database_name }}
+            </span>
           </div>
 
           <!-- 双 Tab 切换 -->
@@ -1038,48 +1076,67 @@ const dbTypeColor = (type: string) => {
       </div>
 
       <!-- Footer -->
-      <div class="p-6 border-t border-gray-100 flex justify-between items-center bg-gray-50/30 shrink-0">
-        <!-- 左侧：第一步显示"测试连接"，第二步返回数据源选择 -->
-        <div v-if="step === 1" class="flex items-center gap-2">
+      <div class="px-5 py-2.5 border-t border-gray-100 flex justify-between items-center gap-3 bg-gray-50/30 shrink-0">
+        <button @click="handleClose" class="px-4 py-1.5 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-100 shrink-0">取消</button>
+
+        <!-- Step 1: 验证 → 继续 连贯操作 -->
+        <div v-if="step === 1 && !isDataSourceLocked" class="flex items-center gap-2 min-w-0 flex-1 justify-end">
+          <div v-if="selectedConfigId" class="hidden sm:flex items-center gap-1.5 text-xs text-gray-500 min-w-0 mr-1">
+            <template v-if="testing">
+              <svg class="animate-spin h-3.5 w-3.5 text-blue-500 shrink-0" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
+              <span class="truncate">验证 <strong class="text-gray-700">{{ selectedConfigName }}</strong> 连接中</span>
+            </template>
+            <template v-else-if="testPassed">
+              <svg class="w-3.5 h-3.5 text-green-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
+              <span class="text-green-600 font-medium shrink-0">连接正常</span>
+              <button
+                type="button"
+                @click="handleTestConnection"
+                :disabled="testing"
+                class="text-primary hover:underline shrink-0 disabled:opacity-50"
+              >重新测试</button>
+            </template>
+            <template v-else-if="connError">
+              <span class="text-red-500 shrink-0">连接失败，请重试</span>
+            </template>
+            <template v-else>
+              <span class="truncate">已选 <strong class="text-gray-700">{{ selectedConfigName }}</strong>，点击继续验证</span>
+            </template>
+          </div>
+
           <button
-            @click="handleTestConnection"
-            :disabled="testing || !selectedConfigId || !config.host || !config.database"
-            class="px-5 py-2 bg-blue-50 hover:bg-blue-100 text-blue-600 rounded-xl text-sm font-bold transition-all flex items-center gap-2 disabled:opacity-50 border border-blue-100"
+            @click="handleStep1Continue"
+            :disabled="step1ActionDisabled"
+            class="px-5 py-1.5 rounded-lg text-sm font-bold shadow-sm transition-all flex items-center gap-1.5 shrink-0 disabled:opacity-50"
+            :class="testPassed && !testing && !loading
+              ? 'bg-primary hover:bg-primary-dark text-white'
+              : 'bg-blue-600 hover:bg-blue-700 text-white'"
           >
-            <svg v-if="testing" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
-            <svg v-else-if="testPassed" class="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
-            <span>{{ testing ? '正在连接...' : testPassed ? '连接成功' : '测试连接' }}</span>
+            <svg v-if="testing || loading" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
+            <svg v-else-if="testPassed" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+            <span>{{ step1ActionLabel }}</span>
           </button>
         </div>
-        <div v-else-if="isDataSourceLocked" class="flex items-center gap-2 text-sm text-gray-500">
-          <span class="font-bold text-gray-700">数据集数据源</span>
-          <span class="px-2 py-1 rounded-lg bg-primary/10 text-primary font-mono text-xs border border-primary/20">{{ lockedDataSourceName }}</span>
+
+        <!-- Step 2 左侧信息 -->
+        <div v-else-if="step === 2 && isDataSourceLocked" class="flex items-center gap-1.5 text-xs text-gray-500 min-w-0 flex-1">
+          <span class="font-bold text-gray-700 shrink-0">数据集数据源</span>
+          <span class="px-1.5 py-0.5 rounded bg-primary/10 text-primary font-mono text-[11px] border border-primary/20 truncate">{{ lockedDataSourceName }}</span>
         </div>
-        <div v-else>
-          <button @click="step = 1" class="text-sm font-bold text-gray-400 hover:text-gray-600 transition-all flex items-center gap-1">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        <div v-else-if="step === 2" class="flex-1">
+          <button @click="step = 1" class="text-xs font-bold text-gray-400 hover:text-gray-600 transition-all flex items-center gap-1">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
             更换数据源
           </button>
         </div>
+        <div v-else class="flex-1"></div>
 
-        <div class="flex gap-3">
-          <button @click="handleClose" class="px-6 py-2 border border-gray-300 rounded-xl text-sm font-medium text-gray-700 hover:bg-gray-100">取消</button>
-
+        <!-- Step 2 确认按钮 -->
+        <div v-if="step === 2" class="flex gap-2 shrink-0">
           <button
-            v-if="step === 1"
-            @click="handleNext"
-            :disabled="loading || !selectedConfigId || !config.host || !config.database || !testPassed"
-            class="px-8 py-2 bg-primary hover:bg-primary-dark text-white rounded-xl text-sm font-bold shadow-lg shadow-primary/20 transition-all flex items-center gap-2 disabled:opacity-50"
-          >
-            <svg v-if="loading" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
-            <span>下一步 (浏览表)</span>
-          </button>
-
-          <button
-            v-else
             @click="handleConfirm"
             :disabled="loading || selectedTables.length === 0"
-            class="px-8 py-2 bg-green-600 hover:bg-green-700 text-white rounded-xl text-sm font-bold shadow-lg shadow-green-500/20 transition-all flex items-center gap-2 disabled:opacity-50"
+            class="px-5 py-1.5 bg-green-600 hover:bg-green-700 text-white rounded-lg text-sm font-bold shadow-sm transition-all flex items-center gap-1.5 disabled:opacity-50"
           >
             <svg v-if="loading" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
             <span>{{ activeTab === 'profile' ? '使用摸排画像导入' : '确认导入' }} ({{ selectedTables.length }})</span>

--- a/frontend/src/components/metadata/SmartImportWizard.vue
+++ b/frontend/src/components/metadata/SmartImportWizard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted, watch } from 'vue'
+import axios from '../../utils/axios'
 import { metadataApi } from '../../api/metadata'
 import { useToast } from '../../composables/useToast'
 import TraceLogViewer from '../TraceLogViewer.vue'
@@ -10,6 +11,7 @@ const props = defineProps<{
   datasetId?: number,
   datasetDisplayName?: string,
   datasetPhysicalName?: string,
+  datasetDataSource?: string,
   importedTableNames?: string[],
 }>()
 
@@ -23,6 +25,8 @@ const saving = ref(false)
 // Dataset Name State
 const datasetName = ref('')
 const datasetDisplayName = ref('')
+const importDataSourceName = ref('')
+const defaultDataSource = ref('')
 
 // Toast
 const { showToast } = useToast()
@@ -89,6 +93,33 @@ onUnmounted(() => {
   stopFakeProgress()
 })
 
+const fetchSystemDefaultDataSource = async () => {
+  try {
+    const res = await axios.get('/api/portal/system/configs')
+    const groups = res.data
+    if (groups?.data_api) {
+      const config = groups.data_api.find((item: any) => item.key === 'external_sql_data_source')
+      if (config?.value) {
+        defaultDataSource.value = config.value
+      }
+    }
+  } catch {
+    // 加载失败时使用后端默认值
+  }
+}
+
+watch(() => props.show, (visible) => {
+  if (visible && !props.datasetId) {
+    fetchSystemDefaultDataSource()
+  }
+})
+
+onMounted(() => {
+  if (!props.datasetId) {
+    fetchSystemDefaultDataSource()
+  }
+})
+
 // Preview Data
 const previewData = ref<{
   tables: any[],
@@ -99,6 +130,12 @@ const previewData = ref<{
   metrics: [],
   relationships: []
 })
+
+const expandedPreviewTables = ref<Record<number, boolean>>({})
+
+const togglePreviewTableExpand = (idx: number) => {
+  expandedPreviewTables.value[idx] = !expandedPreviewTables.value[idx]
+}
 
 const applyImportPreview = (data: any) => {
   let tables: any[] = []
@@ -202,11 +239,13 @@ const handleSave = async () => {
         return
       }
 
+      const dataSource = importDataSourceName.value || defaultDataSource.value || undefined
       const dsRes = await metadataApi.createDataset({
         name: datasetName.value.trim(),
         display_name: datasetDisplayName.value.trim(),
         description: 'Imported via Smart Wizard',
-        tags: ['auto-import']
+        tags: ['auto-import'],
+        ...(dataSource ? { data_source: dataSource } : {}),
       })
       targetDatasetId = (dsRes.data as any).id
     }
@@ -264,20 +303,28 @@ const handleClose = () => {
   step.value = 1
   ddlText.value = ''
   previewData.value = { tables: [], metrics: [], relationships: [] }
+  expandedPreviewTables.value = {}
+  importDataSourceName.value = ''
   stopFakeProgress()
   emit('close')
 }
 
-const handleDbDdlConfirm = (ddl: string) => {
+const handleDbDdlConfirm = (payload: { ddl: string; dataSourceName?: string }) => {
+  if (payload.dataSourceName) {
+    importDataSourceName.value = payload.dataSourceName
+  }
   if (ddlText.value.trim()) {
-    ddlText.value += '\n\n' + ddl
+    ddlText.value += '\n\n' + payload.ddl
   } else {
-    ddlText.value = ddl
+    ddlText.value = payload.ddl
   }
 }
 
-const handleProfileImportConfirm = (preview: any) => {
-  applyImportPreview(preview)
+const handleProfileImportConfirm = (payload: { preview: any; dataSourceName?: string }) => {
+  if (payload.dataSourceName) {
+    importDataSourceName.value = payload.dataSourceName
+  }
+  applyImportPreview(payload.preview)
   showToast('已使用摸排画像直接进入预览，无需重复分析', 'success')
 }
 
@@ -442,6 +489,9 @@ const normalizeType = (rawType: string): string => {
                  </div>
                </div>
                <p class="text-[10px] text-gray-400 mt-2 leading-tight">数据集 ID 全局唯一，用于标识；显示名称用于 UI 展示。</p>
+               <div v-if="importDataSourceName" class="mt-3 p-2.5 rounded-lg bg-emerald-50 border border-emerald-100 text-[11px] text-emerald-700">
+                  数据源 ID：<span class="font-mono font-bold">{{ importDataSourceName }}</span>
+               </div>
             </div>
 
             <!-- Append Mode Indicator -->
@@ -454,9 +504,12 @@ const normalizeType = (rawType: string): string => {
                   <div class="min-w-0">
                      <div class="text-[10px] font-bold text-blue-800 uppercase tracking-wider">追加到现有数据集</div>
                      <div class="text-xs font-bold text-blue-700 truncate" :title="datasetDisplayName">{{ datasetDisplayName || '当前数据集' }}</div>
-                     <div class="text-[9px] text-blue-400 font-mono flex items-center gap-1 mt-0.5">
+                     <div class="text-[9px] text-blue-400 font-mono flex items-center gap-1 mt-0.5 flex-wrap">
                         <span class="bg-blue-100 px-1 rounded">#{{ datasetPhysicalName }}</span>
                         <span>ID: {{ datasetId }}</span>
+                        <span v-if="datasetDataSource" class="bg-emerald-100 text-emerald-700 px-1 rounded" :title="datasetDataSource">
+                          数据源: {{ datasetDataSource }}
+                        </span>
                      </div>
                   </div>
                </div>
@@ -496,58 +549,123 @@ const normalizeType = (rawType: string): string => {
                  识别到的表结构
                </h3>
                <div class="grid gap-4">
-                  <div v-for="(table, idx) in previewData.tables" :key="idx" class="bg-white rounded-xl border border-gray-200 p-5 shadow-sm group">
-                     <div class="flex justify-between items-center mb-3">
-                        <div class="flex items-center gap-3">
-                           <div class="px-2 py-1 bg-blue-50 text-blue-700 font-mono text-xs rounded border border-blue-100">{{ table.physical_name }}</div>
-                           <input v-model="table.term" class="text-sm font-bold border-none focus:ring-0 p-0 text-gray-800" placeholder="业务名称">
-                        </div>
-                        <button @click="removeTable(idx)" class="text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity">
-                           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
-                        </button>
-                     </div>
-                     <p class="text-xs text-gray-500 mb-3">{{ table.description || '无描述' }}</p>
-                     
-                     <!-- Columns Preview (Editable) -->
-                     <div class="space-y-2">
-                        <div class="grid grid-cols-12 gap-2 px-2 text-[10px] font-bold text-gray-400 uppercase tracking-wider">
-                           <div class="col-span-3">物理字段名</div>
-                           <div class="col-span-2">类型</div>
-                           <div class="col-span-3">业务术语 (Term)</div>
-                           <div class="col-span-3">描述</div>
-                           <div class="col-span-1"></div>
-                        </div>
-                        <div v-for="(col, cIdx) in table.columns" :key="cIdx" class="grid grid-cols-12 gap-2 items-center bg-gray-50/50 p-1.5 rounded-lg border border-transparent hover:border-blue-100 hover:bg-white transition-all group/col">
-                           <div class="col-span-3">
-                              <input v-model="col.physical_name" class="w-full bg-transparent border-none focus:ring-0 p-0 text-xs font-mono text-gray-600" placeholder="物理名">
+                  <div
+                    v-for="(table, idx) in previewData.tables"
+                    :key="idx"
+                    class="bg-white rounded-xl border border-gray-200 shadow-sm group overflow-hidden"
+                  >
+                     <div class="p-5">
+                        <div class="flex justify-between items-start gap-3 mb-3">
+                           <div class="min-w-0 flex-1">
+                              <div class="flex items-center gap-2 flex-wrap">
+                                 <h4 class="font-bold text-gray-900 font-mono">{{ table.physical_name }}</h4>
+                                 <input
+                                   v-model="table.term"
+                                   class="text-[10px] font-bold text-gray-500 px-1.5 py-0.5 bg-gray-50 rounded border border-gray-100 max-w-[200px]"
+                                   placeholder="业务名称"
+                                 >
+                              </div>
+                              <textarea
+                                v-model="table.description"
+                                rows="2"
+                                class="w-full mt-2 text-xs text-gray-500 bg-gray-50/60 border border-gray-100 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-100 resize-none"
+                                placeholder="表用途描述..."
+                              />
                            </div>
-                           <div class="col-span-2">
-                              <select v-model="col.type" class="w-full bg-transparent border-none text-[10px] text-gray-500 focus:ring-0 outline-none p-0">
-                                 <option value="String">String</option>
-                                 <option value="Int64">Int64</option>
-                                 <option value="Float64">Float64</option>
-                                 <option value="DateTime">DateTime</option>
-                                 <option value="Boolean">Boolean</option>
-                                 <option value="JSON">JSON</option>
-                              </select>
-                           </div>
-                           <div class="col-span-3">
-                              <input v-model="col.term" class="w-full bg-transparent border-none focus:ring-0 p-0 text-xs text-gray-800 font-medium" placeholder="业务名">
-                           </div>
-                           <div class="col-span-3">
-                              <input v-model="col.description" class="w-full bg-transparent border-none focus:ring-0 p-0 text-xs text-gray-500" placeholder="描述...">
-                           </div>
-                           <div class="col-span-1 flex justify-end">
-                              <button @click="table.columns.splice(cIdx, 1)" class="text-gray-300 hover:text-red-500 opacity-0 group-hover/col:opacity-100 transition-opacity">
-                                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+                           <div class="flex items-center gap-1 shrink-0">
+                              <button
+                                 type="button"
+                                 class="text-gray-400 hover:text-gray-600 p-1.5 rounded-md hover:bg-gray-50 transition-colors"
+                                 :class="expandedPreviewTables[idx] ? 'rotate-90' : ''"
+                                 @click="togglePreviewTableExpand(idx)"
+                                 title="展开字段画像"
+                              >
+                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>
+                              </button>
+                              <button @click="removeTable(idx)" class="text-gray-300 hover:text-red-500 p-1.5 rounded-md hover:bg-red-50 transition-colors">
+                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
                               </button>
                            </div>
                         </div>
-                        
-                        <!-- Add Column Helper (Optional) -->
-                        <button 
+
+                        <div v-if="!expandedPreviewTables[idx]" class="flex flex-wrap gap-1.5">
+                           <div
+                              v-for="(col, cIdx) in table.columns.slice(0, 10)"
+                              :key="cIdx"
+                              class="flex items-center gap-1 px-2 py-0.5 bg-slate-50 border border-slate-100 rounded-md text-[10px] font-mono"
+                           >
+                              <span class="text-slate-600 font-bold">{{ col.physical_name }}</span>
+                              <span class="text-slate-300">/</span>
+                              <span class="text-blue-500">{{ col.term || '?' }}</span>
+                           </div>
+                           <div
+                              v-if="table.columns.length > 10"
+                              class="px-2 py-0.5 bg-gray-50 border border-gray-100 rounded-md text-[10px] text-gray-400 font-medium"
+                           >
+                              +{{ table.columns.length - 10 }} 更多字段
+                           </div>
+                           <button
+                              v-if="table.columns.length > 0"
+                              type="button"
+                              @click="togglePreviewTableExpand(idx)"
+                              class="px-2 py-0.5 text-[10px] text-blue-500 hover:bg-blue-50 rounded-md border border-transparent hover:border-blue-100 transition-colors"
+                           >
+                              展开字段画像
+                           </button>
+                        </div>
+                     </div>
+
+                     <div v-if="expandedPreviewTables[idx]" class="border-t border-gray-100 p-5 bg-gray-50/30 space-y-3">
+                        <div class="text-xs font-bold text-gray-400 uppercase tracking-wider">
+                           字段画像定义 (Columns Profile)
+                           <span class="text-gray-300 font-normal ml-1">· {{ table.columns.length }} 个字段</span>
+                        </div>
+
+                        <div class="border border-gray-100 rounded-xl overflow-hidden bg-white">
+                           <table class="w-full text-left border-collapse text-xs mb-3">
+                              <thead>
+                                 <tr class="bg-gray-50 border-b border-gray-100 text-gray-400 font-bold uppercase">
+                                    <th class="px-4 py-2 border-r border-gray-100 w-[18%]">物理字段</th>
+                                    <th class="px-4 py-2 border-r border-gray-100 w-[14%]">类型</th>
+                                    <th class="px-4 py-2 border-r border-gray-100 w-[18%]">业务术语</th>
+                                    <th class="px-4 py-2 w-[42%]">业务含义说明</th>
+                                    <th class="px-4 py-2 w-[8%]"></th>
+                                 </tr>
+                              </thead>
+                              <tbody class="divide-y divide-gray-100 text-gray-700">
+                                 <tr v-for="(col, cIdx) in table.columns" :key="cIdx" class="hover:bg-gray-50">
+                                    <td class="px-3 py-2 border-r border-gray-100">
+                                       <input v-model="col.physical_name" class="w-full bg-transparent border-none focus:ring-0 p-0 text-xs font-mono font-bold text-gray-700" placeholder="物理名">
+                                    </td>
+                                    <td class="px-3 py-2 border-r border-gray-100">
+                                       <select v-model="col.type" class="w-full bg-transparent border-none text-[10px] text-gray-500 focus:ring-0 outline-none p-0">
+                                          <option value="String">String</option>
+                                          <option value="Int64">Int64</option>
+                                          <option value="Float64">Float64</option>
+                                          <option value="DateTime">DateTime</option>
+                                          <option value="Boolean">Boolean</option>
+                                          <option value="JSON">JSON</option>
+                                       </select>
+                                    </td>
+                                    <td class="px-3 py-2 border-r border-gray-100">
+                                       <input v-model="col.term" class="w-full bg-transparent border-none focus:ring-0 p-0 text-xs text-primary font-medium" placeholder="业务名">
+                                    </td>
+                                    <td class="px-3 py-2">
+                                       <input v-model="col.description" class="w-full bg-transparent border-none focus:ring-0 p-0 text-xs text-gray-500" placeholder="描述...">
+                                    </td>
+                                    <td class="px-3 py-2 text-right">
+                                       <button @click="table.columns.splice(cIdx, 1)" class="text-gray-300 hover:text-red-500 transition-colors">
+                                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+                                       </button>
+                                    </td>
+                                 </tr>
+                              </tbody>
+                           </table>
+                        </div>
+
+                        <button
                            @click="table.columns.push({ physical_name: '', term: '', type: 'String', description: '' })"
-                           class="w-full py-1.5 mt-1 border border-dashed border-gray-200 rounded-lg text-[10px] text-gray-400 hover:text-blue-500 hover:border-blue-200 hover:bg-blue-50 transition-all flex items-center justify-center gap-1"
+                           class="w-full py-1.5 border border-dashed border-gray-200 rounded-lg text-[10px] text-gray-400 hover:text-blue-500 hover:border-blue-200 hover:bg-blue-50 transition-all flex items-center justify-center gap-1"
                         >
                            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
                            添加更多字段
@@ -652,6 +770,7 @@ const normalizeType = (rawType: string): string => {
   <DatabaseImportModal 
     :show="showDbImportModal"
     :imported-table-names="props.datasetId ? (props.importedTableNames || []) : []"
+    :locked-data-source-name="props.datasetId ? (props.datasetDataSource || '') : ''"
     @close="showDbImportModal = false"
     @confirm="handleDbDdlConfirm"
     @confirm-profile="handleProfileImportConfirm"

--- a/frontend/src/components/metadata/SmartImportWizard.vue
+++ b/frontend/src/components/metadata/SmartImportWizard.vue
@@ -137,6 +137,36 @@ const togglePreviewTableExpand = (idx: number) => {
   expandedPreviewTables.value[idx] = !expandedPreviewTables.value[idx]
 }
 
+const getDescriptionRows = (desc?: string) => {
+  if (!desc?.trim()) return 2
+  const lineCount = desc.split('\n').length
+  const wrappedLines = Math.ceil(desc.length / 46)
+  return Math.min(12, Math.max(2, Math.max(lineCount, wrappedLines)))
+}
+
+const EDITABLE_INPUT =
+  'w-full px-3 py-2 bg-amber-50/60 border-2 border-dashed border-amber-300 rounded-lg text-sm text-gray-800 shadow-sm hover:border-amber-400 hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-200 focus:border-amber-500 focus:bg-white transition-colors'
+
+const EDITABLE_INPUT_SM =
+  'w-full px-2.5 py-1.5 bg-amber-50/60 border border-dashed border-amber-300 rounded-md text-xs text-gray-800 hover:border-amber-400 hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-200 focus:border-amber-500 focus:bg-white transition-colors'
+
+const EDITABLE_TEXTAREA =
+  'w-full px-3 py-2 bg-amber-50/60 border-2 border-dashed border-amber-300 rounded-lg text-xs text-gray-700 leading-relaxed shadow-sm hover:border-amber-400 hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-200 focus:border-amber-500 focus:bg-white transition-colors resize-y min-h-[3rem]'
+
+const EDITABLE_CELL =
+  'w-full px-2 py-1.5 bg-amber-50/50 border border-dashed border-amber-300 rounded-md hover:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-200 focus:border-amber-500 focus:bg-white transition-colors'
+
+const EDITABLE_SELECT =
+  'w-full px-2 py-1.5 bg-amber-50/50 border border-dashed border-amber-300 rounded-md text-[10px] text-gray-700 hover:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-200 focus:border-amber-500 focus:bg-white transition-colors'
+
+const expandAllPreviewTables = (tableCount: number) => {
+  const expanded: Record<number, boolean> = {}
+  for (let i = 0; i < tableCount; i++) {
+    expanded[i] = true
+  }
+  expandedPreviewTables.value = expanded
+}
+
 const applyImportPreview = (data: any) => {
   let tables: any[] = []
   let metrics: any[] = []
@@ -164,6 +194,7 @@ const applyImportPreview = (data: any) => {
   })
 
   previewData.value = { tables, metrics, relationships }
+  expandAllPreviewTables(tables.length)
 
   if (previewData.value.tables.length > 0) {
     const firstTable = previewData.value.tables[0]
@@ -395,9 +426,62 @@ const normalizeType = (rawType: string): string => {
              </div>
            </div>
         </div>
-        <button @click="handleClose" class="text-gray-400 hover:text-gray-600 transition-colors p-2 hover:bg-white rounded-full">
+        <button @click="handleClose" class="text-gray-400 hover:text-gray-600 transition-colors p-2 hover:bg-white rounded-full shrink-0">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
         </button>
+      </div>
+
+      <!-- Step 2: 数据集信息顶栏 -->
+      <div v-if="step === 2" class="px-6 py-4 border-b border-gray-100 bg-white shrink-0">
+        <div v-if="!datasetId" class="space-y-3">
+          <div class="flex items-start gap-2 text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2.5">
+            <svg class="w-4 h-4 shrink-0 mt-0.5 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
+            <span>以下为 AI 识别结果，<strong class="font-bold">虚线框</strong>内内容可直接修改，保存前请核对数据集信息与表结构。</span>
+          </div>
+          <div class="flex flex-col lg:flex-row lg:items-end gap-4">
+          <div class="flex-1 min-w-0">
+            <label class="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase tracking-wider mb-1.5">
+              <span>数据集 ID (Unique)</span>
+              <span class="inline-flex items-center gap-0.5 text-[10px] font-semibold text-amber-600 normal-case tracking-normal">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/></svg>
+                可编辑
+              </span>
+            </label>
+            <input
+              v-model="datasetName"
+              :class="[EDITABLE_INPUT, 'font-mono']"
+              placeholder="e.g. user_orders_ds"
+            >
+          </div>
+          <div class="flex-[1.4] min-w-0">
+            <label class="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase tracking-wider mb-1.5">
+              <span>显示名称</span>
+              <span class="inline-flex items-center gap-0.5 text-[10px] font-semibold text-amber-600 normal-case tracking-normal">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/></svg>
+                可编辑
+              </span>
+            </label>
+            <input
+              v-model="datasetDisplayName"
+              :class="EDITABLE_INPUT"
+              placeholder="e.g. 用户订单数据集"
+            >
+          </div>
+          </div>
+        </div>
+        <div v-else class="flex items-center gap-3 p-3 bg-blue-50 border border-blue-100 rounded-xl">
+          <div class="w-8 h-8 rounded-lg bg-white flex items-center justify-center text-blue-600 shadow-sm shrink-0">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="text-[10px] font-bold text-blue-800 uppercase tracking-wider">追加到现有数据集</div>
+            <div class="text-sm font-bold text-blue-700 truncate" :title="datasetDisplayName">{{ datasetDisplayName || '当前数据集' }}</div>
+            <div class="text-[10px] text-blue-500 font-mono flex items-center gap-2 mt-0.5 flex-wrap">
+              <span class="bg-blue-100 px-1.5 py-0.5 rounded">#{{ datasetPhysicalName }}</span>
+              <span>ID: {{ datasetId }}</span>
+            </div>
+          </div>
+        </div>
       </div>
 
       <!-- Content Step 1: Input -->
@@ -459,65 +543,23 @@ const normalizeType = (rawType: string): string => {
       </div>
 
       <!-- Content Step 2: Preview -->
-      <div v-else class="flex-1 flex overflow-hidden">
+      <div v-else class="flex-1 flex min-h-0 overflow-hidden">
          <!-- Sidebar Navigation -->
-         <div class="w-64 bg-gray-50 border-r border-gray-100 flex flex-col py-6">
-            
-            <!-- Dataset Name Input (Only if not in append mode) -->
-            <div class="px-6 mb-6" v-if="!datasetId">
-               <label class="block text-xs font-bold text-gray-400 uppercase tracking-wider mb-2">数据集 ID (Unique)</label>
-               <div class="relative mb-3">
-                 <input 
-                   v-model="datasetName" 
-                   class="w-full pl-3 pr-8 py-2 bg-white border border-gray-200 rounded-lg text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder-gray-400 font-mono"
-                   placeholder="e.g. user_orders_ds"
-                 >
-                 <div class="absolute right-2 top-2.5 text-gray-400 pointer-events-none">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"></path></svg>
-                 </div>
-               </div>
-               
-               <label class="block text-xs font-bold text-gray-400 uppercase tracking-wider mb-2">显示名称</label>
-               <div class="relative">
-                 <input 
-                   v-model="datasetDisplayName" 
-                   class="w-full pl-3 pr-8 py-2 bg-white border border-gray-200 rounded-lg text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder-gray-400"
-                   placeholder="e.g. 用户订单数据集"
-                 >
-                 <div class="absolute right-2 top-2.5 text-gray-400 pointer-events-none">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
-                 </div>
-               </div>
-               <p class="text-[10px] text-gray-400 mt-2 leading-tight">数据集 ID 全局唯一，用于标识；显示名称用于 UI 展示。</p>
-               <div v-if="importDataSourceName" class="mt-3 p-2.5 rounded-lg bg-emerald-50 border border-emerald-100 text-[11px] text-emerald-700">
-                  数据源 ID：<span class="font-mono font-bold">{{ importDataSourceName }}</span>
-               </div>
-            </div>
-
-            <!-- Append Mode Indicator -->
-            <div class="px-6 mb-6" v-else>
-               <label class="block text-xs font-bold text-gray-400 uppercase tracking-wider mb-2">导入模式</label>
-               <div class="flex items-center gap-2 p-3 bg-blue-50 border border-blue-100 rounded-xl">
-                  <div class="w-8 h-8 rounded-lg bg-white flex items-center justify-center text-blue-600 shadow-sm">
-                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
-                  </div>
-                  <div class="min-w-0">
-                     <div class="text-[10px] font-bold text-blue-800 uppercase tracking-wider">追加到现有数据集</div>
-                     <div class="text-xs font-bold text-blue-700 truncate" :title="datasetDisplayName">{{ datasetDisplayName || '当前数据集' }}</div>
-                     <div class="text-[9px] text-blue-400 font-mono flex items-center gap-1 mt-0.5 flex-wrap">
-                        <span class="bg-blue-100 px-1 rounded">#{{ datasetPhysicalName }}</span>
-                        <span>ID: {{ datasetId }}</span>
-                        <span v-if="datasetDataSource" class="bg-emerald-100 text-emerald-700 px-1 rounded" :title="datasetDataSource">
-                          数据源: {{ datasetDataSource }}
-                        </span>
-                     </div>
-                  </div>
-               </div>
+         <div class="w-64 shrink-0 bg-gray-50 border-r border-gray-100 flex flex-col min-h-0 overflow-hidden">
+            <div class="flex-1 min-h-0 overflow-y-auto py-6">
+            <div
+              v-if="(!datasetId && importDataSourceName) || (datasetId && datasetDataSource)"
+              class="px-6 mb-6"
+            >
+              <label class="block text-xs font-bold text-gray-400 uppercase tracking-wider mb-2">数据源 ID</label>
+              <div class="p-2.5 rounded-lg bg-emerald-50 border border-emerald-100 text-[11px] text-emerald-700">
+                <span class="font-mono font-bold break-all">{{ datasetId ? datasetDataSource : importDataSourceName }}</span>
+              </div>
             </div>
 
             <div class="px-6 mb-4 font-bold text-xs text-gray-400 uppercase tracking-wider">识别结果概览</div>
             
-            <div class="flex-1 overflow-y-auto space-y-1 px-4">
+            <div class="space-y-1 px-4 pb-4">
                <div class="flex justify-between items-center p-2 rounded-lg bg-white border border-gray-200 shadow-sm">
                   <span class="text-sm font-bold text-gray-700">Tables</span>
                   <span class="text-xs bg-gray-100 px-2 py-0.5 rounded-full text-gray-600">{{ previewData.tables.length }}</span>
@@ -532,7 +574,9 @@ const normalizeType = (rawType: string): string => {
                </div>
             </div>
 
-            <div class="px-6 mt-4">
+            </div>
+
+            <div class="shrink-0 px-6 py-4 border-t border-gray-100 bg-gray-50">
                <button @click="step = 1" class="w-full py-2 border border-gray-300 rounded-lg text-sm text-gray-600 hover:bg-gray-100">
                   ← 返回修改输入
                </button>
@@ -540,14 +584,15 @@ const normalizeType = (rawType: string): string => {
          </div>
 
          <!-- Main Preview Area -->
-         <div class="flex-1 overflow-y-auto bg-gray-50/50 p-8 space-y-8">
+         <div class="flex-1 min-h-0 overflow-y-auto bg-gray-50/50 p-8 space-y-8">
             
             <!-- Tables Section -->
             <section v-if="previewData.tables.length > 0">
-               <h3 class="text-lg font-bold text-gray-900 mb-4 flex items-center gap-2">
+               <h3 class="text-lg font-bold text-gray-900 mb-1 flex items-center gap-2">
                  <span class="w-2 h-6 bg-blue-500 rounded-full"></span>
                  识别到的表结构
                </h3>
+               <p class="text-xs text-gray-500 mb-4 ml-4">物理表名只读；业务名称、描述与字段画像在虚线框内可编辑。</p>
                <div class="grid gap-4">
                   <div
                     v-for="(table, idx) in previewData.tables"
@@ -557,20 +602,33 @@ const normalizeType = (rawType: string): string => {
                      <div class="p-5">
                         <div class="flex justify-between items-start gap-3 mb-3">
                            <div class="min-w-0 flex-1">
-                              <div class="flex items-center gap-2 flex-wrap">
-                                 <h4 class="font-bold text-gray-900 font-mono">{{ table.physical_name }}</h4>
-                                 <input
-                                   v-model="table.term"
-                                   class="text-[10px] font-bold text-gray-500 px-1.5 py-0.5 bg-gray-50 rounded border border-gray-100 max-w-[200px]"
-                                   placeholder="业务名称"
-                                 >
+                              <div class="flex items-center gap-2 flex-wrap mb-3">
+                                 <span class="px-2 py-1 bg-slate-100 text-slate-600 font-mono text-xs font-bold rounded border border-slate-200">{{ table.physical_name }}</span>
+                                 <span class="text-[10px] text-gray-400">物理表名（只读）</span>
                               </div>
-                              <textarea
-                                v-model="table.description"
-                                rows="2"
-                                class="w-full mt-2 text-xs text-gray-500 bg-gray-50/60 border border-gray-100 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-100 resize-none"
-                                placeholder="表用途描述..."
-                              />
+                              <div class="rounded-xl border-2 border-dashed border-amber-300/80 bg-amber-50/20 p-4 space-y-3">
+                                 <div class="flex items-center gap-1.5 text-[10px] font-bold text-amber-700 uppercase tracking-wider">
+                                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/></svg>
+                                    可编辑区域
+                                 </div>
+                                 <div>
+                                    <label class="block text-[10px] font-bold text-gray-500 mb-1">业务名称</label>
+                                    <input
+                                      v-model="table.term"
+                                      :class="EDITABLE_INPUT_SM"
+                                      placeholder="例如：数据库列级权限控制表"
+                                    >
+                                 </div>
+                                 <div>
+                                    <label class="block text-[10px] font-bold text-gray-500 mb-1">表用途描述</label>
+                                    <textarea
+                                      v-model="table.description"
+                                      :rows="getDescriptionRows(table.description)"
+                                      :class="EDITABLE_TEXTAREA"
+                                      placeholder="请补充或修改表的用途说明..."
+                                    />
+                                 </div>
+                              </div>
                            </div>
                            <div class="flex items-center gap-1 shrink-0">
                               <button
@@ -615,30 +673,31 @@ const normalizeType = (rawType: string): string => {
                         </div>
                      </div>
 
-                     <div v-if="expandedPreviewTables[idx]" class="border-t border-gray-100 p-5 bg-gray-50/30 space-y-3">
-                        <div class="text-xs font-bold text-gray-400 uppercase tracking-wider">
-                           字段画像定义 (Columns Profile)
-                           <span class="text-gray-300 font-normal ml-1">· {{ table.columns.length }} 个字段</span>
+                     <div v-if="expandedPreviewTables[idx]" class="border-t border-amber-200/60 p-5 bg-amber-50/10 space-y-3">
+                        <div class="text-xs font-bold text-gray-500 uppercase tracking-wider flex items-center gap-2">
+                           <span>字段画像定义 (Columns Profile)</span>
+                           <span class="text-gray-300 font-normal">· {{ table.columns.length }} 个字段</span>
+                           <span class="text-[10px] font-semibold text-amber-600 normal-case tracking-normal">虚线框可编辑</span>
                         </div>
 
-                        <div class="border border-gray-100 rounded-xl overflow-hidden bg-white">
+                        <div class="border-2 border-dashed border-amber-300/70 rounded-xl overflow-hidden bg-white">
                            <table class="w-full text-left border-collapse text-xs mb-3">
                               <thead>
-                                 <tr class="bg-gray-50 border-b border-gray-100 text-gray-400 font-bold uppercase">
-                                    <th class="px-4 py-2 border-r border-gray-100 w-[18%]">物理字段</th>
-                                    <th class="px-4 py-2 border-r border-gray-100 w-[14%]">类型</th>
-                                    <th class="px-4 py-2 border-r border-gray-100 w-[18%]">业务术语</th>
+                                 <tr class="bg-amber-50/80 border-b border-amber-200/60 text-gray-500 font-bold uppercase">
+                                    <th class="px-4 py-2 border-r border-amber-100 w-[18%]">物理字段</th>
+                                    <th class="px-4 py-2 border-r border-amber-100 w-[14%]">类型</th>
+                                    <th class="px-4 py-2 border-r border-amber-100 w-[18%]">业务术语</th>
                                     <th class="px-4 py-2 w-[42%]">业务含义说明</th>
                                     <th class="px-4 py-2 w-[8%]"></th>
                                  </tr>
                               </thead>
-                              <tbody class="divide-y divide-gray-100 text-gray-700">
-                                 <tr v-for="(col, cIdx) in table.columns" :key="cIdx" class="hover:bg-gray-50">
-                                    <td class="px-3 py-2 border-r border-gray-100">
-                                       <input v-model="col.physical_name" class="w-full bg-transparent border-none focus:ring-0 p-0 text-xs font-mono font-bold text-gray-700" placeholder="物理名">
+                              <tbody class="divide-y divide-amber-100/80 text-gray-700">
+                                 <tr v-for="(col, cIdx) in table.columns" :key="cIdx" class="hover:bg-amber-50/30">
+                                    <td class="px-3 py-2 border-r border-amber-100">
+                                       <input v-model="col.physical_name" :class="[EDITABLE_CELL, 'font-mono font-bold']" placeholder="物理名">
                                     </td>
-                                    <td class="px-3 py-2 border-r border-gray-100">
-                                       <select v-model="col.type" class="w-full bg-transparent border-none text-[10px] text-gray-500 focus:ring-0 outline-none p-0">
+                                    <td class="px-3 py-2 border-r border-amber-100">
+                                       <select v-model="col.type" :class="EDITABLE_SELECT">
                                           <option value="String">String</option>
                                           <option value="Int64">Int64</option>
                                           <option value="Float64">Float64</option>
@@ -647,11 +706,11 @@ const normalizeType = (rawType: string): string => {
                                           <option value="JSON">JSON</option>
                                        </select>
                                     </td>
-                                    <td class="px-3 py-2 border-r border-gray-100">
-                                       <input v-model="col.term" class="w-full bg-transparent border-none focus:ring-0 p-0 text-xs text-primary font-medium" placeholder="业务名">
+                                    <td class="px-3 py-2 border-r border-amber-100">
+                                       <input v-model="col.term" :class="[EDITABLE_CELL, 'text-primary font-medium']" placeholder="业务名">
                                     </td>
                                     <td class="px-3 py-2">
-                                       <input v-model="col.description" class="w-full bg-transparent border-none focus:ring-0 p-0 text-xs text-gray-500" placeholder="描述...">
+                                       <input v-model="col.description" :class="EDITABLE_CELL" placeholder="描述...">
                                     </td>
                                     <td class="px-3 py-2 text-right">
                                        <button @click="table.columns.splice(cIdx, 1)" class="text-gray-300 hover:text-red-500 transition-colors">
@@ -665,7 +724,7 @@ const normalizeType = (rawType: string): string => {
 
                         <button
                            @click="table.columns.push({ physical_name: '', term: '', type: 'String', description: '' })"
-                           class="w-full py-1.5 border border-dashed border-gray-200 rounded-lg text-[10px] text-gray-400 hover:text-blue-500 hover:border-blue-200 hover:bg-blue-50 transition-all flex items-center justify-center gap-1"
+                           class="w-full py-1.5 border-2 border-dashed border-amber-300 rounded-lg text-[10px] text-amber-600 hover:text-amber-700 hover:border-amber-400 hover:bg-amber-50 transition-all flex items-center justify-center gap-1"
                         >
                            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
                            添加更多字段
@@ -784,5 +843,11 @@ const normalizeType = (rawType: string): string => {
 @keyframes fadeInUp {
   from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }
+}
+
+:deep(input[class*="border-dashed"]::placeholder),
+:deep(textarea[class*="border-dashed"]::placeholder) {
+  color: #d97706;
+  opacity: 0.55;
 }
 </style>

--- a/frontend/src/components/metadata/SmartImportWizard.vue
+++ b/frontend/src/components/metadata/SmartImportWizard.vue
@@ -145,7 +145,7 @@ const getDescriptionRows = (desc?: string) => {
 }
 
 const EDITABLE_INPUT =
-  'w-full px-3 py-2 bg-amber-50/60 border-2 border-dashed border-amber-300 rounded-lg text-sm text-gray-800 shadow-sm hover:border-amber-400 hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-200 focus:border-amber-500 focus:bg-white transition-colors'
+  'w-full px-2.5 py-1.5 bg-amber-50/60 border-2 border-dashed border-amber-300 rounded-lg text-sm text-gray-800 shadow-sm hover:border-amber-400 hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-200 focus:border-amber-500 focus:bg-white transition-colors'
 
 const EDITABLE_INPUT_SM =
   'w-full px-2.5 py-1.5 bg-amber-50/60 border border-dashed border-amber-300 rounded-md text-xs text-gray-800 hover:border-amber-400 hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-200 focus:border-amber-500 focus:bg-white transition-colors'
@@ -389,18 +389,22 @@ const normalizeType = (rawType: string): string => {
 </script>
 
 <template>
-  <div v-if="show" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-    <div class="bg-white rounded-xl shadow-2xl w-full max-w-6xl h-[90vh] flex flex-col overflow-hidden border border-gray-100 animate-fade-in-up">
+  <div v-if="show" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+    <div class="bg-white rounded-xl shadow-2xl w-full max-w-5xl h-[92vh] flex flex-col overflow-hidden border border-gray-100 animate-fade-in-up">
       
       <!-- Header -->
-      <div class="p-6 border-b border-gray-100 flex justify-between items-center bg-gradient-to-r from-blue-50 to-indigo-50">
-        <div class="flex items-center gap-4">
-           <div class="w-12 h-12 rounded-xl bg-white shadow-sm flex items-center justify-center text-blue-600 border border-blue-100">
-              <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.384-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"/></svg>
+      <div
+        class="border-b border-gray-100 flex justify-between items-center bg-gradient-to-r from-blue-50 to-indigo-50 shrink-0 px-5 py-3"
+      >
+        <div class="flex items-center gap-3">
+           <div
+             class="rounded-xl bg-white shadow-sm flex items-center justify-center text-blue-600 border border-blue-100 shrink-0 w-9 h-9"
+           >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.384-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"/></svg>
            </div>
            <div>
-             <h2 class="text-xl font-bold text-gray-900">智能元数据导入向导</h2>
-             <div class="flex items-center gap-3 mt-1">
+             <h2 class="font-bold text-gray-900 text-lg">智能元数据导入向导</h2>
+             <div class="flex items-center gap-2 mt-0.5">
                 <!-- Step 1 -->
                 <div class="flex items-center gap-2" :class="step >= 1 ? 'text-blue-600' : 'text-gray-400'">
                   <div class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold border-2 transition-colors"
@@ -431,69 +435,17 @@ const normalizeType = (rawType: string): string => {
         </button>
       </div>
 
-      <!-- Step 2: 数据集信息顶栏 -->
-      <div v-if="step === 2" class="px-6 py-4 border-b border-gray-100 bg-white shrink-0">
-        <div v-if="!datasetId" class="space-y-3">
-          <div class="flex items-start gap-2 text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2.5">
-            <svg class="w-4 h-4 shrink-0 mt-0.5 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
-            <span>以下为 AI 识别结果，<strong class="font-bold">虚线框</strong>内内容可直接修改，保存前请核对数据集信息与表结构。</span>
-          </div>
-          <div class="flex flex-col lg:flex-row lg:items-end gap-4">
-          <div class="flex-1 min-w-0">
-            <label class="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase tracking-wider mb-1.5">
-              <span>数据集 ID (Unique)</span>
-              <span class="inline-flex items-center gap-0.5 text-[10px] font-semibold text-amber-600 normal-case tracking-normal">
-                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/></svg>
-                可编辑
-              </span>
-            </label>
-            <input
-              v-model="datasetName"
-              :class="[EDITABLE_INPUT, 'font-mono']"
-              placeholder="e.g. user_orders_ds"
-            >
-          </div>
-          <div class="flex-[1.4] min-w-0">
-            <label class="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase tracking-wider mb-1.5">
-              <span>显示名称</span>
-              <span class="inline-flex items-center gap-0.5 text-[10px] font-semibold text-amber-600 normal-case tracking-normal">
-                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/></svg>
-                可编辑
-              </span>
-            </label>
-            <input
-              v-model="datasetDisplayName"
-              :class="EDITABLE_INPUT"
-              placeholder="e.g. 用户订单数据集"
-            >
-          </div>
-          </div>
-        </div>
-        <div v-else class="flex items-center gap-3 p-3 bg-blue-50 border border-blue-100 rounded-xl">
-          <div class="w-8 h-8 rounded-lg bg-white flex items-center justify-center text-blue-600 shadow-sm shrink-0">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
-          </div>
-          <div class="min-w-0 flex-1">
-            <div class="text-[10px] font-bold text-blue-800 uppercase tracking-wider">追加到现有数据集</div>
-            <div class="text-sm font-bold text-blue-700 truncate" :title="datasetDisplayName">{{ datasetDisplayName || '当前数据集' }}</div>
-            <div class="text-[10px] text-blue-500 font-mono flex items-center gap-2 mt-0.5 flex-wrap">
-              <span class="bg-blue-100 px-1.5 py-0.5 rounded">#{{ datasetPhysicalName }}</span>
-              <span>ID: {{ datasetId }}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
       <!-- Content Step 1: Input -->
-      <div v-if="step === 1" class="flex-1 p-8 flex flex-col gap-6 overflow-hidden">
-        <div class="flex-1 relative">
+      <div v-if="step === 1" class="flex-1 flex flex-col min-h-0 overflow-hidden">
+        <div class="flex-1 p-5 min-h-0 overflow-hidden">
+        <div class="relative h-full">
            <textarea 
              v-model="ddlText" 
              :disabled="analyzing"
-             class="w-full h-full bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 p-6 font-mono text-sm text-gray-800 resize-none shadow-inner disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors"
+             class="w-full h-full bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 p-5 font-mono text-sm text-gray-800 resize-none shadow-inner disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors"
              placeholder="请在此粘贴 SQL DDL (CREATE TABLE...) 或者业务需求文档...&#10;&#10;示例:&#10;CREATE TABLE orders (id int, user_id int); -- 订单表&#10;CREATE TABLE users (id int, name varchar); -- 用户表&#10;-- 用户表和订单表是一对多关系"
            ></textarea>
-            <div class="absolute top-4 right-4 z-10">
+            <div class="absolute top-3 right-3 z-10">
                <button 
                  @click="showDbImportModal = true"
                  :disabled="analyzing"
@@ -503,17 +455,19 @@ const normalizeType = (rawType: string): string => {
                  从数据库加载 (MySQL/CK)
                </button>
             </div>
-            <div class="absolute bottom-4 right-4 text-xs text-gray-400 flex items-center gap-4">
+            <div class="absolute bottom-3 right-3 text-xs text-gray-400 flex items-center gap-4">
               <span class="font-mono">{{ ddlText.length }} 字符</span>
               <span>支持 SQL, Markdown, 自然语言</span>
             </div>
         </div>
-        <div class="flex justify-between items-center">
-           <!-- Log Button -->
+        </div>
+
+        <!-- Footer Step 1 -->
+        <div class="px-5 py-2.5 border-t border-gray-100 bg-white flex justify-between items-center shrink-0">
            <button 
              v-if="currentTraceId"
              @click="showLogs = true"
-             class="text-xs text-gray-400 hover:text-blue-600 transition-colors flex items-center gap-1.5 px-3 py-2 rounded hover:bg-gray-100"
+             class="text-xs text-gray-400 hover:text-blue-600 transition-colors flex items-center gap-1.5 px-2 py-1 rounded hover:bg-gray-100"
              title="查看执行过程日志"
            >
              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path></svg>
@@ -521,20 +475,18 @@ const normalizeType = (rawType: string): string => {
            </button>
            <div v-else></div>
 
-           <button              @click="handleAnalyze"
+           <button
+              @click="handleAnalyze"
               :disabled="analyzing || !ddlText"
-              class="px-8 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-bold shadow-lg shadow-blue-500/30 transition-all flex items-center gap-3 disabled:opacity-50 disabled:cursor-not-allowed relative overflow-hidden"
+              class="px-5 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-bold shadow-sm transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed relative overflow-hidden min-w-[140px] justify-center"
             >
-              <!-- Progress Background -->
               <div 
                 v-if="analyzing" 
                 class="absolute left-0 top-0 bottom-0 bg-blue-800/50 transition-all duration-300 ease-linear"
                 :style="{ width: `${progress}%` }"
               ></div>
-              
-              <!-- Content -->
-              <div class="relative flex items-center gap-2 z-10 w-full justify-center min-w-[160px]">
-                 <svg v-if="analyzing" class="animate-spin h-5 w-5" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
+              <div class="relative flex items-center gap-2 z-10">
+                 <svg v-if="analyzing" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
                  <span v-if="analyzing" class="text-sm font-light tracking-wide">{{ progressStatus }} ({{ analysisSeconds }}s)</span>
                  <span v-else>开始智能识别</span>
               </div>
@@ -545,69 +497,109 @@ const normalizeType = (rawType: string): string => {
       <!-- Content Step 2: Preview -->
       <div v-else class="flex-1 flex min-h-0 overflow-hidden">
          <!-- Sidebar Navigation -->
-         <div class="w-64 shrink-0 bg-gray-50 border-r border-gray-100 flex flex-col min-h-0 overflow-hidden">
-            <div class="flex-1 min-h-0 overflow-y-auto py-6">
+         <div class="w-60 shrink-0 bg-gray-50 border-r border-gray-100 flex flex-col min-h-0 overflow-hidden">
+            <div class="flex-1 min-h-0 overflow-y-auto py-4">
+            <!-- 数据集信息 -->
+            <div class="px-4 mb-4 space-y-3">
+              <div v-if="!datasetId" class="space-y-3">
+                <div class="flex items-center gap-1.5 text-[10px] text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-2 py-1.5">
+                  <svg class="w-3 h-3 shrink-0 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
+                  <span><strong class="font-bold">虚线框</strong>可编辑</span>
+                </div>
+                <div>
+                  <label class="flex items-center gap-1 text-[10px] font-bold text-gray-500 uppercase tracking-wider mb-1">
+                    <span>数据集 ID</span>
+                    <span class="text-amber-600 normal-case tracking-normal font-semibold">可编辑</span>
+                  </label>
+                  <input
+                    v-model="datasetName"
+                    :class="[EDITABLE_INPUT, 'font-mono text-xs']"
+                    placeholder="e.g. user_orders_ds"
+                  >
+                </div>
+                <div>
+                  <label class="flex items-center gap-1 text-[10px] font-bold text-gray-500 uppercase tracking-wider mb-1">
+                    <span>显示名称</span>
+                    <span class="text-amber-600 normal-case tracking-normal font-semibold">可编辑</span>
+                  </label>
+                  <input
+                    v-model="datasetDisplayName"
+                    :class="[EDITABLE_INPUT, 'text-xs']"
+                    placeholder="e.g. 用户订单数据集"
+                  >
+                </div>
+              </div>
+              <div v-else class="p-2.5 bg-blue-50 border border-blue-100 rounded-lg space-y-1">
+                <div class="text-[10px] font-bold text-blue-800 uppercase tracking-wider">追加到现有数据集</div>
+                <div class="text-xs font-bold text-blue-700 break-words" :title="datasetDisplayName">{{ datasetDisplayName || '当前数据集' }}</div>
+                <div class="text-[10px] text-blue-500 font-mono flex flex-col gap-0.5">
+                  <span class="bg-blue-100 px-1.5 py-0.5 rounded w-fit">#{{ datasetPhysicalName }}</span>
+                  <span>ID: {{ datasetId }}</span>
+                </div>
+              </div>
+            </div>
+
             <div
               v-if="(!datasetId && importDataSourceName) || (datasetId && datasetDataSource)"
-              class="px-6 mb-6"
+              class="px-4 mb-4"
             >
-              <label class="block text-xs font-bold text-gray-400 uppercase tracking-wider mb-2">数据源 ID</label>
-              <div class="p-2.5 rounded-lg bg-emerald-50 border border-emerald-100 text-[11px] text-emerald-700">
+              <label class="block text-[10px] font-bold text-gray-400 uppercase tracking-wider mb-1">数据源 ID</label>
+              <div class="px-2 py-1.5 rounded-lg bg-emerald-50 border border-emerald-100 text-[11px] text-emerald-700">
                 <span class="font-mono font-bold break-all">{{ datasetId ? datasetDataSource : importDataSourceName }}</span>
               </div>
             </div>
 
-            <div class="px-6 mb-4 font-bold text-xs text-gray-400 uppercase tracking-wider">识别结果概览</div>
+            <div class="px-4 mb-2 font-bold text-[10px] text-gray-400 uppercase tracking-wider">识别结果概览</div>
             
-            <div class="space-y-1 px-4 pb-4">
-               <div class="flex justify-between items-center p-2 rounded-lg bg-white border border-gray-200 shadow-sm">
-                  <span class="text-sm font-bold text-gray-700">Tables</span>
+            <div class="space-y-1 px-3 pb-2">
+               <div class="flex justify-between items-center px-2 py-1.5 rounded-lg bg-white border border-gray-200 shadow-sm">
+                  <span class="text-xs font-bold text-gray-700">Tables</span>
                   <span class="text-xs bg-gray-100 px-2 py-0.5 rounded-full text-gray-600">{{ previewData.tables.length }}</span>
                </div>
-               <div class="flex justify-between items-center p-2 rounded-lg bg-white border border-gray-200 shadow-sm">
-                  <span class="text-sm font-bold text-gray-700">Metrics</span>
+               <div class="flex justify-between items-center px-2 py-1.5 rounded-lg bg-white border border-gray-200 shadow-sm">
+                  <span class="text-xs font-bold text-gray-700">Metrics</span>
                   <span class="text-xs bg-gray-100 px-2 py-0.5 rounded-full text-gray-600">{{ previewData.metrics.length }}</span>
                </div>
-               <div class="flex justify-between items-center p-2 rounded-lg bg-white border border-gray-200 shadow-sm">
-                  <span class="text-sm font-bold text-gray-700">Relationships</span>
+               <div class="flex justify-between items-center px-2 py-1.5 rounded-lg bg-white border border-gray-200 shadow-sm">
+                  <span class="text-xs font-bold text-gray-700">Relationships</span>
                   <span class="text-xs bg-gray-100 px-2 py-0.5 rounded-full text-gray-600">{{ previewData.relationships.length }}</span>
                </div>
             </div>
 
             </div>
 
-            <div class="shrink-0 px-6 py-4 border-t border-gray-100 bg-gray-50">
-               <button @click="step = 1" class="w-full py-2 border border-gray-300 rounded-lg text-sm text-gray-600 hover:bg-gray-100">
+            <div class="shrink-0 px-4 py-2.5 border-t border-gray-100 bg-gray-50">
+               <button @click="step = 1" class="w-full py-1.5 border border-gray-300 rounded-lg text-xs text-gray-600 hover:bg-gray-100">
                   ← 返回修改输入
                </button>
             </div>
          </div>
 
          <!-- Main Preview Area -->
-         <div class="flex-1 min-h-0 overflow-y-auto bg-gray-50/50 p-8 space-y-8">
+         <div class="flex-1 min-h-0 overflow-y-auto bg-gray-50/50 p-4 md:p-5 space-y-5">
             
             <!-- Tables Section -->
             <section v-if="previewData.tables.length > 0">
-               <h3 class="text-lg font-bold text-gray-900 mb-1 flex items-center gap-2">
-                 <span class="w-2 h-6 bg-blue-500 rounded-full"></span>
+               <h3 class="text-base font-bold text-gray-900 flex items-center gap-2">
+                 <span class="w-1.5 h-5 bg-blue-500 rounded-full"></span>
                  识别到的表结构
+                 <span class="text-[11px] font-normal text-gray-400">物理表名只读，虚线框可编辑</span>
                </h3>
-               <p class="text-xs text-gray-500 mb-4 ml-4">物理表名只读；业务名称、描述与字段画像在虚线框内可编辑。</p>
-               <div class="grid gap-4">
+               <div class="grid gap-3 mt-2">
                   <div
                     v-for="(table, idx) in previewData.tables"
                     :key="idx"
                     class="bg-white rounded-xl border border-gray-200 shadow-sm group overflow-hidden"
                   >
-                     <div class="p-5">
-                        <div class="flex justify-between items-start gap-3 mb-3">
+                     <div class="p-4">
+                        <div class="flex justify-between items-start gap-2 mb-2">
                            <div class="min-w-0 flex-1">
-                              <div class="flex items-center gap-2 flex-wrap mb-3">
-                                 <span class="px-2 py-1 bg-slate-100 text-slate-600 font-mono text-xs font-bold rounded border border-slate-200">{{ table.physical_name }}</span>
-                                 <span class="text-[10px] text-gray-400">物理表名（只读）</span>
+                              <div class="flex items-center gap-2 flex-wrap mb-2">
+                                 <span class="px-2 py-0.5 bg-slate-100 text-slate-600 font-mono text-xs font-bold rounded border border-slate-200">{{ table.physical_name }}</span>
+                                 <span class="text-[10px] text-gray-400">只读</span>
                               </div>
-                              <div class="rounded-xl border-2 border-dashed border-amber-300/80 bg-amber-50/20 p-4 space-y-3">
-                                 <div class="flex items-center gap-1.5 text-[10px] font-bold text-amber-700 uppercase tracking-wider">
+                              <div class="rounded-lg border-2 border-dashed border-amber-300/80 bg-amber-50/20 p-3 space-y-2">
+                                 <div class="flex items-center gap-1 text-[10px] font-bold text-amber-700 uppercase tracking-wider">
                                     <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/></svg>
                                     可编辑区域
                                  </div>
@@ -673,7 +665,7 @@ const normalizeType = (rawType: string): string => {
                         </div>
                      </div>
 
-                     <div v-if="expandedPreviewTables[idx]" class="border-t border-amber-200/60 p-5 bg-amber-50/10 space-y-3">
+                     <div v-if="expandedPreviewTables[idx]" class="border-t border-amber-200/60 p-3 bg-amber-50/10 space-y-2">
                         <div class="text-xs font-bold text-gray-500 uppercase tracking-wider flex items-center gap-2">
                            <span>字段画像定义 (Columns Profile)</span>
                            <span class="text-gray-300 font-normal">· {{ table.columns.length }} 个字段</span>
@@ -736,12 +728,12 @@ const normalizeType = (rawType: string): string => {
 
             <!-- Metrics Section -->
             <section v-if="previewData.metrics.length > 0">
-               <h3 class="text-lg font-bold text-gray-900 mb-4 flex items-center gap-2">
-                 <span class="w-2 h-6 bg-amber-500 rounded-full"></span>
+               <h3 class="text-base font-bold text-gray-900 mb-2 flex items-center gap-2">
+                 <span class="w-1.5 h-5 bg-amber-500 rounded-full"></span>
                  业务指标 (Metrics)
                </h3>
-               <div class="grid grid-cols-2 gap-4">
-                  <div v-for="(metric, idx) in previewData.metrics" :key="idx" class="bg-white rounded-xl border border-gray-200 p-5 shadow-sm group border-l-4 border-l-amber-400">
+               <div class="grid grid-cols-2 gap-3">
+                  <div v-for="(metric, idx) in previewData.metrics" :key="idx" class="bg-white rounded-xl border border-gray-200 p-4 shadow-sm group border-l-4 border-l-amber-400">
                      <div class="flex justify-between items-start">
                         <div>
                            <div class="flex items-center gap-2 mb-1">
@@ -763,30 +755,30 @@ const normalizeType = (rawType: string): string => {
 
             <!-- Relationships Section -->
             <section v-if="previewData.relationships.length > 0">
-               <h3 class="text-lg font-bold text-gray-900 mb-4 flex items-center gap-2">
-                 <span class="w-2 h-6 bg-purple-500 rounded-full"></span>
+               <h3 class="text-base font-bold text-gray-900 mb-2 flex items-center gap-2">
+                 <span class="w-1.5 h-5 bg-purple-500 rounded-full"></span>
                  实体关系 (Relationships)
                </h3>
                <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
                   <table class="min-w-full text-sm">
                      <thead class="bg-gray-50 text-gray-500 font-medium">
                         <tr>
-                           <th class="px-4 py-3 text-left">Source</th>
-                           <th class="px-4 py-3 text-center">Type</th>
-                           <th class="px-4 py-3 text-left">Target</th>
-                           <th class="px-4 py-3 text-left">Condition</th>
-                           <th class="px-4 py-3"></th>
+                           <th class="px-3 py-2 text-left">Source</th>
+                           <th class="px-3 py-2 text-center">Type</th>
+                           <th class="px-3 py-2 text-left">Target</th>
+                           <th class="px-3 py-2 text-left">Condition</th>
+                           <th class="px-3 py-2"></th>
                         </tr>
                      </thead>
                      <tbody class="divide-y divide-gray-100">
                         <tr v-for="(rel, idx) in previewData.relationships" :key="idx" class="group hover:bg-gray-50">
-                           <td class="px-4 py-3 font-mono text-blue-600 font-bold">{{ rel.source_table }}</td>
-                           <td class="px-4 py-3 text-center">
+                           <td class="px-3 py-2 font-mono text-blue-600 font-bold">{{ rel.source_table }}</td>
+                           <td class="px-3 py-2 text-center">
                               <span class="px-2 py-0.5 bg-purple-50 text-purple-600 rounded text-xs border border-purple-100">{{ rel.type }}</span>
                            </td>
-                           <td class="px-4 py-3 font-mono text-blue-600 font-bold">{{ rel.target_table }}</td>
-                           <td class="px-4 py-3 font-mono text-xs text-gray-500">{{ rel.condition }}</td>
-                           <td class="px-4 py-3 text-right">
+                           <td class="px-3 py-2 font-mono text-blue-600 font-bold">{{ rel.target_table }}</td>
+                           <td class="px-3 py-2 font-mono text-xs text-gray-500">{{ rel.condition }}</td>
+                           <td class="px-3 py-2 text-right">
                               <button @click="removeRel(idx)" class="text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity">
                                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
                               </button>
@@ -806,14 +798,14 @@ const normalizeType = (rawType: string): string => {
       </div>
 
       <!-- Footer Step 2 -->
-      <div v-if="step === 2" class="p-6 border-t border-gray-100 bg-white flex justify-end gap-3">
-         <button @click="handleClose" class="px-6 py-2 border border-gray-300 rounded-xl text-gray-700 font-medium hover:bg-gray-50">取消</button>
+      <div v-if="step === 2" class="px-5 py-2.5 border-t border-gray-100 bg-white flex justify-end gap-2 shrink-0">
+         <button @click="handleClose" class="px-4 py-1.5 text-sm border border-gray-300 rounded-lg text-gray-700 font-medium hover:bg-gray-50">取消</button>
          <button 
             @click="handleSave"
             :disabled="saving || previewData.tables.length === 0"
-            class="px-8 py-2 bg-green-600 hover:bg-green-700 text-white rounded-xl font-bold shadow-lg shadow-green-500/20 transition-all flex items-center gap-2 disabled:opacity-50"
+            class="px-5 py-1.5 text-sm bg-green-600 hover:bg-green-700 text-white rounded-lg font-bold shadow-sm transition-all flex items-center gap-1.5 disabled:opacity-50"
          >
-            <svg v-if="saving" class="animate-spin h-5 w-5" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
+            <svg v-if="saving" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
             {{ saving ? '正在入库...' : '确认并保存' }}
          </button>
       </div>

--- a/frontend/src/views/DataSourceManagement.vue
+++ b/frontend/src/views/DataSourceManagement.vue
@@ -649,6 +649,13 @@ const toggleProfileTag = async (tag: string) => {
   await loadProfilePage()
 }
 
+const clearProfileTag = async () => {
+  if (!selectedProfileTag.value) return
+  selectedProfileTag.value = null
+  profilesPage.value = 1
+  await loadProfilePage()
+}
+
 const availableTags = computed(() => profileStats.value?.tags || [])
 
 const activeProfileTask = computed(() => {
@@ -1330,7 +1337,7 @@ onUnmounted(() => {
             <div v-if="availableTags.length > 0" class="flex flex-wrap items-center gap-1.5 pt-1">
               <span class="text-xs font-bold text-gray-400 mr-1.5 select-none">快速过滤:</span>
               <button
-                @click="selectedProfileTag = null"
+                @click="clearProfileTag"
                 :class="['px-2.5 py-1 rounded-full text-xs font-medium border transition-all cursor-pointer flex items-center gap-1', !selectedProfileTag ? 'bg-primary text-white border-primary shadow-sm shadow-primary/20' : 'bg-gray-100 border-gray-200/50 hover:bg-gray-200/50 text-gray-600']"
               >
                 <span>全部</span>

--- a/frontend/src/views/MetadataDatasets.vue
+++ b/frontend/src/views/MetadataDatasets.vue
@@ -525,15 +525,75 @@ watch(viewMode, (newMode) => {
 
 // Search and Filter
 const searchQuery = ref('')
-const filteredDatasets = computed(() => {
-  if (!searchQuery.value) return datasets.value
-  const q = searchQuery.value.toLowerCase()
-  return datasets.value.filter(ds => 
-    ds.name.toLowerCase().includes(q) || 
-    (ds.display_name && ds.display_name.toLowerCase().includes(q)) ||
-    (ds.description && ds.description.toLowerCase().includes(q))
-  )
+type StatusFilter = 'all' | 'active' | 'inactive'
+type DatasetSortField = 'display_name' | 'status' | 'table_count' | 'rag_sync_status' | 'updated_at'
+type SortDirection = 'asc' | 'desc'
+
+const statusFilter = ref<StatusFilter>('all')
+const sortField = ref<DatasetSortField>('updated_at')
+const sortDirection = ref<SortDirection>('desc')
+
+const toggleSort = (field: DatasetSortField) => {
+  if (sortField.value === field) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortField.value = field
+    sortDirection.value = field === 'display_name' ? 'asc' : 'desc'
+  }
+}
+
+const compareDatasets = (a: Dataset, b: Dataset): number => {
+  const dir = sortDirection.value === 'asc' ? 1 : -1
+
+  switch (sortField.value) {
+    case 'display_name': {
+      const aName = (a.display_name || a.name || '').toLowerCase()
+      const bName = (b.display_name || b.name || '').toLowerCase()
+      return aName.localeCompare(bName, 'zh-CN') * dir
+    }
+    case 'status':
+      return ((a.status ?? 0) - (b.status ?? 0)) * dir
+    case 'table_count': {
+      const tableDiff = (a.table_count || 0) - (b.table_count || 0)
+      if (tableDiff !== 0) return tableDiff * dir
+      return ((a.metric_count || 0) - (b.metric_count || 0)) * dir
+    }
+    case 'rag_sync_status':
+      return ((a.rag_sync_status ?? -99) - (b.rag_sync_status ?? -99)) * dir
+    case 'updated_at': {
+      const aTime = a.updated_at ? new Date(a.updated_at).getTime() : 0
+      const bTime = b.updated_at ? new Date(b.updated_at).getTime() : 0
+      return (aTime - bTime) * dir
+    }
+    default:
+      return 0
+  }
+}
+
+const displayDatasets = computed(() => {
+  let list = datasets.value
+
+  if (statusFilter.value === 'active') {
+    list = list.filter((ds) => ds.status === 1)
+  } else if (statusFilter.value === 'inactive') {
+    list = list.filter((ds) => ds.status !== 1)
+  }
+
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    list = list.filter((ds) =>
+      ds.name.toLowerCase().includes(q) ||
+      (ds.display_name && ds.display_name.toLowerCase().includes(q)) ||
+      (ds.description && ds.description.toLowerCase().includes(q))
+    )
+  }
+
+  return [...list].sort(compareDatasets)
 })
+
+const hasActiveFilters = computed(() =>
+  !!searchQuery.value || statusFilter.value !== 'all'
+)
 
 // Test Retrieval State
 const testQuery = ref('')
@@ -1012,17 +1072,36 @@ onMounted(async () => {
 
     <!-- Toolbar -->
     <div class="flex flex-col sm:flex-row justify-between items-center gap-4 bg-white p-4 rounded-xl border border-gray-100 shadow-sm">
-       <!-- Search -->
-       <div class="relative w-full sm:w-96">
-          <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-gray-400">
-             <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
-          </span>
-          <input 
-            v-model="searchQuery" 
-            type="text" 
-            class="block w-full pl-10 pr-3 py-2 border border-gray-200 rounded-lg leading-5 bg-gray-50 placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary focus:bg-white sm:text-sm transition-all" 
-            placeholder="搜索数据集名称、ID或描述..."
-          >
+       <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 w-full sm:w-auto flex-1">
+         <!-- Search -->
+         <div class="relative w-full sm:w-80">
+            <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-gray-400">
+               <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+            </span>
+            <input 
+              v-model="searchQuery" 
+              type="text" 
+              class="block w-full pl-10 pr-3 py-2 border border-gray-200 rounded-lg leading-5 bg-gray-50 placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary focus:bg-white sm:text-sm transition-all" 
+              placeholder="搜索数据集名称、ID或描述..."
+            >
+         </div>
+
+         <!-- Status Filter -->
+         <select
+           v-model="statusFilter"
+           class="w-full sm:w-36 py-2 px-3 border border-gray-200 rounded-lg bg-gray-50 text-sm text-gray-700 focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary focus:bg-white transition-all"
+         >
+           <option value="all">全部状态</option>
+           <option value="active">已启用</option>
+           <option value="inactive">已禁用</option>
+         </select>
+
+         <div
+           v-if="hasActiveFilters"
+           class="text-xs text-gray-400 whitespace-nowrap px-1"
+         >
+           显示 {{ displayDatasets.length }} / {{ datasets.length }}
+         </div>
        </div>
        
        <!-- View Toggle -->
@@ -1052,10 +1131,26 @@ onMounted(async () => {
       <div v-for="i in 3" :key="i" class="h-32 bg-gray-100 rounded-xl animate-pulse"></div>
     </div>
 
+    <!-- Filtered Empty State -->
+    <div
+      v-else-if="datasets.length > 0 && displayDatasets.length === 0"
+      class="text-center py-20 bg-white rounded-xl border border-dashed border-gray-200"
+    >
+      <div class="text-4xl mb-3">🔍</div>
+      <h3 class="text-lg font-medium text-gray-900">没有匹配的数据集</h3>
+      <p class="text-gray-500 mt-1 mb-5 text-sm">请调整搜索关键词或状态筛选条件后重试。</p>
+      <button
+        @click="searchQuery = ''; statusFilter = 'all'"
+        class="px-4 py-2 text-sm font-medium text-primary hover:bg-primary/5 rounded-lg border border-primary/20 transition-colors"
+      >
+        清除筛选
+      </button>
+    </div>
+
     <!-- Grid View -->
     <div v-else-if="viewMode === 'grid'" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       <div 
-        v-for="ds in filteredDatasets" 
+        v-for="ds in displayDatasets" 
         :key="ds.id"
         class="bg-white rounded-xl shadow-sm border border-gray-100 hover:shadow-xl transition-all duration-300 cursor-pointer group overflow-hidden flex flex-col hover:-translate-y-1 relative"
         @click="goToTables(ds.id)"
@@ -1227,16 +1322,46 @@ onMounted(async () => {
     <!-- List View -->
     <div v-else class="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden">
        <div class="grid grid-cols-12 gap-4 px-6 py-3 bg-gray-50 border-b border-gray-100 text-xs font-bold text-gray-500 uppercase tracking-wider">
-          <div class="col-span-3">数据集 (Dataset)</div>
-          <div class="col-span-2">状态 (Status)</div>
-          <div class="col-span-2">统计 (Stats)</div>
-          <div class="col-span-2">RAG 状态</div>
-          <div class="col-span-1">更新时间</div>
+          <button type="button" class="col-span-3 inline-flex items-center gap-1 text-left hover:text-gray-700 transition-colors" @click="toggleSort('display_name')">
+            <span>数据集 (Dataset)</span>
+            <svg v-if="sortField === 'display_name'" class="w-3.5 h-3.5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path v-if="sortDirection === 'asc'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+              <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <button type="button" class="col-span-2 inline-flex items-center gap-1 text-left hover:text-gray-700 transition-colors" @click="toggleSort('status')">
+            <span>状态 (Status)</span>
+            <svg v-if="sortField === 'status'" class="w-3.5 h-3.5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path v-if="sortDirection === 'asc'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+              <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <button type="button" class="col-span-2 inline-flex items-center gap-1 text-left hover:text-gray-700 transition-colors" @click="toggleSort('table_count')">
+            <span>统计 (Stats)</span>
+            <svg v-if="sortField === 'table_count'" class="w-3.5 h-3.5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path v-if="sortDirection === 'asc'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+              <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <button type="button" class="col-span-2 inline-flex items-center gap-1 text-left hover:text-gray-700 transition-colors" @click="toggleSort('rag_sync_status')">
+            <span>RAG 状态</span>
+            <svg v-if="sortField === 'rag_sync_status'" class="w-3.5 h-3.5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path v-if="sortDirection === 'asc'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+              <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <button type="button" class="col-span-1 inline-flex items-center gap-1 text-left hover:text-gray-700 transition-colors" @click="toggleSort('updated_at')">
+            <span>更新时间</span>
+            <svg v-if="sortField === 'updated_at'" class="w-3.5 h-3.5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path v-if="sortDirection === 'asc'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+              <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
           <div class="col-span-2 text-right">操作</div>
        </div>
        <div class="divide-y divide-gray-100">
           <div 
-             v-for="ds in filteredDatasets" 
+             v-for="ds in displayDatasets" 
              :key="ds.id" 
              class="grid grid-cols-12 gap-4 px-6 py-4 items-center hover:bg-gray-50 transition-colors cursor-pointer group"
              @click="goToTables(ds.id)"

--- a/frontend/src/views/MetadataTables.vue
+++ b/frontend/src/views/MetadataTables.vue
@@ -67,6 +67,11 @@ const handleCreateTable = async () => {
 
 // Search and Filter
 const searchQuery = ref('')
+const expandedTables = ref<Record<string, boolean>>({})
+
+const toggleTableExpand = (tableName: string) => {
+  expandedTables.value[tableName] = !expandedTables.value[tableName]
+}
 const filteredTables = computed(() => {
   if (!searchQuery.value) return tables.value
   const q = searchQuery.value.toLowerCase()
@@ -607,44 +612,94 @@ defineExpose({ fetchMetrics })
             <button v-else @click="showImportModal = true" class="mt-4 text-primary text-sm font-medium hover:underline">立即导入</button>
          </div>
          
-         <div v-for="table in filteredTables" :key="table.physical_name" class="bg-white rounded-xl border border-gray-100 p-5 hover:shadow-md transition-shadow group">
-            <div class="flex justify-between items-start mb-4">
-              <div class="flex-1">
-                <div class="flex items-center gap-2">
-                  <h3 class="font-bold text-gray-900 group-hover:text-primary transition-colors">{{ table.physical_name }}</h3>
-                  <span class="text-[10px] font-bold text-gray-400 px-1.5 py-0.5 bg-gray-50 rounded border border-gray-100 uppercase tracking-wider">{{ table.term || '未命名' }}</span>
+         <div v-for="table in filteredTables" :key="table.physical_name" class="bg-white rounded-xl border border-gray-100 overflow-hidden hover:shadow-md transition-shadow group">
+            <div class="p-5">
+              <div class="flex justify-between items-start mb-3 gap-3">
+                <div class="flex-1 min-w-0 cursor-pointer" @click="toggleTableExpand(table.physical_name)">
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <h3 class="font-bold text-gray-900 group-hover:text-primary transition-colors font-mono">{{ table.physical_name }}</h3>
+                    <span class="text-[10px] font-bold text-gray-500 px-1.5 py-0.5 bg-gray-50 rounded border border-gray-100">{{ table.term || '未命名' }}</span>
+                  </div>
+                  <p class="text-xs text-gray-500 mt-2 leading-relaxed line-clamp-2">{{ table.description || '暂无描述' }}</p>
                 </div>
-                <p class="text-xs text-gray-500 mt-1 line-clamp-1">{{ table.description || '暂无描述' }}</p>
+                <div class="flex items-center gap-1 shrink-0">
+                  <button
+                    type="button"
+                    class="text-gray-400 hover:text-gray-600 p-1.5 rounded-md hover:bg-gray-50 transition-all"
+                    :class="expandedTables[table.physical_name] ? 'rotate-90' : ''"
+                    @click="toggleTableExpand(table.physical_name)"
+                    title="展开字段画像"
+                  >
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>
+                  </button>
+                  <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity" v-if="hasPermission('element:metadata:edit_table')">
+                    <button 
+                      @click.stop="openEditModal(table)"
+                      class="text-gray-400 hover:text-primary transition-colors p-1.5 hover:bg-gray-100 rounded-md"
+                      title="编辑表结构"
+                    >
+                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
+                    </button>
+                    <button 
+                      v-if="hasPermission('element:metadata:delete_table')"
+                      @click.stop="handleDeleteTable(table.physical_name)"
+                      class="text-gray-400 hover:text-red-500 transition-colors p-1.5 hover:bg-gray-100 rounded-md"
+                      title="删除表"
+                    >
+                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+                    </button>
+                  </div>
+                </div>
               </div>
-              <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity" v-if="hasPermission('element:metadata:edit_table')">
-                <button 
-                  @click.stop="openEditModal(table)"
-                  class="text-gray-400 hover:text-primary transition-colors p-1.5 hover:bg-gray-100 rounded-md"
-                  title="编辑表结构"
+              
+              <div v-if="!expandedTables[table.physical_name]" class="flex flex-wrap gap-1.5">
+                <div v-for="col in table.columns.slice(0, 10)" :key="col.physical_name" class="flex items-center gap-1 px-2 py-0.5 bg-slate-50 border border-slate-100 rounded-md text-[10px] font-mono group/col">
+                  <span class="text-amber-500" v-if="col.is_primary" title="Primary Key">🔑</span>
+                  <span class="text-slate-600 font-bold">{{ col.physical_name }}</span>
+                  <span class="text-slate-300">/</span>
+                  <span class="text-blue-500">{{ col.term || '?' }}</span>
+                </div>
+                <div v-if="table.columns.length > 10" class="px-2 py-0.5 bg-gray-50 border border-gray-100 rounded-md text-[10px] text-gray-400 font-medium">
+                  +{{ table.columns.length - 10 }} 更多字段
+                </div>
+                <button
+                  v-if="table.columns.length > 0"
+                  type="button"
+                  @click="toggleTableExpand(table.physical_name)"
+                  class="px-2 py-0.5 text-[10px] text-blue-500 hover:bg-blue-50 rounded-md border border-transparent hover:border-blue-100 transition-colors"
                 >
-                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
-                </button>
-                <button 
-                  v-if="hasPermission('element:metadata:delete_table')"
-                  @click.stop="handleDeleteTable(table.physical_name)"
-                  class="text-gray-400 hover:text-red-500 transition-colors p-1.5 hover:bg-gray-100 rounded-md"
-                  title="删除表"
-                >
-                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+                  展开字段画像
                 </button>
               </div>
             </div>
-            
-            <!-- Columns Minimal View -->
-            <div class="flex flex-wrap gap-1.5">
-              <div v-for="col in table.columns.slice(0, 10)" :key="col.physical_name" class="flex items-center gap-1 px-2 py-0.5 bg-slate-50 border border-slate-100 rounded-md text-[10px] font-mono group/col">
-                <span class="text-amber-500" v-if="col.is_primary" title="Primary Key">🔑</span>
-                <span class="text-slate-600 font-bold">{{ col.physical_name }}</span>
-                <span class="text-slate-300">/</span>
-                <span class="text-blue-500">{{ col.term || '?' }}</span>
+
+            <div v-if="expandedTables[table.physical_name]" class="border-t border-gray-100 p-5 bg-gray-50/30">
+              <div class="text-xs font-bold text-gray-400 uppercase tracking-wider mb-3">
+                字段画像定义 (Columns Profile)
+                <span class="text-gray-300 font-normal ml-1">· {{ table.columns.length }} 个字段</span>
               </div>
-              <div v-if="table.columns.length > 10" class="px-2 py-0.5 bg-gray-50 border border-gray-100 rounded-md text-[10px] text-gray-400 font-medium">
-                +{{ table.columns.length - 10 }} more columns
+              <div class="border border-gray-100 rounded-xl overflow-hidden bg-white">
+                <table class="w-full text-left border-collapse text-xs">
+                  <thead>
+                    <tr class="bg-gray-50 border-b border-gray-100 text-gray-400 font-bold uppercase">
+                      <th class="px-4 py-2 border-r border-gray-100 w-[22%]">物理字段</th>
+                      <th class="px-4 py-2 border-r border-gray-100 w-[12%]">类型</th>
+                      <th class="px-4 py-2 border-r border-gray-100 w-[20%]">业务术语/中文名</th>
+                      <th class="px-4 py-2">业务含义说明</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-gray-100 text-gray-700">
+                    <tr v-for="col in table.columns" :key="col.physical_name" class="hover:bg-gray-50">
+                      <td class="px-4 py-2 border-r border-gray-100 font-mono font-bold">
+                        <span v-if="col.is_primary" class="text-amber-500 mr-1" title="Primary Key">🔑</span>
+                        {{ col.physical_name }}
+                      </td>
+                      <td class="px-4 py-2 border-r border-gray-100 text-gray-500">{{ col.type || '-' }}</td>
+                      <td class="px-4 py-2 border-r border-gray-100 text-primary font-medium">{{ col.term || '-' }}</td>
+                      <td class="px-4 py-2 text-gray-500 leading-normal">{{ col.description || '-' }}</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
          </div>
@@ -1117,6 +1172,7 @@ defineExpose({ fetchMetrics })
       :dataset-id="datasetId"
       :dataset-display-name="dataset?.display_name"
       :dataset-physical-name="dataset?.name"
+      :dataset-data-source="dataset?.data_source"
       :imported-table-names="tables.map((t) => t.physical_name)"
       @close="showImportModal = false"
       @saved="fetchDatasetInfo"


### PR DESCRIPTION

# Pull Request: 智能导入绑定数据源、画像式展示与弹窗布局优化

## 概要 (Overview)

本 PR 完善智能元数据导入的数据源绑定与追加导入流程，将摸排画像、预览确认、数据表列表统一为卡片 + 可展开字段画像展示；数据集列表增加状态筛选与表头排序；修复标签筛选计数 bug；并对智能导入向导、数据库 DDL 导入弹窗做布局紧凑化与数据源验证流程优化。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)
- [x] **智能导入绑定数据源**：新建数据集时写入所选数据源 `name`；从数据库加载时记录 `importDataSourceName`
- [x] **追加导入锁定数据源**：传入 `lockedDataSourceName` 后跳过选源步骤，自动加载表列表；侧边栏/顶栏展示锁定信息
- [x] **画像式展示对齐**：`DatabaseImportModal` 摸排 Tab、`MetadataTables` 表列表、`SmartImportWizard` 预览页统一为卡片 + 可展开字段画像（懒加载详情）
- [x] **预览页默认可展开**：进入预览自动展开所有表字段画像
- [x] **数据集列表增强**：支持全部/已启用/已禁用状态筛选；列表视图表头可排序（名称、状态、统计、RAG、更新时间）
- [x] **数据源验证流程合并**：选源步骤将「测试连接」与「下一步」合并为「测试并继续」，验证通过后自动进入表列表

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)
- [x] **预览页布局重构**：数据集 ID / 显示名称移入左侧边栏；数据源 ID、识别概览、返回按钮同列展示，主内容区专注表结构编辑
- [x] **可编辑区域强化**：琥珀色虚线框 + 提示条，物理表名只读标签，业务名称/描述/字段画像可编辑区分清晰
- [x] **弹窗紧凑化**：智能导入向导宽度 `max-w-6xl` → `max-w-5xl`，避免叠层时后窗从遮罩边缘露出；各区域 padding、footer 按钮统一收紧
- [x] **数据库导入弹窗**：锁定数据源提示改为单行横条；底部按钮区紧凑；选中卡片展示「验证中 / 已连接 / 连接失败」状态
- [x] **第一步操作栏**：智能导入「开始智能识别」移入独立 footer，与预览步样式一致

### 3. 🐞 关键修复 (Bug Fixes)
- [x] **标签筛选计数**：点「非业务表」等标签后「全部」徽章不再错误变为 11；点「全部」时清空标签并重新加载列表（`clearProfileTag`）
- [x] **预览页滚动**：侧边栏统一滚动，描述 textarea 按长度自适应行数

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `e32fd37` | 智能导入绑定数据源；画像卡片与可展开字段；数据集状态筛选与表头排序；修复标签「全部」计数 bug |
| `f57237f` | 预览页布局调整、默认可展开字段、琥珀虚线框可编辑提示、侧边栏滚动修复 |
| `d2ebcbb` | 预览页数据集信息移入侧栏并紧凑化；弹窗宽度收窄；数据库导入合并测试与继续、锁定提示与 footer 紧凑化 |

**涉及文件（5）：**

| 文件 | 变更概要 |
| :--- | :--- |
| `SmartImportWizard.vue` | 数据源保存、预览布局、侧栏信息、可编辑样式、紧凑化 |
| `DatabaseImportModal.vue` | 数据源锁定、画像卡片、标签计数修复、验证流程合并、布局紧凑 |
| `MetadataDatasets.vue` | 状态筛选、表头排序 |
| `MetadataTables.vue` | 可展开字段画像 |
| `DataSourceManagement.vue` | `clearProfileTag` 修复 |

---

## 测试覆盖 (Testing)
- [ ] **UI 兼容性**: 已验证不同浏览器下的展示效果。
- [ ] **核心功能**: 关键业务流程已通过手动或自动化测试。
- [ ] **回归测试**: 确认未引入已知回归错误。

> [!IMPORTANT]
> 提交前请务必确认已更新 `tests/CHECKLIST.md` 中的自动化测试清单。

**建议手动验证：**

1. **新建智能导入**：从数据库选源 → 识别 → 预览 → 保存，确认数据集 `data_source` 正确写入
2. **追加导入**：在已有数据集点智能导入，确认跳过选源、锁定当前数据源、只能选该源下的表
3. **摸排标签**：切换「非业务表」等标签后点「全部」，确认计数恢复为摸排成功总数、列表正确刷新
4. **预览页**：确认侧栏数据集 ID/名称可编辑、表字段默认展开、footer 紧凑
5. **数据库导入弹窗**：选数据源后点「测试并继续」，确认一次完成验证并进入表列表；叠层时后窗不露出
6. **数据集列表**：状态筛选、各列排序、无结果空状态

---

## 其他备注 (Notes)

- 数据集 `data_source` 存的是数据源配置的 **name** 字符串，非数字 ID
- 无后端 API 变更，纯前端改动
- 合并后需本地 `./dev.sh` 重新编译前端验证

