### PR TITLE
feat: 管理页顶栏优化 + 智能体自定义 Skills 白名单

### DIFF
--- a/app/api/portal/endpoints/agents.py
+++ b/app/api/portal/endpoints/agents.py
@@ -79,7 +79,10 @@ async def list_agent_versions(agent_id: str, session: AsyncSession = Depends(get
 @router.post("/{agent_id}/versions", response_model=AIAgentVersionResponse)
 async def create_agent_version(agent_id: str, data: AIAgentVersionBase, session: AsyncSession = Depends(get_db_session), user: Dict[str, Any] = Depends(get_current_user)):
     """为智能体创建新版本 (默认 DRAFT)"""
-    version = await AgentManagerService.create_agent_version(session, agent_id, data, user=user)
+    try:
+        version = await AgentManagerService.create_agent_version(session, agent_id, data, user=user)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not version:
         raise HTTPException(status_code=403, detail="Forbidden: You can only add versions to your own agents")
     return version
@@ -87,7 +90,10 @@ async def create_agent_version(agent_id: str, data: AIAgentVersionBase, session:
 @router.put("/{agent_id}/versions/{version_id}", response_model=AIAgentVersionResponse)
 async def update_agent_version(agent_id: str, version_id: str, data: AIAgentVersionBase, session: AsyncSession = Depends(get_db_session), user: Dict[str, Any] = Depends(get_current_user)):
     """更新现有的草稿版本 (仅限 DRAFT 状态)"""
-    version = await AgentManagerService.update_agent_version(session, agent_id, version_id, data, user=user)
+    try:
+        version = await AgentManagerService.update_agent_version(session, agent_id, version_id, data, user=user)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not version:
         raise HTTPException(status_code=403, detail="Forbidden: Version not found, not a DRAFT, or missing permissions")
     return version

--- a/app/core/context.py
+++ b/app/core/context.py
@@ -54,6 +54,10 @@ class AgentContext(BaseModel):
     # Runtime tool approval (inherited by sub_agent_call delegation)
     permission_options: Dict[str, Any] = Field(default_factory=dict)
 
+    # Agent-level custom Skills allowlist (from published ChatConfig)
+    skills_custom: bool = False
+    skills: List[str] = Field(default_factory=list)
+
     # Queue for streaming sub-agent log/progress chunks back to client
     event_queue: Optional[Any] = None
 

--- a/app/models/agent.py
+++ b/app/models/agent.py
@@ -37,6 +37,8 @@ class AIAgentVersion(Base):
     synthesis_temperature = Column(Float, nullable=True)
     system_prompt = Column(Text, nullable=False)
     tools = Column(JSON) # List of tool names ["tool1", "tool2"]
+    skills_custom = Column(Boolean, default=False, nullable=False)  # 是否自定义公共 Skills
+    skills = Column(JSON)  # 自定义公共技能 ID 列表 ["skill-id", ...]
     status = Column(String(20), default="DRAFT") # DRAFT, PUBLISHED, ARCHIVED
     comment = Column(String(255))
     created_at = Column(DateTime, default=datetime.now)

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, model_validator, field_validator
 from typing import Optional, Dict, Any, List, Union
 from datetime import datetime
 
@@ -21,8 +21,31 @@ class AIAgentVersionBase(BaseModel):
     synthesis_temperature: Optional[float] = None # NEW: Separate synthesizer temp
     system_prompt: str
     tools: List[Union[str, ToolConfigItem]] = Field(default_factory=list)
+    skills_custom: bool = False
+    skills: List[str] = Field(default_factory=list)
     status: str = "DRAFT"
     comment: Optional[str] = None
+
+    @field_validator("skills", mode="before")
+    @classmethod
+    def coerce_skills_list(cls, value):
+        # DB 历史行 skills 可能为 NULL；from_attributes 时需归一成 []
+        if value is None:
+            return []
+        return value
+
+    @field_validator("skills_custom", mode="before")
+    @classmethod
+    def coerce_skills_custom(cls, value):
+        if value is None:
+            return False
+        return bool(value)
+
+    @model_validator(mode="after")
+    def normalize_skills_when_not_custom(self):
+        if not self.skills_custom:
+            self.skills = []
+        return self
 
 class AIAgentVersionResponse(AIAgentVersionBase):
     id: str
@@ -78,6 +101,8 @@ class ChatConfig(BaseModel):
     synthesis_temperature: Optional[float] = None
     system_prompt: str
     tools: List[Union[str, ToolConfigItem]]
+    skills_custom: bool = False
+    skills: List[str] = Field(default_factory=list)
     capabilities: List[str] = Field(default_factory=list)
     engine_type: str = "LOCAL"
     engine_config: Optional[Dict[str, Any]] = None

--- a/app/services/ai/agent_manager.py
+++ b/app/services/ai/agent_manager.py
@@ -91,6 +91,8 @@ class AgentManagerService:
                 synthesis_temperature=version.synthesis_temperature,
                 system_prompt=version.system_prompt,
                 tools=tools_list or [],
+                skills_custom=bool(getattr(version, "skills_custom", False)),
+                skills=AgentManagerService._normalize_skills_list(getattr(version, "skills", None)),
                 capabilities=agent.capabilities or [],
                 engine_type=agent.engine_type,
                 engine_config=agent.engine_config
@@ -134,6 +136,8 @@ class AgentManagerService:
                     synthesis_temperature=version.synthesis_temperature,
                     system_prompt=version.system_prompt,
                     tools=tools_list or [],
+                    skills_custom=bool(getattr(version, "skills_custom", False)),
+                    skills=AgentManagerService._normalize_skills_list(getattr(version, "skills", None)),
                     capabilities=version.agent.capabilities or [],
                     engine_type=version.agent.engine_type,
                     engine_config=version.agent.engine_config
@@ -441,6 +445,30 @@ class AgentManagerService:
         return normalized
 
     @staticmethod
+    def _normalize_skills_list(skills: Any) -> List[str]:
+        """Normalize skills JSON (list/str) into a clean list of skill ids."""
+        if not skills:
+            return []
+        if isinstance(skills, str):
+            try:
+                skills = json.loads(skills)
+            except Exception:
+                return []
+        if not isinstance(skills, list):
+            return []
+        result: List[str] = []
+        for item in skills:
+            skill_id = str(item or "").strip()
+            if skill_id and skill_id not in result:
+                result.append(skill_id)
+        return result
+
+    @staticmethod
+    def _validate_skills_config(skills_custom: bool, skills: List[str]) -> None:
+        if skills_custom and not skills:
+            raise ValueError("自定义 Skills 开启时至少选择一个公共技能")
+
+    @staticmethod
     async def create_agent_version(session: AsyncSession, agent_id: str, data: AIAgentVersionBase, user: Any = None) -> Optional[AIAgentVersion]:
         """Create a new version for an agent (checks ownership)"""
         agent = await session.get(AIAgent, agent_id)
@@ -458,12 +486,16 @@ class AgentManagerService:
         if not is_admin and agent.created_by and agent.created_by != username:
             return None # Forbidden
 
+        skills_custom = bool(getattr(data, "skills_custom", False))
+        skills_list = AgentManagerService._normalize_skills_list(getattr(data, "skills", None)) if skills_custom else []
+        AgentManagerService._validate_skills_config(skills_custom, skills_list)
+
         # Determine next version number
         query = select(AIAgentVersion.version_number).where(AIAgentVersion.agent_id == agent_id).order_by(AIAgentVersion.version_number.desc()).limit(1)
         prev_result = await session.execute(query)
         prev_v = prev_result.scalar_one_or_none()
         next_v = (prev_v or 0) + 1
-        
+
         version = AIAgentVersion(
             id=str(uuid.uuid4()),
             agent_id=agent_id,
@@ -474,6 +506,8 @@ class AgentManagerService:
             synthesis_temperature=data.synthesis_temperature,
             system_prompt=data.system_prompt,
             tools=AgentManagerService._normalize_tools_for_db(data.tools),
+            skills_custom=skills_custom,
+            skills=skills_list,
             status="DRAFT",
             comment=data.comment
         )
@@ -510,6 +544,14 @@ class AgentManagerService:
         if not is_admin and agent.created_by and agent.created_by != username:
             return None # Forbidden
 
+        skills_custom = bool(getattr(data, "skills_custom", False))
+        skills_list = (
+            AgentManagerService._normalize_skills_list(getattr(data, "skills", None))
+            if skills_custom
+            else []
+        )
+        AgentManagerService._validate_skills_config(skills_custom, skills_list)
+
         # Update fields
         version.model_name = data.model_name or version.model_name
         version.temperature = data.temperature if data.temperature is not None else version.temperature
@@ -517,6 +559,8 @@ class AgentManagerService:
         version.synthesis_temperature = data.synthesis_temperature
         version.system_prompt = data.system_prompt
         version.tools = AgentManagerService._normalize_tools_for_db(data.tools)
+        version.skills_custom = skills_custom
+        version.skills = skills_list
         version.comment = data.comment or version.comment
         
         await session.commit()

--- a/app/services/ai/agent_service.py
+++ b/app/services/ai/agent_service.py
@@ -653,9 +653,15 @@ class AgentService:
                 from app.services.ai.skill_resolver import (
                     load_skill_md_content,
                     resolve_skills_from_query,
+                    skill_filter_kwargs_from_config,
                 )
 
-                for skill_meta in resolve_skills_from_query(user_query, user_info=user_info):
+                skill_filter = skill_filter_kwargs_from_config(agent_config)
+                for skill_meta in resolve_skills_from_query(
+                    user_query,
+                    user_info=user_info,
+                    **skill_filter,
+                ):
                     skill_id = skill_meta.get("id")
                     if not skill_id or skill_id in mounted_skill_ids:
                         continue
@@ -707,10 +713,12 @@ class AgentService:
                     load_skill_md_content,
                     scan_relevant_skills,
                     should_scan_skills_for_query,
+                    skill_filter_kwargs_from_config,
                 )
                 from app.services.config_service import ConfigService
 
                 if is_main_general_agent(agent_config):
+                    skill_filter = skill_filter_kwargs_from_config(agent_config)
                     scan_enabled_raw = await ConfigService.get("skill_auto_scan_enabled", "true")
                     scan_enabled = str(scan_enabled_raw or "true").strip().lower() in {
                         "1", "true", "yes", "on",
@@ -736,8 +744,12 @@ class AgentService:
                                 exclude_ids=mounted_skill_ids,
                                 max_results=max_scan_results,
                                 min_score=min_score,
+                                **skill_filter,
                             )
-                        available_skills = list_skill_metas()
+                        available_skills = list_skill_metas(
+                            user_info=user_info,
+                            **skill_filter,
+                        )
                         scanned_skills = self._ensure_first_turn_superpowers_candidate(
                             scanned_skills=scanned_skills,
                             available_skills=available_skills,

--- a/app/services/ai/context_manager.py
+++ b/app/services/ai/context_manager.py
@@ -277,5 +277,7 @@ class AgentContextManager:
             user_dimensions=user_dims,
             authorized_attachment_paths=list(authorized_attachment_paths or []),
             current_turn_attachment_paths=list(current_turn_attachment_paths or []),
-            trace_buffer=trace_buffer or []
+            trace_buffer=trace_buffer or [],
+            skills_custom=bool(getattr(config, "skills_custom", False)),
+            skills=list(getattr(config, "skills", None) or []),
         ))

--- a/app/services/ai/executors/base.py
+++ b/app/services/ai/executors/base.py
@@ -109,6 +109,8 @@ class BaseExecutor(ABC):
         identity = self._user_identity_from_info()
         if ctx is not None:
             self._apply_user_identity_to_context(ctx, identity)
+            ctx.skills_custom = bool(getattr(self.config, "skills_custom", False))
+            ctx.skills = list(getattr(self.config, "skills", None) or [])
             return ctx
 
         from app.services.ai.knowledge_utils import merge_dataset_id_sources
@@ -134,6 +136,8 @@ class BaseExecutor(ABC):
             trace_buffer=self.trace_buffer or [],
             delegation_depth=0,
             permission_options=dict(self.permission_options or {}),
+            skills_custom=bool(getattr(self.config, "skills_custom", False)),
+            skills=list(getattr(self.config, "skills", None) or []),
         )
         set_agent_context(ctx)
         return ctx

--- a/app/services/ai/runners/assistant_agent_runner.py
+++ b/app/services/ai/runners/assistant_agent_runner.py
@@ -1176,6 +1176,8 @@ class AssistantAgentRunner(BaseExecutor):
             user_name=self._runtime_user_name(),
             user_info=self.user_info,
             conversation_id=self.conversation_id,
+            skills_custom=bool(getattr(self.config, "skills_custom", False)),
+            allowed_global_skills=list(getattr(self.config, "skills", None) or []),
         )
         # 仅挂载 agent 后端配置的工具；workspace 只作 offloader，不自动注入 Grep/Read/Bash 等内置工具。
         toolkit = build_toolkit(

--- a/app/services/ai/runners/chatbi/agent_builder.py
+++ b/app/services/ai/runners/chatbi/agent_builder.py
@@ -49,6 +49,8 @@ async def build_native_agent(
         user_name=runner._runtime_user_name(),
         user_info=runner.user_info,
         conversation_id=runner.conversation_id,
+        skills_custom=bool(getattr(runner.config, "skills_custom", False)),
+        allowed_global_skills=list(getattr(runner.config, "skills", None) or []),
     )
     context_config = await dar.load_context_config()
     model_config = await dar.build_model_config(

--- a/app/services/ai/runtime/agentscope/workspace.py
+++ b/app/services/ai/runtime/agentscope/workspace.py
@@ -97,8 +97,15 @@ def default_workspace_root() -> str:
 
 def discover_platform_skill_paths(
     user_info: dict[str, Any] | None = None,
+    *,
+    skills_custom: bool = False,
+    allowed_global_skills: list[str] | None = None,
 ) -> list[str]:
-    """Collect skill directories: global platform skills + user personal skills."""
+    """Collect skill directories: global platform skills + user personal skills.
+
+    When skills_custom is True, only allowlisted global skill ids are included;
+    personal skills are always appended (if enabled).
+    """
     try:
         from app.core.config import settings
 
@@ -108,11 +115,17 @@ def discover_platform_skill_paths(
     if not skills_root or not os.path.isdir(skills_root):
         return []
 
+    allowlist: set[str] | None = None
+    if skills_custom:
+        allowlist = {str(s).strip() for s in (allowed_global_skills or []) if str(s).strip()}
+
     paths: list[str] = []
     from app.utils.skill_metadata import parse_skill_frontmatter
     for entry in sorted(os.listdir(skills_root)):
         skill_dir = os.path.join(skills_root, entry)
         if os.path.isdir(skill_dir) and os.path.isfile(os.path.join(skill_dir, "SKILL.md")):
+            if allowlist is not None and entry not in allowlist:
+                continue
             # 过滤禁用的技能
             meta = parse_skill_frontmatter(entry, os.path.join(skill_dir, "SKILL.md"))
             if meta.get("enabled", "true") == "false":
@@ -269,6 +282,8 @@ async def get_local_workspace(
     conversation_id: str | None,
     user_name: str | None = None,
     user_info: dict[str, Any] | None = None,
+    skills_custom: bool = False,
+    allowed_global_skills: list[str] | None = None,
 ) -> Any | None:
     """Return an initialized LocalWorkspace for the conversation."""
     if not conversation_id:
@@ -283,7 +298,13 @@ async def get_local_workspace(
         conversation_id=conversation_id,
     )
     os.makedirs(workdir, exist_ok=True)
-    cached = _workspace_cache.get(workdir)
+    skills_fp = (
+        f"custom:{','.join(sorted(str(s) for s in (allowed_global_skills or []) if str(s).strip()))}"
+        if skills_custom
+        else "all"
+    )
+    cache_key = f"{workdir}::{skills_fp}"
+    cached = _workspace_cache.get(cache_key)
     if cached is not None:
         return cached
 
@@ -295,7 +316,11 @@ async def get_local_workspace(
 
     workspace = LocalWorkspace(
         workdir=workdir,
-        skill_paths=discover_platform_skill_paths(user_info=user_info),
+        skill_paths=discover_platform_skill_paths(
+            user_info=user_info,
+            skills_custom=skills_custom,
+            allowed_global_skills=allowed_global_skills,
+        ),
     )
     try:
         await workspace.initialize()
@@ -303,7 +328,7 @@ async def get_local_workspace(
         logger.warning("[workspace] Failed to initialize LocalWorkspace workdir=%s: %s", workdir, exc)
         return None
 
-    _workspace_cache[workdir] = workspace
+    _workspace_cache[cache_key] = workspace
     return workspace
 
 
@@ -313,6 +338,8 @@ async def get_local_workspace_offloader(
     conversation_id: str | None,
     user_name: str | None = None,
     user_info: dict[str, Any] | None = None,
+    skills_custom: bool = False,
+    allowed_global_skills: list[str] | None = None,
 ) -> Any | None:
     """Backward-compatible alias for get_local_workspace."""
     return await get_local_workspace(
@@ -320,6 +347,8 @@ async def get_local_workspace_offloader(
         conversation_id=conversation_id,
         user_name=user_name,
         user_info=user_info,
+        skills_custom=skills_custom,
+        allowed_global_skills=allowed_global_skills,
     )
 
 
@@ -340,6 +369,10 @@ async def delete_workspace_for_session(
         conversation_id=conversation_id,
     )
     _workspace_cache.pop(workdir, None)
+    prefix = f"{workdir}::"
+    for key in list(_workspace_cache.keys()):
+        if key == workdir or (isinstance(key, str) and key.startswith(prefix)):
+            _workspace_cache.pop(key, None)
     if not os.path.isdir(workdir):
         return
     try:

--- a/app/services/ai/skill_resolver.py
+++ b/app/services/ai/skill_resolver.py
@@ -89,11 +89,19 @@ def _scan_skill_dir(skills_dir: str, scope: str) -> List[Dict[str, str]]:
     return metas
 
 
-def list_skill_metas(user_info: Optional[Dict[str, Any]] = None) -> List[Dict[str, str]]:
+def list_skill_metas(
+    user_info: Optional[Dict[str, Any]] = None,
+    *,
+    skills_custom: bool = False,
+    allowed_global_skills: Optional[List[str]] = None,
+) -> List[Dict[str, str]]:
     """扫描技能目录，返回 id/name/description/scope 摘要列表。
 
     合并顺序：全局平台技能（scope=global）+ 当前用户个人技能（scope=personal）。
     若 ID 冲突，个人技能优先覆盖全局同 ID 技能。
+
+    skills_custom=True 时，全局技能仅保留 allowed_global_skills 白名单中的项；
+    个人技能始终合并。
     """
     try:
         from app.core.config import settings
@@ -103,6 +111,9 @@ def list_skill_metas(user_info: Optional[Dict[str, Any]] = None) -> List[Dict[st
         return []
 
     global_metas = _scan_skill_dir(skills_dir, SCOPE_GLOBAL)
+    if skills_custom:
+        allowlist = {str(s).strip() for s in (allowed_global_skills or []) if str(s).strip()}
+        global_metas = [m for m in global_metas if m.get("id") in allowlist]
 
     personal_metas: List[Dict[str, str]] = []
     personal_dir = get_user_personal_skills_dir(user_info)
@@ -115,6 +126,24 @@ def list_skill_metas(user_info: Optional[Dict[str, Any]] = None) -> List[Dict[st
         merged[m["id"]] = m
 
     return list(merged.values())
+
+
+def skill_filter_kwargs_from_config(agent_config: Any = None) -> Dict[str, Any]:
+    """从 ChatConfig / dict 提取 skills 过滤参数。"""
+    if agent_config is None:
+        return {"skills_custom": False, "allowed_global_skills": None}
+    if isinstance(agent_config, dict):
+        skills_custom = bool(agent_config.get("skills_custom") or False)
+        skills = agent_config.get("skills") or []
+    else:
+        skills_custom = bool(getattr(agent_config, "skills_custom", False) or False)
+        skills = getattr(agent_config, "skills", None) or []
+    if not isinstance(skills, list):
+        skills = []
+    return {
+        "skills_custom": skills_custom,
+        "allowed_global_skills": [str(s).strip() for s in skills if str(s).strip()],
+    }
 
 
 def load_skill_md_content(skill_id: str, max_bytes: int = 262144) -> Optional[str]:
@@ -271,6 +300,8 @@ def scan_relevant_skills(
     exclude_ids: Optional[Set[str]] = None,
     max_results: int = 1,
     min_score: float = 0.45,
+    skills_custom: bool = False,
+    allowed_global_skills: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """扫描技能库，按关键词相关度返回候选技能（流程化自动匹配，非语义向量）。
 
@@ -281,7 +312,11 @@ def scan_relevant_skills(
     if not query or not should_scan_skills_for_query(query):
         return []
 
-    metas = list_skill_metas(user_info=user_info)
+    metas = list_skill_metas(
+        user_info=user_info,
+        skills_custom=skills_custom,
+        allowed_global_skills=allowed_global_skills,
+    )
     if not metas:
         return []
 
@@ -318,6 +353,8 @@ def resolve_skills_from_query(
     *,
     user_info: Optional[Dict[str, Any]] = None,
     max_results: int = 2,
+    skills_custom: bool = False,
+    allowed_global_skills: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """从用户问题中解析技能引用并按 name/id 匹配可用技能。
 
@@ -331,7 +368,11 @@ def resolve_skills_from_query(
     if not hints and not any(token in query.lower() for token in ("技能", "skill")):
         return []
 
-    metas = list_skill_metas(user_info=user_info)
+    metas = list_skill_metas(
+        user_info=user_info,
+        skills_custom=skills_custom,
+        allowed_global_skills=allowed_global_skills,
+    )
     if not metas:
         return []
 

--- a/app/services/ai/tools/agent_delegate_tool.py
+++ b/app/services/ai/tools/agent_delegate_tool.py
@@ -352,6 +352,8 @@ async def sub_agent_call(agent_name: str, query: str) -> str:
         # 共享主 runner 的事实取证账本，使子智能体工具调用产生的取证凭证回流到主链路。
         # 依赖顺序：主 runner._execute_raw 在调用本工具前必须已完成 ctx.grounding_evidence_ledger 初始化。
         grounding_evidence_ledger=main_ctx.grounding_evidence_ledger,
+        skills_custom=bool(getattr(target_config, "skills_custom", False)),
+        skills=list(getattr(target_config, "skills", None) or []),
     )
     if main_ctx.grounding_evidence_ledger is None:
         import logging as _logging

--- a/app/services/ai/tools/system_executive_tools.py
+++ b/app/services/ai/tools/system_executive_tools.py
@@ -145,31 +145,38 @@ def _is_forbidden_shell_command(command: str) -> str | None:
 @tool
 def list_available_skills() -> str:
     """
-    列出当前平台技能库中可用的技能摘要，供智能体按 name/description 判断是否需要读取具体技能。
-    只返回技能 ID、名称和描述，不读取完整 SKILL.md。
+    列出当前会话可用的技能摘要（已启用），供智能体按 name/description 判断是否需要读取具体技能。
+    规则与运行时一致：未自定义时=全部已启用公共技能+当前用户个人技能；
+    自定义开启时=智能体勾选的公共技能+当前用户个人技能。
+    只返回技能 ID、名称、描述与 scope，不读取完整 SKILL.md。
     """
     try:
-        from app.core.config import settings
+        from app.core.context import get_current_agent_context
+        from app.utils.context import current_user_info
+        from app.services.ai.skill_resolver import list_skill_metas
 
-        skills_dir = settings.SKILLS_DIR
-        if not os.path.exists(skills_dir):
-            return "[]"
+        user_info = current_user_info.get()
+        ctx = get_current_agent_context()
+        skills_custom = bool(getattr(ctx, "skills_custom", False)) if ctx else False
+        allowed = list(getattr(ctx, "skills", None) or []) if ctx else []
 
+        metas = list_skill_metas(
+            user_info=user_info,
+            skills_custom=skills_custom,
+            allowed_global_skills=allowed if skills_custom else None,
+        )
         skills = []
-        for item in sorted(os.listdir(skills_dir)):
-            if item.startswith("."):
+        for meta in metas:
+            if meta.get("enabled", "true") == "false":
                 continue
-            item_path = os.path.join(skills_dir, item)
-            if not os.path.isdir(item_path):
-                continue
-            try:
-                _validate_skill_id(item)
-            except ValueError:
-                logger.warning("[Skills] Ignored invalid skill directory name: %s", item)
-                continue
-            skill_md_path = os.path.join(item_path, "SKILL.md")
-            skills.append(_parse_skill_frontmatter(item, skill_md_path))
-
+            skills.append(
+                {
+                    "id": meta.get("id"),
+                    "name": meta.get("name") or meta.get("id"),
+                    "description": meta.get("description") or "",
+                    "scope": meta.get("scope") or "global",
+                }
+            )
         return json.dumps(skills, ensure_ascii=False, indent=2)
     except Exception as e:
         return f"错误：列出技能失败，原因: {str(e)}"
@@ -179,24 +186,75 @@ def list_available_skills() -> str:
 def read_skill_instruction(skill_id: str) -> str:
     """
     读取指定技能的 SKILL.md 指令内容。调用前应先使用 list_available_skills 确认技能存在且适用。
+    仅允许读取当前会话可见技能（含自定义白名单过滤后的公共技能与个人技能）。
 
     Args:
         skill_id: 技能唯一 ID，仅允许英文、数字、中划线及下划线。
     """
     try:
-        from app.core.config import settings
+        from app.core.context import get_current_agent_context
+        from app.utils.context import current_user_info
+        from app.services.ai.skill_resolver import list_skill_metas
 
         safe_skill_id = _validate_skill_id(skill_id)
-        skills_dir = os.path.abspath(settings.SKILLS_DIR)
-        skill_md_path = os.path.abspath(os.path.join(skills_dir, safe_skill_id, "SKILL.md"))
-        if os.path.commonpath([skills_dir, skill_md_path]) != skills_dir:
-            return "错误：技能路径越界。"
-        if not os.path.exists(skill_md_path):
-            return f"错误：技能 {safe_skill_id} 不存在或缺少 SKILL.md。"
+        user_info = current_user_info.get()
+        ctx = get_current_agent_context()
+        skills_custom = bool(getattr(ctx, "skills_custom", False)) if ctx else False
+        allowed = list(getattr(ctx, "skills", None) or []) if ctx else []
 
-        with open(skill_md_path, "r", encoding="utf-8", errors="ignore") as f:
+        metas = list_skill_metas(
+            user_info=user_info,
+            skills_custom=skills_custom,
+            allowed_global_skills=allowed if skills_custom else None,
+        )
+        matched = next(
+            (
+                m
+                for m in metas
+                if m.get("id") == safe_skill_id and m.get("enabled", "true") != "false"
+            ),
+            None,
+        )
+        if not matched:
+            return (
+                f"错误：技能 {safe_skill_id} 不存在、已禁用，"
+                "或不在当前智能体可用 Skills 范围内。"
+            )
+
+        skill_md_path = matched.get("skill_md_path")
+        if not skill_md_path or not os.path.exists(skill_md_path):
+            return f"错误：技能 {safe_skill_id} 缺少 SKILL.md。"
+
+        # 路径安全：限制在全局 SKILLS_DIR 或个人 skills 根目录下
+        abs_md = os.path.abspath(skill_md_path)
+        allowed_roots: list[str] = []
+        try:
+            from app.core.config import settings
+
+            if getattr(settings, "SKILLS_DIR", None):
+                allowed_roots.append(os.path.abspath(settings.SKILLS_DIR))
+        except Exception:
+            pass
+        if user_info:
+            try:
+                from app.services.ai.skill_resolver import get_user_personal_skills_dir
+
+                personal_dir = get_user_personal_skills_dir(user_info)
+                if personal_dir:
+                    allowed_roots.append(os.path.abspath(personal_dir))
+            except Exception:
+                pass
+        if not any(
+            os.path.commonpath([abs_md, root]) == root
+            for root in allowed_roots
+            if root
+        ):
+            return "错误：技能路径越界。"
+
+        with open(abs_md, "r", encoding="utf-8", errors="ignore") as f:
             content = f.read(262144)
-        return f"[技能读取成功: {safe_skill_id}/SKILL.md]\n{content}"
+        scope = matched.get("scope") or "global"
+        return f"[技能读取成功: {safe_skill_id}/SKILL.md · scope={scope}]\n{content}"
     except ValueError as e:
         return f"错误：非法技能 ID，{str(e)}"
     except Exception as e:

--- a/db-prod/V99-agent-version-custom-skills.sql
+++ b/db-prod/V99-agent-version-custom-skills.sql
@@ -1,0 +1,4 @@
+-- V99: 智能体版本支持自定义 Skills 白名单
+ALTER TABLE `ai_agent_versions`
+  ADD COLUMN `skills_custom` BOOLEAN NOT NULL DEFAULT 0 COMMENT '是否自定义 Skills（仅勾选公共技能）' AFTER `tools`,
+  ADD COLUMN `skills` JSON NULL COMMENT '自定义公共技能 ID 列表' AFTER `skills_custom`;

--- a/docs/superpowers/specs/2026-07-18-agent-custom-skills-design.md
+++ b/docs/superpowers/specs/2026-07-18-agent-custom-skills-design.md
@@ -1,0 +1,37 @@
+# 智能体自定义 Skills 设计
+
+**日期:** 2026-07-18  
+**状态:** 已批准，实施中
+
+## 目标
+
+在智能体版本配置中支持「是否自定义 Skills」。自定义开启时仅从公共（全局）已启用技能中勾选；运行时加载 = 勾选的全局技能 + 当前用户已启用个人技能。
+
+## 行为
+
+| `skills_custom` | 加载 |
+|-----------------|------|
+| `false`（默认） | 全部已启用全局 + 当前用户已启用个人 |
+| `true` | `skills[]` 白名单全局 + 当前用户已启用个人 |
+
+- 配置端不展示/不保存个人技能
+- 自定义开启时至少选 1 个全局 skill id（前后端校验）
+- 已禁用或已删除的 id 运行时跳过
+
+## 数据
+
+`ai_agent_versions`:
+- `skills_custom` BOOLEAN NOT NULL DEFAULT 0
+- `skills` JSON NULL（`string[]`）
+
+同步到 ORM、Pydantic（含 `ChatConfig`）、前端 `AIAgentVersion`。
+
+## 运行时
+
+过滤点统一：
+- `discover_platform_skill_paths`（AgentScope workspace）
+- `list_skill_metas` / `scan_relevant_skills` / `resolve_skills_from_query`（prompt 注入）
+
+## UI
+
+工具步骤第三 tab「Skills」：开关 + 已启用公共技能卡片多选。

--- a/frontend/src/api/agent.ts
+++ b/frontend/src/api/agent.ts
@@ -44,6 +44,8 @@ export interface AIAgentVersion {
   synthesis_temperature?: number
   system_prompt: string
   tools: string[]
+  skills_custom?: boolean
+  skills?: string[]
   status: 'DRAFT' | 'PUBLISHED' | 'ARCHIVED'
   comment?: string
   created_at: string

--- a/frontend/src/components/agent/AgentVersionEditorDrawer.vue
+++ b/frontend/src/components/agent/AgentVersionEditorDrawer.vue
@@ -5,6 +5,7 @@ import MarkdownEditor from '../MarkdownEditor.vue';
 
 type VersionConfigStep = 'model' | 'tools' | 'prompt' | 'review';
 type ToolGroup = { label: string; icon: string; tools: any[] };
+type SkillItem = { id: string; name?: string; description?: string; enabled?: string | boolean; path?: string };
 
 const props = defineProps<{
   show: boolean;
@@ -12,20 +13,24 @@ const props = defineProps<{
   selectedAgent: AIAgent | null;
   models: AIModel[];
   canEditVersion: boolean;
-  toolTab: 'static' | 'mcp';
+  toolTab: 'static' | 'mcp' | 'skills';
   toolSearchQuery: string;
   versionConfigStep: VersionConfigStep;
   versionConfigSteps: { id: VersionConfigStep; label: string }[];
   versionConfigProgress: number;
   selectedToolsCount: number;
+  selectedSkillsCount: number;
   promptCharCount: number;
   versionStatusLabel: string;
   versionStatusClass: string;
   filteredGroupedTools: ToolGroup[];
   filteredGroupedMcpTools: Record<string, any[]>;
+  filteredEnabledSkills: SkillItem[];
+  enabledGlobalSkillsCount: number;
   allAvailableToolsCount: number;
   mcpToolsCount: number;
   isToolSelected: (name: string) => boolean;
+  isSkillSelected: (skillId: string) => boolean;
   getToolCustomConfig: (name: string) => any;
   isAllMcpSelected: (serverName: string, tools: any[]) => boolean;
   isMcpGroupCollapsed: (serverName: string) => boolean;
@@ -38,10 +43,12 @@ const props = defineProps<{
 const emit = defineEmits<{
   close: [];
   save: [];
-  'update:toolTab': [value: 'static' | 'mcp'];
+  'update:toolTab': [value: 'static' | 'mcp' | 'skills'];
   'update:toolSearchQuery': [value: string];
   'update:versionConfigStep': [value: VersionConfigStep];
   toggleTool: [name: string];
+  toggleSkill: [skillId: string];
+  setSkillsCustom: [enabled: boolean];
   toggleSelectAllMcp: [serverName: string, tools: any[]];
   toggleMcpGroupCollapse: [serverName: string];
   toggleStaticGroupCollapse: [label: string];
@@ -251,6 +258,12 @@ const goStep = (step: VersionConfigStep) => emit('update:versionConfigStep', ste
                   class="px-3 py-1.5 rounded-md transition-all font-medium"
                   :class="toolTab === 'mcp' ? 'bg-white shadow-sm text-primary' : 'text-gray-400'"
                 >MCP 工具 ({{ mcpToolsCount }})</button>
+                <button
+                  type="button"
+                  @click="emit('update:toolTab', 'skills')"
+                  class="px-3 py-1.5 rounded-md transition-all font-medium"
+                  :class="toolTab === 'skills' ? 'bg-white shadow-sm text-primary' : 'text-gray-400'"
+                >Skills ({{ enabledGlobalSkillsCount }})</button>
               </div>
             </div>
 
@@ -320,7 +333,7 @@ const goStep = (step: VersionConfigStep) => emit('update:versionConfigStep', ste
             </div>
 
             <!-- MCP Tools -->
-            <div v-else class="flex-1 overflow-y-auto space-y-3 pr-1 version-editor-scroll">
+            <div v-else-if="toolTab === 'mcp'" class="flex-1 overflow-y-auto space-y-3 pr-1 version-editor-scroll">
               <div v-if="mcpToolsCount === 0" class="p-12 text-center text-gray-400 text-sm">
                 暂无已发布的 MCP 工具，请前往系统设置配置。
               </div>
@@ -362,6 +375,76 @@ const goStep = (step: VersionConfigStep) => emit('update:versionConfigStep', ste
                 </div>
               </div>
             </div>
+
+            <!-- Skills -->
+            <div v-else class="flex-1 overflow-y-auto space-y-3 pr-1 version-editor-scroll">
+              <div class="rounded-lg border border-emerald-100 bg-emerald-50/40 px-4 py-3 flex items-start justify-between gap-3">
+                <div class="min-w-0">
+                  <div class="text-sm font-bold text-gray-800">自定义 Skills</div>
+                  <p class="text-[11px] text-gray-500 mt-1 leading-relaxed">
+                    关闭时加载全部已启用公共技能 + 当前用户个人技能。开启后仅从公共技能中勾选；运行时仍会附带当前用户个人技能。
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  :aria-checked="!!versionForm.skills_custom"
+                  :disabled="!canEditVersion"
+                  @click="emit('setSkillsCustom', !versionForm.skills_custom)"
+                  class="relative inline-flex h-6 w-11 flex-shrink-0 rounded-full transition-colors"
+                  :class="[
+                    versionForm.skills_custom ? 'bg-primary' : 'bg-gray-300',
+                    canEditVersion ? 'cursor-pointer' : 'opacity-60 cursor-not-allowed'
+                  ]"
+                >
+                  <span
+                    class="inline-block h-5 w-5 transform rounded-full bg-white shadow transition mt-0.5"
+                    :class="versionForm.skills_custom ? 'translate-x-5 ml-0.5' : 'translate-x-0.5'"
+                  />
+                </button>
+              </div>
+
+              <div v-if="!versionForm.skills_custom" class="p-10 text-center text-gray-400 text-sm border border-dashed border-gray-200 rounded-xl">
+                当前使用默认策略：全部已启用公共 Skills + 个人 Skills
+              </div>
+              <template v-else>
+                <div class="flex items-center justify-between gap-2">
+                  <span class="text-xs font-medium text-primary bg-primary/10 px-2.5 py-1 rounded-full">
+                    已选 {{ selectedSkillsCount }} 个公共技能
+                  </span>
+                  <span class="text-[10px] text-amber-600" v-if="selectedSkillsCount === 0">至少选择 1 个公共技能</span>
+                </div>
+                <div v-if="enabledGlobalSkillsCount === 0" class="p-12 text-center text-gray-400 text-sm">
+                  暂无已启用的公共技能，请前往技能工作台启用。
+                </div>
+                <div v-else class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <div
+                    v-for="skill in filteredEnabledSkills"
+                    :key="skill.id"
+                    @click="emit('toggleSkill', skill.id)"
+                    class="tool-card"
+                    :class="[
+                      isSkillSelected(skill.id) ? 'tool-card--selected' : '',
+                      !canEditVersion ? 'opacity-90 cursor-default' : 'cursor-pointer'
+                    ]"
+                  >
+                    <div class="tool-checkbox" :class="isSkillSelected(skill.id) ? 'tool-checkbox--on' : ''">
+                      <svg v-if="isSkillSelected(skill.id)" class="w-2.5 h-2.5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M5 13l4 4L19 7" />
+                      </svg>
+                    </div>
+                    <div class="flex-1 min-w-0">
+                      <div class="text-[11px] font-bold font-mono text-gray-800 flex items-center gap-1 flex-wrap">
+                        {{ skill.name || skill.id }}
+                        <span class="text-[9px] bg-emerald-50 text-emerald-600 px-1 rounded font-sans font-normal">公共</span>
+                      </div>
+                      <div class="text-[10px] text-gray-400 mt-0.5 font-mono">{{ skill.id }}</div>
+                      <div class="text-[10px] text-gray-400 mt-0.5 line-clamp-2">{{ skill.description || '暂无描述' }}</div>
+                    </div>
+                  </div>
+                </div>
+              </template>
+            </div>
           </div>
 
           <!-- Step 3: Prompt -->
@@ -390,7 +473,7 @@ const goStep = (step: VersionConfigStep) => emit('update:versionConfigStep', ste
           <!-- Step 4: Review -->
           <div v-else class="space-y-4 max-w-2xl">
             <h3 class="text-sm font-bold text-gray-900">配置总览</h3>
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
               <div class="summary-card">
                 <div class="text-[10px] text-gray-400 uppercase font-bold mb-1">编排模型</div>
                 <div class="text-sm font-semibold text-gray-800 truncate">{{ getModelDisplayName(versionForm.model_name) }}</div>
@@ -399,6 +482,12 @@ const goStep = (step: VersionConfigStep) => emit('update:versionConfigStep', ste
               <div class="summary-card">
                 <div class="text-[10px] text-gray-400 uppercase font-bold mb-1">工具能力</div>
                 <div class="text-sm font-semibold text-gray-800">{{ selectedToolsCount }} 个已启用</div>
+              </div>
+              <div class="summary-card">
+                <div class="text-[10px] text-gray-400 uppercase font-bold mb-1">Skills</div>
+                <div class="text-sm font-semibold text-gray-800">
+                  {{ versionForm.skills_custom ? `自定义 ${selectedSkillsCount} 个` : '全部公共 + 个人' }}
+                </div>
               </div>
               <div class="summary-card">
                 <div class="text-[10px] text-gray-400 uppercase font-bold mb-1">系统提示词</div>

--- a/frontend/src/components/embed/SkillBrowserDrawer.vue
+++ b/frontend/src/components/embed/SkillBrowserDrawer.vue
@@ -13,8 +13,13 @@ const props = withDefaults(
     pinnedDockClass?: string
     /** 已挂载到输入框的技能 ID */
     attachedSkillIds?: string[]
+    /**
+     * 当前会话有效智能体 ID。有值时按该智能体已发布版本的 skills_custom / skills
+     * 过滤「平台技能」列表；个人技能始终全量展示。
+     */
+    agentId?: string | null
   }>(),
-  { pinnedDockClass: 'right-0', attachedSkillIds: () => [] },
+  { pinnedDockClass: 'right-0', attachedSkillIds: () => [], agentId: null },
 )
 
 const emit = defineEmits<{
@@ -40,6 +45,9 @@ const showSkillPreviewModal = ref(false)
 const previewLoading = ref(false)
 const previewSkill = ref<SkillItem | null>(null)
 const previewMarkdown = ref('')
+/** 当前智能体是否开启了自定义公共 Skills */
+const skillsCustom = ref(false)
+const allowedGlobalSkillIds = ref<string[] | null>(null)
 
 const isMobile = ref(false)
 let mobileMq: MediaQueryList | null = null
@@ -64,19 +72,45 @@ const filteredSkillsList = computed(() => {
 
 const renderedPreviewHtml = computed(() => renderMarkdownPreview(previewMarkdown.value || ''))
 
+const resolveAgentSkillFilter = async (agentId: string | null | undefined) => {
+  skillsCustom.value = false
+  allowedGlobalSkillIds.value = null
+  const id = String(agentId || '').trim()
+  if (!id) return
+  try {
+    const res = await axios.get(`/api/portal/agents/${encodeURIComponent(id)}/active-config`)
+    const cfg = res.data || {}
+    if (cfg.skills_custom) {
+      skillsCustom.value = true
+      allowedGlobalSkillIds.value = Array.isArray(cfg.skills)
+        ? cfg.skills.map((s: any) => String(s || '').trim()).filter(Boolean)
+        : []
+    }
+  } catch (err) {
+    // 无已发布版本或拉取失败时不拦截：回退为展示全部已启用公共技能
+    console.warn('加载智能体 Skills 配置失败，回退为全量公共技能', err)
+  }
+}
+
 const loadSkillsList = async () => {
   skillsList.value = []
   personalSkillsList.value = []
   isLoadingSkillsList.value = true
   try {
+    await resolveAgentSkillFilter(props.agentId)
     const [globalRes, personalRes] = await Promise.allSettled([
       axios.get('/api/portal/skills'),
-      axios.get('/api/portal/skills/personal')
+      axios.get('/api/portal/skills/personal'),
     ])
     if (globalRes.status === 'fulfilled' && globalRes.value.data?.status === 'success') {
-      skillsList.value = (globalRes.value.data.data || [])
-        .map((s: any) => ({ ...s, scope: 'global' }))
+      let list = (globalRes.value.data.data || [])
+        .map((s: any) => ({ ...s, scope: 'global' as const }))
         .filter((s: any) => s.enabled !== 'false')
+      if (skillsCustom.value && allowedGlobalSkillIds.value) {
+        const allow = new Set(allowedGlobalSkillIds.value)
+        list = list.filter((s: SkillItem) => allow.has(s.id))
+      }
+      skillsList.value = list
     }
     if (personalRes.status === 'fulfilled' && personalRes.value.data?.status === 'success') {
       personalSkillsList.value = (personalRes.value.data.data || [])
@@ -184,6 +218,13 @@ watch(modelValue, (open) => {
     previewMarkdown.value = ''
   }
 })
+
+watch(
+  () => props.agentId,
+  () => {
+    if (modelValue.value) void loadSkillsList()
+  },
+)
 
 const onGlobalKeydown = (event: KeyboardEvent) => {
   if (event.key !== 'Escape' || !modelValue.value) return
@@ -384,6 +425,13 @@ onUnmounted(() => {
                 </button>
               </div>
 
+              <div
+                v-if="skillsCustom && activeScope === 'global'"
+                class="mb-3 shrink-0 rounded-lg border border-amber-200/80 bg-amber-50/80 dark:border-amber-500/30 dark:bg-amber-500/10 px-3 py-2 text-[11px] text-amber-800 dark:text-amber-200 leading-relaxed"
+              >
+                当前智能体已开启自定义 Skills，仅展示其配置的 {{ skillsList.length }} 个公共技能；「我的技能」不受限制。
+              </div>
+
               <div class="relative mb-3 shrink-0">
                 <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -407,7 +455,13 @@ onUnmounted(() => {
                 <div v-else-if="filteredSkillsList.length === 0" class="text-center py-12">
                   <span class="text-2xl opacity-40">⚙️</span>
                   <p class="text-xs text-gray-400 mt-2 font-bold">未发现可用的智能体技能</p>
-                  <p class="text-[10px] text-gray-400/70 mt-1">您可以前往系统控制台「技能管理」页面创建</p>
+                  <p class="text-[10px] text-gray-400/70 mt-1">
+                    {{
+                      skillsCustom && activeScope === 'global'
+                        ? '当前智能体自定义 Skills 未匹配到可用公共技能，可切换到「我的技能」'
+                        : '您可以前往系统控制台「技能管理」页面创建'
+                    }}
+                  </p>
                 </div>
 
                 <div

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -1943,9 +1943,31 @@ const handleReorderCommands = async (reorderData: any[]) => {
 };
 
 const isFullScreen = ref(false);
+const FULLSCREEN_TIP_KEY = "agent_debug_fullscreen_tip_dismissed";
+const showFullscreenTip = ref(
+  typeof localStorage !== "undefined" &&
+    localStorage.getItem(FULLSCREEN_TIP_KEY) !== "1"
+);
 
 const toggleFullScreen = () => {
   isFullScreen.value = !isFullScreen.value;
+  if (isFullScreen.value) {
+    dismissFullscreenTip();
+  }
+};
+
+const dismissFullscreenTip = () => {
+  showFullscreenTip.value = false;
+  try {
+    localStorage.setItem(FULLSCREEN_TIP_KEY, "1");
+  } catch {
+    /* ignore */
+  }
+};
+
+const enterFullScreenFromTip = () => {
+  isFullScreen.value = true;
+  dismissFullscreenTip();
 };
 
 const userInput = ref("");
@@ -3360,6 +3382,43 @@ onUnmounted(() => {
       class="flex-1 flex flex-col bg-white shadow-sm overflow-hidden mr-px transition-[margin] duration-300 relative"
       :style="pinnedDrawerMarginStyle"
     >
+      <!-- 模块说明提示（含一次性全屏引导，避免每次 toast） -->
+      <div
+        v-if="!isFullScreen"
+        class="px-4 sm:px-6 py-2 bg-sky-50 border-b border-sky-100 flex items-start sm:items-center gap-2 flex-shrink-0"
+      >
+        <svg class="w-4 h-4 text-sky-600 shrink-0 mt-0.5 sm:mt-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <div class="flex-1 min-w-0 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+          <p class="text-xs sm:text-sm text-sky-800 leading-relaxed">
+            当前是<strong class="font-semibold">智能体开发调试</strong>模块，可展示更详尽的运行日志与链路信息，便于开发排查与调试。
+            <template v-if="showFullscreenTip">
+              建议使用右上角<strong class="font-semibold">全屏</strong>，调试视野更完整。
+            </template>
+          </p>
+          <div v-if="showFullscreenTip" class="flex items-center gap-2 shrink-0">
+            <button
+              type="button"
+              @click="enterFullScreenFromTip"
+              class="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-semibold text-white bg-sky-600 hover:bg-sky-700 rounded-md transition-colors"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4M20 4l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
+              </svg>
+              进入全屏
+            </button>
+            <button
+              type="button"
+              @click="dismissFullscreenTip"
+              class="text-xs text-sky-600/80 hover:text-sky-900 px-1.5 py-1 transition-colors"
+            >
+              知道了
+            </button>
+          </div>
+        </div>
+      </div>
+
       <!-- Header -->
       <div
         class="h-14 px-6 border-b border-gray-200 flex items-center justify-between bg-white flex-shrink-0"
@@ -3421,11 +3480,13 @@ onUnmounted(() => {
           <!-- 1. 全屏 -->
           <button
             @click="toggleFullScreen"
-            class="flex items-center transition-all"
+            class="flex items-center gap-1.5 transition-all"
             :class="isFullScreen
-              ? 'bg-primary/10 text-primary border border-primary/20 p-1.5 rounded-lg hover:bg-primary/20'
-              : 'text-gray-500 hover:text-blue-600 p-1.5 rounded-lg hover:bg-gray-50'"
-            :title="isFullScreen ? '退出全屏' : '全屏调试'"
+              ? 'bg-primary/10 text-primary border border-primary/20 px-2.5 py-1.5 rounded-lg hover:bg-primary/20'
+              : showFullscreenTip
+                ? 'bg-sky-50 text-sky-700 border border-sky-200 px-2.5 py-1.5 rounded-lg hover:bg-sky-100 ring-2 ring-sky-200/60 animate-pulse'
+                : 'text-gray-500 hover:text-blue-600 px-2 py-1.5 rounded-lg hover:bg-gray-50'"
+            :title="isFullScreen ? '退出全屏（Esc）' : '全屏调试，获得更大视野'"
           >
             <svg
               class="w-5 h-5"
@@ -3448,6 +3509,7 @@ onUnmounted(() => {
                 d="M4 14h6v6m0-6l-6 6m16-6h-6v6m0-6l6 6M4 10h6V4m0 6L4 4m16 6h-6V4m0 6l6-6"
               />
             </svg>
+            <span class="text-xs font-medium hidden sm:inline">{{ isFullScreen ? '退出全屏' : '全屏' }}</span>
           </button>
 
           <div class="h-4 w-px bg-gray-200"></div>

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -5380,6 +5380,7 @@ onUnmounted(() => {
     v-model:pinned="skillPinned"
     :pinned-dock-class="skillPinnedDockClass"
     :attached-skill-ids="attachedSkillIds"
+    :agent-id="agentParams.agent_id"
     @select="handleSelectSkill"
   />
 

--- a/frontend/src/views/AgentManagement.vue
+++ b/frontend/src/views/AgentManagement.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from "vue";
+import { ref, onMounted, onUnmounted, computed } from "vue";
 import { agentApi } from "../api/agent";
 import type {
   AIAgent,
@@ -1354,12 +1354,28 @@ const getAgentColorTheme = (agent: AIAgent) => {
   return themes[index] || themes[0]!;
 };
 
+const getEngineShortLabel = (agent: AIAgent) => {
+  if (agent.engine_type === 'RAGFLOW') return 'RAGFlow'
+  if (agent.engine_type === 'OPENCLAW') return 'OpenClaw'
+  return 'NanZi'
+}
+
+const openCardMenuId = ref<string | null>(null)
+const toggleCardMenu = (agentId: string, e?: Event) => {
+  e?.stopPropagation()
+  openCardMenuId.value = openCardMenuId.value === agentId ? null : agentId
+}
+const closeCardMenus = () => {
+  openCardMenuId.value = null
+}
+
 onMounted(() => {
   fetchAgents();
   fetchModels();
   fetchTools();
   const cached = localStorage.getItem("user_info");
   if (cached) userInfo.value = JSON.parse(cached);
+  document.addEventListener('click', closeCardMenus);
 });
 
 const versionsDrawerRef = ref<any>(null);
@@ -1372,9 +1388,9 @@ onMounted(() => {
   window.addEventListener('resize', handleResize);
 });
 
-import { onUnmounted } from 'vue';
 onUnmounted(() => {
   window.removeEventListener('resize', handleResize);
+  document.removeEventListener('click', closeCardMenus);
 });
 
 const formatDate = (dateStr: string) => {
@@ -1390,107 +1406,60 @@ const formatDate = (dateStr: string) => {
 </script>
 
 <template>
-  <div class="space-y-4 sm:space-y-6">
-    <div class="flex justify-between items-center">
-      <div>
-        <div class="flex items-center space-x-3">
-          <h1 class="text-xl sm:text-2xl font-bold text-gray-900">智能体中心</h1>
-          <!-- 「？」帮助按钮 -->
-          <button 
-            @click="showHelp = true"
-            class="flex items-center justify-center w-7 h-7 rounded-full bg-white text-blue-600 border border-gray-200 hover:border-blue-300 hover:bg-blue-50 transition-colors shadow-sm"
-            title="智能体调度与托管说明"
-          >
-            <span class="font-bold text-sm">?</span>
-          </button>
-        </div>
-        <p v-if="!isMobile" class="text-gray-500 mt-1">
-          管理并配置系统中的 AI 智能体及其运行策略
-        </p>
-      </div>
-      <button
-        v-if="!isMobile"
-        v-has-perm="'element:agent:create'"
-        @click="openAgentModal()"
-        class="px-4 py-2 bg-primary text-white rounded-lg shadow-sm hover:bg-primary-dark transition-colors flex items-center"
-      >
-        <svg
-          class="w-5 h-5 mr-2"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M12 4v16m8-8H4"
-          />
-        </svg>
-        新建智能体
-      </button>
-    </div>
-
-    <!-- Filters & Toolbar -->
-    <div
-      class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 flex flex-wrap items-center justify-between gap-4"
-    >
-      <div class="flex items-center space-x-4">
-        <!-- Status Filter -->
-        <div class="flex items-center space-x-2">
-          <span class="text-sm text-gray-500">状态:</span>
-          <select
-            v-model="statusFilter"
-            class="text-sm border-gray-300 rounded-md focus:ring-primary focus:border-primary"
-          >
-            <option value="all">全部</option>
-            <option value="enabled">已启用</option>
-            <option value="disabled">已禁用</option>
-          </select>
-        </div>
-        <!-- Type Filter -->
-        <div class="flex items-center space-x-2">
-          <span class="text-sm text-gray-500">类型:</span>
-          <select
-            v-model="typeFilter"
-            class="text-sm border-gray-300 rounded-md focus:ring-primary focus:border-primary"
-          >
-            <option value="all">全部</option>
-            <option value="system">系统内置</option>
-            <option value="custom">自定义</option>
-          </select>
-        </div>
-      </div>
-
-      <!-- Search & View Switch -->
+  <div class="space-y-4 sm:space-y-5">
+    <!-- Header：与技能工作台一致，标题左 / 筛选操作右 -->
+    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
       <div class="flex items-center space-x-3">
-        <div class="relative w-64">
+        <h1 class="text-xl sm:text-2xl font-bold text-gray-900">智能体中心</h1>
+        <button 
+          @click="showHelp = true"
+          class="flex items-center justify-center w-7 h-7 rounded-full bg-white text-blue-600 border border-gray-200 hover:border-blue-300 hover:bg-blue-50 transition-colors shadow-sm"
+          title="智能体调度与托管说明"
+        >
+          <span class="font-bold text-sm">?</span>
+        </button>
+      </div>
+
+      <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+        <div class="relative w-full sm:w-56 lg:w-64">
+          <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </span>
           <input
             v-model="searchKeyword"
+            type="text"
             placeholder="搜索智能体名称..."
-            class="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none transition-all"
+            class="w-full pl-9 pr-3 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none text-sm transition-all shadow-sm"
           />
-          <svg
-            class="w-4 h-4 text-gray-400 absolute left-3 top-2.5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            ></path>
-          </svg>
         </div>
 
-        <!-- View Mode Switcher -->
-        <div v-if="!isMobile" class="flex items-center bg-gray-100 p-1 rounded-lg border border-gray-200">
+        <select
+          v-model="statusFilter"
+          class="text-sm border border-gray-300 rounded-lg py-2 px-2.5 bg-white shadow-sm focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none shrink-0"
+          title="按状态筛选"
+        >
+          <option value="all">状态：全部</option>
+          <option value="enabled">状态：已启用</option>
+          <option value="disabled">状态：已禁用</option>
+        </select>
+
+        <select
+          v-model="typeFilter"
+          class="text-sm border border-gray-300 rounded-lg py-2 px-2.5 bg-white shadow-sm focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none shrink-0"
+          title="按类型筛选"
+        >
+          <option value="all">类型：全部</option>
+          <option value="system">类型：系统内置</option>
+          <option value="custom">类型：自定义</option>
+        </select>
+
+        <div v-if="!isMobile" class="flex items-center bg-gray-200/60 p-0.5 rounded-lg border border-gray-300 gap-0.5 select-none shrink-0">
           <button
             @click="toggleViewMode('grid')"
             class="p-1.5 rounded-md transition-all"
-            :class="viewMode === 'grid' ? 'bg-white shadow-sm text-primary' : 'text-gray-400 hover:text-gray-600'"
+            :class="viewMode === 'grid' ? 'bg-white shadow-sm text-primary border border-gray-200' : 'text-gray-500 hover:text-gray-800'"
             title="网格视图"
           >
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1499,8 +1468,8 @@ const formatDate = (dateStr: string) => {
           </button>
           <button
             @click="toggleViewMode('list')"
-            class="p-1.5 rounded-md transition-all ml-0.5"
-            :class="viewMode === 'list' ? 'bg-white shadow-sm text-primary' : 'text-gray-400 hover:text-gray-600'"
+            class="p-1.5 rounded-md transition-all"
+            :class="viewMode === 'list' ? 'bg-white shadow-sm text-primary border border-gray-200' : 'text-gray-500 hover:text-gray-800'"
             title="列表视图"
           >
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1508,14 +1477,26 @@ const formatDate = (dateStr: string) => {
             </svg>
           </button>
         </div>
-        <p
-          v-if="canDragAgents"
-          class="text-[11px] text-gray-400 hidden sm:block"
+
+        <button
+          v-has-perm="'element:agent:create'"
+          @click="openAgentModal()"
+          class="flex items-center justify-center gap-2 px-4 py-2 bg-primary text-white rounded-lg shadow-sm hover:bg-primary-dark transition-colors font-medium text-sm shrink-0"
         >
-          拖动卡片或列表行可调整排序
-        </p>
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          新建智能体
+        </button>
       </div>
     </div>
+
+    <p
+      v-if="canDragAgents && !isMobile"
+      class="text-[11px] text-gray-400 -mt-2"
+    >
+      拖动卡片或列表行可调整排序
+    </p>
 
     <!-- Agents Grid -->
     <div v-if="loading" class="py-12 text-center text-gray-400">
@@ -1588,11 +1569,11 @@ const formatDate = (dateStr: string) => {
         </div>
         <!-- Card Header Accent -->
         <div class="h-1.5 w-full" :class="getAgentColorTheme(agent).accent"></div>
-        <!-- Card Header & Status -->
-        <div class="p-5 flex items-start justify-between relative">
-          <div class="flex items-center space-x-4">
+        <!-- Card Header: title left, enable switch right -->
+        <div class="p-5 flex items-start justify-between gap-3">
+          <div class="flex items-center space-x-3 min-w-0 flex-1">
             <div
-              class="w-12 h-12 rounded-xl flex items-center justify-center text-2xl shadow-inner border overflow-hidden"
+              class="w-11 h-11 rounded-xl flex items-center justify-center text-xl shadow-inner border overflow-hidden shrink-0"
               :class="[getAgentColorTheme(agent).bg, getAgentColorTheme(agent).border]"
             >
               <img
@@ -1602,54 +1583,43 @@ const formatDate = (dateStr: string) => {
               />
               <span v-else>{{ getAgentEmoji(agent) }}</span>
             </div>
-            <div>
+            <div class="min-w-0">
               <h3
-                class="font-bold text-gray-900 line-clamp-1 relative pr-16"
+                class="font-bold text-gray-900 line-clamp-1"
                 :title="agent.display_name"
               >
                 {{ agent.display_name }}
               </h3>
-              <p class="text-xs text-gray-500 font-mono mt-0.5">
-                {{ agent.name }}
-              </p>
+              <div class="mt-1 flex items-center flex-wrap gap-1.5 text-[11px] text-gray-500">
+                <span class="font-mono truncate max-w-[8rem]" :title="agent.name">{{ agent.name }}</span>
+                <span class="text-gray-300">·</span>
+                <span
+                  class="shrink-0 px-1.5 py-0.5 rounded font-medium border"
+                  :class="{
+                    'bg-purple-50 text-purple-600 border-purple-100': agent.engine_type === 'RAGFLOW',
+                    'bg-orange-50 text-orange-600 border-orange-100': agent.engine_type === 'OPENCLAW',
+                    'bg-blue-50 text-blue-600 border-blue-100': agent.engine_type !== 'RAGFLOW' && agent.engine_type !== 'OPENCLAW',
+                  }"
+                >{{ getEngineShortLabel(agent) }}</span>
+                <span
+                  v-if="agent.is_system"
+                  class="shrink-0 px-1.5 py-0.5 rounded font-medium bg-indigo-50 text-indigo-600 border border-indigo-100"
+                >系统</span>
+                <span
+                  v-if="!agent.is_enabled"
+                  class="shrink-0 px-1.5 py-0.5 rounded font-medium bg-gray-100 text-gray-500 border border-gray-200"
+                >已禁用</span>
+              </div>
             </div>
           </div>
 
-          <!-- Status Badge -->
-          <div class="absolute top-5 right-5 flex flex-col items-end space-y-2">
-            <!-- 引擎类型标签 -->
-            <span
-              v-if="agent.engine_type === 'RAGFLOW'"
-              class="px-2 py-0.5 rounded text-[10px] font-bold bg-purple-50 text-purple-600 border border-purple-100 flex items-center"
-            >
-              🌊 RAG Engine
-            </span>
-            <span
-              v-else-if="agent.engine_type === 'OPENCLAW'"
-              class="px-2 py-0.5 rounded text-[10px] font-bold bg-orange-50 text-orange-600 border border-orange-100 flex items-center"
-            >
-              🦞 Claw Engine
-            </span>
-            <span
-              v-else
-              class="px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-600 border border-blue-100 flex items-center"
-            >
-              🧠 NanZi Engine
-            </span>
-
-            <span
-              v-if="agent.is_system"
-              class="px-2 py-0.5 rounded text-[10px] font-bold bg-indigo-50 text-indigo-600 border border-indigo-100"
-              >SYSTEM</span
-            >
-
-            <!-- Toggle Switch -->
+          <div class="shrink-0 pt-0.5">
             <button
+              v-if="agent.is_editable !== false"
               class="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
               :class="agent.is_enabled ? 'bg-green-500' : 'bg-gray-200'"
               @click.stop="toggleAgentStatus(agent)"
-              title="切换启用状态"
-              v-if="agent.is_editable !== false"
+              :title="agent.is_enabled ? '已启用，点击禁用' : '已禁用，点击启用'"
             >
               <span class="sr-only">Toggle Status</span>
               <span
@@ -1658,7 +1628,6 @@ const formatDate = (dateStr: string) => {
                 :class="agent.is_enabled ? 'translate-x-4' : 'translate-x-0'"
               ></span>
             </button>
-            <!-- Read-only Badge -->
             <span
               v-else
               class="px-2 py-0.5 rounded-full text-[10px] items-center space-x-1 flex border"
@@ -1672,162 +1641,111 @@ const formatDate = (dateStr: string) => {
                 class="w-1.5 h-1.5 rounded-full"
                 :class="agent.is_enabled ? 'bg-green-500' : 'bg-gray-400'"
               ></span>
-              <span>{{ agent.is_enabled ? "Active" : "Disabled" }}</span>
+              <span>{{ agent.is_enabled ? '已启用' : '已禁用' }}</span>
             </span>
           </div>
         </div>
 
-        <!-- Description (Comment Style) -->
-        <div class="px-5 pb-3 flex-1 flex flex-col justify-center">
-          <div
-            class="p-2.5 rounded-lg border border-gray-100 bg-gray-50/80 font-mono text-[11px] leading-relaxed relative group/desc min-h-[64px] flex flex-col justify-center transition-all shadow-sm"
+        <!-- Description -->
+        <div class="px-5 pb-3 flex-1 flex flex-col">
+          <p
+            class="text-sm text-gray-600 leading-relaxed line-clamp-3 min-h-[3.75rem]"
+            :title="agent.description || undefined"
           >
-            <div class="absolute top-0 left-0 w-1 h-full transition-colors bg-gray-300 group-hover:bg-primary/50"></div>
-            <p class="italic px-1 line-clamp-3 text-gray-500">
-              <span class="opacity-40 mr-1">/*</span>
-              {{ agent.description || "No description available..." }}
-              <span class="opacity-40 ml-1">*/</span>
-            </p>
-          </div>
+            {{ agent.description || '暂无描述' }}
+          </p>
 
           <div
             v-if="!isMobile"
-            class="mt-auto flex items-center justify-between text-xs text-gray-500 border-t border-gray-50 pt-3"
+            class="mt-3 flex items-center flex-wrap gap-x-3 gap-y-1 text-xs text-gray-400"
           >
-            <span class="flex items-center" title="创建者">
-              <span class="mr-1">👤</span>{{ agent.created_by || "Unknown" }}
-            </span>
-            <span class="flex items-center" title="最后更新">
-              <span class="mr-1">🕒</span>{{ formatDate(agent.updated_at) }}
-            </span>
+            <span title="创建者">{{ agent.created_by || 'Unknown' }}</span>
+            <span class="text-gray-300">·</span>
+            <span title="最后更新">{{ formatDate(agent.updated_at) }}</span>
+            <span class="text-gray-300">·</span>
+            <span title="调用次数">{{ agent.execution_count ?? 0 }} 次调用</span>
           </div>
         </div>
 
         <!-- Actions Footer -->
         <div
-          class="bg-gray-50 px-5 py-3 border-t border-gray-100 flex items-center justify-between group-hover:bg-blue-50/30 transition-colors"
+          class="bg-gray-50 px-4 py-3 border-t border-gray-100 flex items-center justify-end gap-2 group-hover:bg-blue-50/30 transition-colors"
         >
-          <div v-if="!isMobile" class="flex items-center space-x-2">
-            <span
-              class="text-xs font-semibold text-gray-500 bg-white px-2 py-0.5 rounded border border-gray-200 shadow-sm"
-            >
-              {{ agent.execution_count }} runs
-            </span>
-          </div>
-          <div v-else></div> <!-- Placeholder for layout -->
-
-          <div
-            class="flex items-center space-x-1"
-            :class="isMobile ? 'opacity-100' : 'opacity-80 group-hover:opacity-100'"
-          >
-            <!-- Delete -->
+          <div class="relative" @click.stop>
             <button
-              v-has-perm="'element:agent:delete'"
-              @click.stop="handleDeleteAgent(agent)"
-              class="p-1.5 rounded hover:bg-white text-gray-400 hover:text-red-600 transition-colors"
-              title="删除智能体"
-              v-if="!agent.is_system && agent.is_editable !== false"
+              @click="toggleCardMenu(agent.id, $event)"
+              class="p-1.5 rounded-lg text-gray-400 hover:text-gray-700 hover:bg-white border border-transparent hover:border-gray-200 transition-colors"
+              title="更多操作"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                />
+              <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zm6 0a2 2 0 11-4 0 2 2 0 014 0zm6 0a2 2 0 11-4 0 2 2 0 014 0z" />
               </svg>
             </button>
-
-            <!-- Preview -->
-            <button
-              @click.stop="openPreview(agent)"
-              class="p-1.5 rounded hover:bg-white text-gray-400 hover:text-indigo-600 transition-colors"
-              title="预览对话 (EmbedChat)"
+            <div
+              v-if="openCardMenuId === agent.id"
+              class="absolute right-0 bottom-full mb-1 w-40 bg-white border border-gray-200 rounded-xl shadow-lg py-1 z-30"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+              <button
+                @click="closeCardMenus(); openPreview(agent)"
+                class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
               >
-                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-              </svg>
-            </button>
-
-            <!-- Edit (Simplified for mobile) -->
-            <button
-              v-has-perm="'element:agent:edit'"
-              @click.stop="openAgentModal(agent)"
-              class="p-1.5 rounded hover:bg-white text-gray-400 hover:text-blue-600 transition-colors"
-              title="配置元数据"
-              v-if="agent.is_editable !== false"
-            >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+                预览对话
+              </button>
+              <button
+                v-if="agent.is_editable !== false"
+                v-has-perm="'element:agent:edit'"
+                @click="closeCardMenus(); openAgentModal(agent)"
+                class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                />
-              </svg>
-            </button>
-
-            <!-- History -->
-            <button
-              v-if="!isMobile"
-              @click.stop="openHistoryModal(agent)"
-              class="p-1.5 rounded hover:bg-white text-gray-400 hover:text-indigo-600 transition-colors"
-              title="历史记录"
-            >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+                配置元数据
+              </button>
+              <button
+                v-if="!isMobile"
+                @click="closeCardMenus(); openHistoryModal(agent)"
+                class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-            </button>
-
-            <!-- Versions (Primary Action - Hidden on mobile, RAGFLOW and OPENCLAW) -->
-            <button
-              v-if="!isMobile && agent.engine_type !== 'RAGFLOW' && agent.engine_type !== 'OPENCLAW'"
-              @click.stop="openDrawer(agent)"
-              class="ml-2 px-3 py-1 bg-primary text-white text-xs rounded shadow-sm hover:bg-primary-dark transition-colors flex items-center"
-            >
-              <svg
-                class="w-3 h-3 mr-1"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+                历史记录
+              </button>
+              <button
+                v-if="!agent.is_system && agent.is_editable !== false"
+                v-has-perm="'element:agent:delete'"
+                @click="closeCardMenus(); handleDeleteAgent(agent)"
+                class="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-                />
-              </svg>
-              版本管理
-            </button>
+                删除
+              </button>
             </div>
           </div>
+
+          <button
+            v-if="!isMobile && agent.engine_type !== 'RAGFLOW' && agent.engine_type !== 'OPENCLAW'"
+            @click.stop="openDrawer(agent)"
+            class="px-3 py-1.5 bg-primary text-white text-xs font-medium rounded-lg shadow-sm hover:bg-primary-dark transition-colors flex items-center"
+          >
+            <svg
+              class="w-3 h-3 mr-1"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+              />
+            </svg>
+            版本管理
+          </button>
+          <button
+            v-else-if="agent.is_editable !== false"
+            v-has-perm="'element:agent:edit'"
+            @click.stop="openAgentModal(agent)"
+            class="px-3 py-1.5 bg-primary text-white text-xs font-medium rounded-lg shadow-sm hover:bg-primary-dark transition-colors"
+          >
+            配置
+          </button>
+        </div>
         </div>
       </template>
 

--- a/frontend/src/views/AgentManagement.vue
+++ b/frontend/src/views/AgentManagement.vue
@@ -367,6 +367,8 @@ const versionForm = ref<Partial<AIAgentVersion>>({
   synthesis_temperature: 0.7, // NEW
   system_prompt: "",
   tools: [],
+  skills_custom: false,
+  skills: [],
   comment: "",
 });
 
@@ -475,7 +477,8 @@ const availableTools = [
 
 const dynamicTools = ref<SysApiTool[]>([]);
 const mcpTools = ref<any[]>([]);
-const toolTab = ref<'static' | 'mcp'>('static');
+const availableSkills = ref<any[]>([]);
+const toolTab = ref<'static' | 'mcp' | 'skills'>('static');
 
 const groupedMcpTools = computed(() => {
   const groups: Record<string, any[]> = {};
@@ -517,6 +520,10 @@ const versionConfigSteps: { id: VersionConfigStep; label: string }[] = [
 ];
 
 const selectedToolsCount = computed(() => versionForm.value.tools?.length ?? 0);
+const selectedSkillsCount = computed(() => versionForm.value.skills?.length ?? 0);
+const enabledGlobalSkills = computed(() =>
+  availableSkills.value.filter((s) => String(s.enabled ?? 'true') !== 'false')
+);
 const promptCharCount = computed(() => versionForm.value.system_prompt?.length ?? 0);
 
 const versionConfigProgress = computed(() => {
@@ -555,6 +562,16 @@ const filteredGroupedMcpTools = computed(() => {
     if (filtered.length > 0) result[serverName] = filtered;
   }
   return result;
+});
+
+const filteredEnabledSkills = computed(() => {
+  const q = toolSearchQuery.value.trim().toLowerCase();
+  return enabledGlobalSkills.value.filter((skill) =>
+    !q ||
+    String(skill.id || '').toLowerCase().includes(q) ||
+    String(skill.name || '').toLowerCase().includes(q) ||
+    String(skill.description || '').toLowerCase().includes(q)
+  );
 });
 
 const collapsedStaticGroups = ref<Set<string>>(new Set());
@@ -633,6 +650,14 @@ const fetchTools = async () => {
       mcpTools.value = Array.isArray(mcpRes.data) ? mcpRes.data : (mcpRes.data.data || []);
     } catch (e) {
       console.warn("MCP tools not loaded");
+    }
+
+    try {
+      const skillsRes = await axios.get('/api/portal/skills');
+      availableSkills.value = Array.isArray(skillsRes.data) ? skillsRes.data : (skillsRes.data.data || []);
+    } catch (e) {
+      console.warn("Skills not loaded");
+      availableSkills.value = [];
     }
   } catch (e) {
     console.error("Failed to fetch dynamic tools", e);
@@ -958,10 +983,16 @@ const openVersionModal = (
         status: "DRAFT", // Reset status
         comment: `Cloned from V${version.version_number}`,
         created_at: undefined,
+        skills_custom: !!version.skills_custom,
+        skills: version.skills_custom ? [...(version.skills || [])] : [],
       };
     } else {
       // Edit mode
-      versionForm.value = { ...version };
+      versionForm.value = {
+        ...version,
+        skills_custom: !!version.skills_custom,
+        skills: version.skills_custom ? [...(version.skills || [])] : [],
+      };
     }
   } else {
     // Default system prompt from selected agent or empty
@@ -972,6 +1003,8 @@ const openVersionModal = (
       synthesis_temperature: 0.7,
       system_prompt: "",
       tools: [],
+      skills_custom: false,
+      skills: [],
       comment: "",
     };
   }
@@ -1057,16 +1090,29 @@ const saveVersion = async () => {
     return;
   }
 
+  if (versionForm.value.skills_custom && !(versionForm.value.skills?.length)) {
+    showToast("自定义 Skills 开启时至少选择一个公共技能", "warning");
+    versionConfigStep.value = 'tools';
+    toolTab.value = 'skills';
+    return;
+  }
+
+  const payload = {
+    ...versionForm.value,
+    skills_custom: !!versionForm.value.skills_custom,
+    skills: versionForm.value.skills_custom ? (versionForm.value.skills || []) : [],
+  };
+
   try {
     if (versionForm.value.id) {
       await agentApi.updateVersion(
         selectedAgent.value.id,
         versionForm.value.id,
-        versionForm.value
+        payload
       );
       showToast("版本更新成功", "success");
     } else {
-      await agentApi.createVersion(selectedAgent.value.id, versionForm.value);
+      await agentApi.createVersion(selectedAgent.value.id, payload);
       showToast("版本创建成功", "success");
     }
     showVersionModal.value = false;
@@ -1171,6 +1217,32 @@ const toggleTool = (toolName: string) => {
     tools.push(toolName);
   }
   versionForm.value.tools = tools;
+};
+
+const setSkillsCustom = (enabled: boolean) => {
+  if (!canEditVersion.value) return;
+  versionForm.value.skills_custom = enabled;
+  if (!enabled) {
+    versionForm.value.skills = [];
+  } else if (!versionForm.value.skills) {
+    versionForm.value.skills = [];
+  }
+};
+
+const toggleSkill = (skillId: string) => {
+  if (!canEditVersion.value || !versionForm.value.skills_custom) return;
+  const skills = [...(versionForm.value.skills || [])];
+  const index = skills.indexOf(skillId);
+  if (index > -1) {
+    skills.splice(index, 1);
+  } else {
+    skills.push(skillId);
+  }
+  versionForm.value.skills = skills;
+};
+
+const isSkillSelected = (skillId: string) => {
+  return !!(versionForm.value.skills || []).includes(skillId);
 };
 
 const isToolSelected = (toolName: string) => {
@@ -2348,14 +2420,18 @@ const formatDate = (dateStr: string) => {
       :version-config-steps="versionConfigSteps"
       :version-config-progress="versionConfigProgress"
       :selected-tools-count="selectedToolsCount"
+      :selected-skills-count="selectedSkillsCount"
       :prompt-char-count="promptCharCount"
       :version-status-label="versionStatusLabel"
       :version-status-class="versionStatusClass"
       :filtered-grouped-tools="filteredGroupedTools"
       :filtered-grouped-mcp-tools="filteredGroupedMcpTools"
+      :filtered-enabled-skills="filteredEnabledSkills"
+      :enabled-global-skills-count="enabledGlobalSkills.length"
       :all-available-tools-count="allAvailableTools.length"
       :mcp-tools-count="mcpTools.length"
       :is-tool-selected="isToolSelected"
+      :is-skill-selected="isSkillSelected"
       :get-tool-custom-config="getToolCustomConfig"
       :is-all-mcp-selected="isAllMcpSelected"
       :is-mcp-group-collapsed="isMcpGroupCollapsed"
@@ -2369,6 +2445,8 @@ const formatDate = (dateStr: string) => {
       @update:tool-search-query="toolSearchQuery = $event"
       @update:version-config-step="versionConfigStep = $event"
       @toggle-tool="toggleTool"
+      @toggle-skill="toggleSkill"
+      @set-skills-custom="setSkillsCustom"
       @toggle-select-all-mcp="toggleSelectAllMcp"
       @toggle-mcp-group-collapse="toggleMcpGroupCollapse"
       @toggle-static-group-collapse="toggleStaticGroupCollapse"

--- a/frontend/src/views/ChatBIExampleManagement.vue
+++ b/frontend/src/views/ChatBIExampleManagement.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from "vue";
+import { ref, onMounted, computed, watch } from "vue";
 import axios from "@/utils/axios";
 import { useToast } from "../composables/useToast";
 import { useUser } from "../composables/useUser";
@@ -15,11 +15,11 @@ import {
   TrashIcon,
   InformationCircleIcon,
   ArrowPathIcon,
-  FunnelIcon,
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
-  DocumentDuplicateIcon
+  DocumentDuplicateIcon,
+  MagnifyingGlassIcon
 } from "@heroicons/vue/24/outline";
 
 const { hasPermission } = useUser();
@@ -63,14 +63,36 @@ const actionLoading = ref<Record<number, boolean>>({}); // 记录每一行的操
 const total = ref(0);
 const page = ref(1);
 const pageSize = ref(10);
-const showFilters = ref(true);
 const showSyncAllConfirm = ref(false);
 
-const filterStatus = ref("");
+/** 默认进入待审核，便于审核工作流 */
+const filterStatus = ref("pending");
 const filterId = ref<number | null>(null);
 const filterAgentId = ref("");
 const filterDatasetId = ref<number | null>(null);
 const searchQuery = ref("");
+
+const statusTabs = [
+  { value: "pending", label: "待审核" },
+  { value: "approved", label: "已通过" },
+  { value: "rejected", label: "已驳回" },
+  { value: "deprecated", label: "已废弃" },
+  { value: "", label: "全部" },
+] as const;
+
+const hasExtraFilters = computed(() =>
+  Boolean(
+    searchQuery.value.trim() ||
+    filterId.value ||
+    filterAgentId.value.trim() ||
+    filterDatasetId.value
+  )
+);
+
+/** 相对默认「待审核」是否偏离，用于显示「重置」 */
+const hasActiveFilters = computed(
+  () => hasExtraFilters.value || filterStatus.value !== "pending"
+);
 
 const fetchExamples = async () => {
   loading.value = true;
@@ -81,9 +103,9 @@ const fetchExamples = async () => {
     };
     if (filterId.value) params.id = filterId.value;
     if (filterStatus.value) params.status = filterStatus.value;
-    if (filterAgentId.value) params.agent_id = filterAgentId.value;
+    if (filterAgentId.value.trim()) params.agent_id = filterAgentId.value.trim();
     if (filterDatasetId.value) params.dataset_id = filterDatasetId.value;
-    if (searchQuery.value) params.search = searchQuery.value;
+    if (searchQuery.value.trim()) params.search = searchQuery.value.trim();
 
     const res = await axios.get("/api/portal/chatbi-examples", { params });
     if (res.data.code === 200) {
@@ -96,6 +118,34 @@ const fetchExamples = async () => {
     loading.value = false;
   }
 };
+
+let fetchTimer: ReturnType<typeof setTimeout> | null = null;
+const scheduleFetch = (resetPage = true) => {
+  if (fetchTimer) clearTimeout(fetchTimer);
+  fetchTimer = setTimeout(() => {
+    if (resetPage) page.value = 1;
+    fetchExamples();
+  }, 300);
+};
+
+const selectStatusTab = (value: string) => {
+  filterStatus.value = value;
+  page.value = 1;
+  fetchExamples();
+};
+
+const resetFilters = () => {
+  filterId.value = null;
+  filterAgentId.value = "";
+  filterDatasetId.value = null;
+  searchQuery.value = "";
+  filterStatus.value = "pending";
+  page.value = 1;
+  fetchExamples();
+};
+
+watch([searchQuery, filterAgentId], () => scheduleFetch(true));
+watch([filterId, filterDatasetId], () => scheduleFetch(true));
 
 const auditExample = async (id: number, status: string) => {
   if (actionLoading.value[id]) return;
@@ -324,55 +374,86 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="space-y-6">
-    <!-- Header Section -->
-    <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 bg-white p-5 rounded-2xl border border-gray-200/80 shadow-sm mb-6">
-      <div>
-        <h1 class="text-2xl font-bold text-gray-900 tracking-tight">案例集管理</h1>
-        <p class="text-sm text-gray-500 mt-1">管理 AI 执行的 ChatBI 问答经验样本及 RAG 语义对齐案例。</p>
-      </div>
-      <div class="flex items-center gap-3">
-        <!-- 引擎连接指示器 -->
-        <div
-          class="flex items-center gap-2 px-3 py-1.5 rounded-xl text-xs border transition-colors shrink-0 group relative cursor-pointer"
-          :class="{
-            'border-blue-200 bg-blue-50/50 text-blue-700': !isLocalMode && engineStatus === 'checking',
-            'border-emerald-200 bg-emerald-50/50 text-emerald-700': isLocalMode || engineStatus === 'connected',
-            'border-amber-200 bg-amber-50/50 text-amber-700': !isLocalMode && engineStatus === 'disconnected'
-          }"
-        >
-          <span
-            class="inline-block w-2 h-2 rounded-full"
+  <div class="space-y-5">
+    <!-- Header：与任务/技能工作台一致 -->
+    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+      <div class="min-w-0">
+        <div class="flex flex-wrap items-center gap-3">
+          <h1 class="text-xl sm:text-2xl font-bold text-gray-900">案例集管理</h1>
+          <div
+            class="flex items-center gap-2 px-2.5 py-1 rounded-lg text-xs border transition-colors shrink-0 group relative cursor-default"
             :class="{
-              'bg-blue-500 animate-pulse': !isLocalMode && engineStatus === 'checking',
-              'bg-emerald-500': isLocalMode || engineStatus === 'connected',
-              'bg-amber-500': !isLocalMode && engineStatus === 'disconnected'
+              'border-blue-200 bg-blue-50/50 text-blue-700': !isLocalMode && engineStatus === 'checking',
+              'border-emerald-200 bg-emerald-50/50 text-emerald-700': isLocalMode || engineStatus === 'connected',
+              'border-amber-200 bg-amber-50/50 text-amber-700': !isLocalMode && engineStatus === 'disconnected'
             }"
-          ></span>
-          <span class="font-medium">引擎 {{ engineStatusText }}</span>
-
-          <!-- 悬浮 Tooltip 提示引擎详细配置 -->
-          <span class="absolute top-full right-0 mt-2 hidden group-hover:block bg-slate-900 text-white text-xs p-2.5 rounded-lg shadow-xl z-50 text-left font-sans font-normal pointer-events-none">
-            <div class="font-medium mb-1 border-b border-white/10 pb-1">知识库引擎信息</div>
-            <template v-if="isLocalMode">
-              <div class="opacity-80">运行模式: 本地 Redis 向量检索</div>
-              <div class="opacity-80 mt-0.5 text-emerald-400 font-medium">无需连接外部 RAGFlow</div>
-            </template>
-            <template v-else>
-              <div class="opacity-80">地址: {{ ragflowApiUrl }}</div>
-              <div class="opacity-80 mt-1">
-                API Key: 
-                <span v-if="ragflowConfig?.api_key_configured" class="text-emerald-400">已配置</span>
-                <span v-else class="text-amber-400">未配置</span>
-              </div>
-            </template>
-          </span>
+          >
+            <span
+              class="inline-block w-2 h-2 rounded-full"
+              :class="{
+                'bg-blue-500 animate-pulse': !isLocalMode && engineStatus === 'checking',
+                'bg-emerald-500': isLocalMode || engineStatus === 'connected',
+                'bg-amber-500': !isLocalMode && engineStatus === 'disconnected'
+              }"
+            ></span>
+            <span class="font-medium">引擎 {{ engineStatusText }}</span>
+            <span class="absolute top-full left-0 mt-2 hidden group-hover:block bg-slate-900 text-white text-xs p-2.5 rounded-lg shadow-xl z-50 text-left font-sans font-normal pointer-events-none w-56">
+              <div class="font-medium mb-1 border-b border-white/10 pb-1">知识库引擎信息</div>
+              <template v-if="isLocalMode">
+                <div class="opacity-80">运行模式: 本地 Redis 向量检索</div>
+                <div class="opacity-80 mt-0.5 text-emerald-400 font-medium">无需连接外部 RAGFlow</div>
+              </template>
+              <template v-else>
+                <div class="opacity-80 truncate">地址: {{ ragflowApiUrl }}</div>
+                <div class="opacity-80 mt-1">
+                  API Key:
+                  <span v-if="ragflowConfig?.api_key_configured" class="text-emerald-400">已配置</span>
+                  <span v-else class="text-amber-400">未配置</span>
+                </div>
+              </template>
+            </span>
+          </div>
         </div>
+        <p class="text-sm text-gray-500 mt-1">管理 ChatBI 问答经验样本及 RAG 语义对齐案例</p>
+      </div>
+
+      <div class="flex flex-col sm:flex-row sm:items-center gap-2.5 sm:gap-3">
+        <div class="relative w-full sm:w-56 lg:w-72">
+          <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <MagnifyingGlassIcon class="h-4 w-4 text-gray-400" />
+          </span>
+          <input
+            v-model="searchQuery"
+            type="text"
+            placeholder="搜索提问内容..."
+            class="w-full pl-9 pr-3 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none text-sm transition-all shadow-sm"
+          />
+        </div>
+
+        <button
+          @click="fetchExamples"
+          class="p-2 text-gray-500 hover:text-primary bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 transition-colors shrink-0 self-start sm:self-auto"
+          title="刷新列表"
+        >
+          <ArrowPathIcon class="w-4 h-4" :class="{ 'animate-spin': loading }" />
+        </button>
+
+        <button
+          v-if="hasPermission('element:chatbi_example:sync') && !isLocalMode"
+          @click="isEngineReady && (showSyncAllConfirm = true)"
+          :disabled="loading || !isEngineReady"
+          class="inline-flex items-center justify-center gap-1.5 px-3.5 py-2 border border-indigo-200 rounded-lg shadow-sm text-sm font-medium text-indigo-700 bg-indigo-50 hover:bg-indigo-100 transition-all disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+          :title="!isEngineReady ? 'RAGFlow 服务未就绪' : '一键同步至 RAGFlow'"
+        >
+          <CloudArrowUpIcon class="h-4 w-4 text-indigo-600" />
+          <span class="hidden sm:inline">一键同步</span>
+          <span class="sm:hidden">同步</span>
+        </button>
       </div>
     </div>
 
     <!-- Error Banner -->
-    <div v-if="errorMessage && showErrorBanner && !isLocalMode" class="relative rounded-2xl border border-amber-200 bg-amber-50 p-4 pr-10 text-sm text-amber-800 shadow-sm flex items-start gap-3 mb-6">
+    <div v-if="errorMessage && showErrorBanner && !isLocalMode" class="relative rounded-2xl border border-amber-200 bg-amber-50 p-4 pr-10 text-sm text-amber-800 shadow-sm flex items-start gap-3">
       <svg class="w-5 h-5 text-amber-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
       </svg>
@@ -384,7 +465,6 @@ onMounted(async () => {
           <div class="mt-0.5">错误日志: {{ errorMessage }}</div>
         </div>
       </div>
-      <!-- 右上角关闭按钮 -->
       <button @click="showErrorBanner = false" class="absolute top-4 right-4 text-amber-500 hover:text-amber-700 transition-colors" title="关闭">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -392,76 +472,59 @@ onMounted(async () => {
       </button>
     </div>
 
-    <!-- Filters -->
-    <div class="bg-white shadow-sm rounded-lg border border-gray-200 overflow-hidden">
-      <div @click="showFilters = !showFilters" class="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-gray-50 active:bg-gray-100 transition-all duration-200 border-b border-gray-200 select-none">
-        <div class="flex items-center space-x-2">
-          <FunnelIcon class="h-5 w-5 text-gray-500" />
-          <h3 class="text-sm font-medium text-gray-900">筛选条件</h3>
-        </div>
-        <ChevronDownIcon class="h-5 w-5 text-gray-400 transition-transform duration-300" :class="{ 'rotate-180': showFilters }" />
+    <!-- 审核状态 Tab -->
+    <div class="border-b border-gray-200">
+      <div class="flex gap-1 overflow-x-auto -mb-px" style="-webkit-overflow-scrolling: touch;">
+        <button
+          v-for="tab in statusTabs"
+          :key="tab.value || 'all'"
+          type="button"
+          class="inline-flex shrink-0 items-center px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 transition-colors whitespace-nowrap"
+          :class="filterStatus === tab.value ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'"
+          @click="selectStatusTab(tab.value)"
+        >
+          {{ tab.label }}
+        </button>
       </div>
+    </div>
 
-      <div v-show="showFilters" class="p-4">
-        <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
-          <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">序号 ID</label>
-            <input type="number" v-model="filterId" @input="fetchExamples" placeholder="输入 ID" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:ring-blue-500 focus:border-blue-500 outline-none" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">审核状态</label>
-            <select v-model="filterStatus" @change="fetchExamples" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:ring-blue-500 focus:border-blue-500 outline-none">
-              <option value="">全部状态</option>
-              <option value="pending">待审核</option>
-              <option value="approved">已通过</option>
-              <option value="rejected">已驳回</option>
-              <option value="deprecated">已废弃</option>
-            </select>
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">数据集 ID</label>
-            <input type="number" v-model="filterDatasetId" @input="fetchExamples" placeholder="输入 ID" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:ring-blue-500 focus:border-blue-500 outline-none" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Agent ID</label>
-            <input type="text" v-model="filterAgentId" @input="fetchExamples" placeholder="搜索 Agent" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:ring-blue-500 focus:border-blue-500 outline-none" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">每页条数</label>
-            <select v-model.number="pageSize" @change="page = 1; fetchExamples();" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:ring-blue-500 focus:border-blue-500 outline-none">
-              <option :value="10">10 条</option>
-              <option :value="20">20 条</option>
-              <option :value="50">50 条</option>
-            </select>
-          </div>
-        </div>
-        <div class="flex items-center space-x-3 mt-4">
-          <button @click="fetchExamples" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 active:scale-95 shadow-sm transition-all duration-200">
-            应用筛选
-          </button>
-          <button @click="filterId = null; filterStatus = ''; filterAgentId = ''; filterDatasetId = null; page = 1; fetchExamples();" class="inline-flex items-center px-4 py-2 border border-gray-300 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-50 active:scale-95 transition-all duration-200">
-            重置
-          </button>
-          <div class="flex-1"></div>
-          <button
-            @click="fetchExamples"
-            class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 active:scale-95 transition-all duration-200"
-          >
-            <ArrowPathIcon class="h-5 w-5 text-gray-500 mr-2" :class="{ 'animate-spin': loading }" />
-            刷新
-          </button>
-          <button
-            v-if="hasPermission('element:chatbi_example:sync')"
-            @click="isEngineReady && !isLocalMode && (showSyncAllConfirm = true)"
-            :disabled="loading || !isEngineReady || isLocalMode"
-            class="inline-flex items-center px-4 py-2 border border-indigo-200 rounded-md shadow-sm text-sm font-medium text-indigo-700 bg-indigo-50 hover:bg-indigo-100 active:scale-95 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-            :title="isLocalMode ? '本地向量模式下已自动同步，无需手动上传' : (!isEngineReady ? 'RAGFlow 服务未就绪' : '一键同步至 RAGFlow')"
-          >
-            <CloudArrowUpIcon class="h-5 w-5 text-indigo-600 mr-2" :class="{ 'animate-pulse': loading }" />
-            一键同步至 RAGFlow
-          </button>
-        </div>
+    <!-- 次级筛选：ID / 数据集 / Agent -->
+    <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-end gap-2.5 sm:gap-3">
+      <div class="w-full sm:w-28">
+        <label class="block text-xs font-medium text-gray-500 mb-1">序号 ID</label>
+        <input
+          type="number"
+          v-model="filterId"
+          placeholder="ID"
+          class="w-full px-2.5 py-1.5 border border-gray-300 rounded-lg text-sm shadow-sm focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none"
+        />
       </div>
+      <div class="w-full sm:w-28">
+        <label class="block text-xs font-medium text-gray-500 mb-1">数据集 ID</label>
+        <input
+          type="number"
+          v-model="filterDatasetId"
+          placeholder="Dataset"
+          class="w-full px-2.5 py-1.5 border border-gray-300 rounded-lg text-sm shadow-sm focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none"
+        />
+      </div>
+      <div class="w-full sm:w-40">
+        <label class="block text-xs font-medium text-gray-500 mb-1">Agent ID</label>
+        <input
+          type="text"
+          v-model="filterAgentId"
+          placeholder="搜索 Agent"
+          class="w-full px-2.5 py-1.5 border border-gray-300 rounded-lg text-sm shadow-sm focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none"
+        />
+      </div>
+      <button
+        v-if="hasActiveFilters"
+        type="button"
+        @click="resetFilters"
+        class="text-sm text-gray-500 hover:text-gray-800 px-2 py-1.5 transition-colors shrink-0"
+      >
+        重置筛选
+      </button>
     </div>
 
     <!-- Table Card -->
@@ -470,45 +533,74 @@ onMounted(async () => {
         <table class="min-w-full divide-y divide-gray-200">
           <thead class="bg-gray-50">
             <tr>
-              <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">ID</th>
-              <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">用户提问</th>
-              <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">反馈/质量</th>
-              <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">状态</th>
-              <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">RAG 同步</th>
-              <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">时间</th>
-              <th scope="col" class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">操作</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">ID</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider min-w-[12rem]">用户提问</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">反馈</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">状态</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">RAG 同步</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">智能体</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">时间</th>
+              <th scope="col" class="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">操作</th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
-            <tr v-if="examples.length === 0" class="text-center">
-              <td colspan="6" class="px-6 py-12 text-gray-400 italic text-sm">暂无反馈数据</td>
+            <tr v-if="!loading && examples.length === 0">
+              <td colspan="8" class="px-6 py-14 text-center">
+                <p class="text-sm text-gray-500 font-medium">
+                  <template v-if="hasExtraFilters || filterStatus !== 'pending'">
+                    没有符合当前筛选条件的案例
+                  </template>
+                  <template v-else-if="filterStatus === 'pending'">
+                    暂无待审核案例
+                  </template>
+                  <template v-else>
+                    暂无案例数据
+                  </template>
+                </p>
+                <p v-if="hasActiveFilters" class="text-xs text-gray-400 mt-1.5">可调整关键词、状态或 ID 后重试</p>
+                <button
+                  v-if="hasActiveFilters"
+                  type="button"
+                  @click="resetFilters"
+                  class="mt-4 inline-flex items-center px-3.5 py-2 text-sm font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 rounded-lg transition-colors"
+                >
+                  清除筛选
+                </button>
+              </td>
             </tr>
             <tr v-for="ex in examples" :key="ex.id" class="hover:bg-gray-50/80 transition-colors">
-              <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-500">
+              <td class="px-4 py-3.5 whitespace-nowrap text-sm font-mono text-gray-500">
                 #{{ ex.id }}
               </td>
-              <td class="px-6 py-4">
-                <div class="flex items-start group">
-                  <div class="text-sm font-medium text-gray-900 line-clamp-2 max-w-md flex-1">{{ ex.user_query }}</div>
-                  <button @click="copyToClipboard(ex.user_query)" class="ml-2 p-1 text-gray-400 hover:text-blue-600 opacity-0 group-hover:opacity-100 transition-all duration-200" title="复制提问内容">
+              <td class="px-4 py-3.5">
+                <div class="flex items-start group max-w-md">
+                  <div class="text-sm font-medium text-gray-900 line-clamp-2 flex-1">{{ ex.user_query }}</div>
+                  <button @click="copyToClipboard(ex.user_query)" class="ml-1.5 p-1 text-gray-400 hover:text-blue-600 opacity-0 group-hover:opacity-100 transition-all shrink-0" title="复制提问">
                     <DocumentDuplicateIcon class="w-4 h-4" />
                   </button>
                 </div>
-                <div class="text-[10px] text-gray-400 font-mono mt-1">Trace: {{ ex.trace_id.substring(0, 8) }}... | Dataset: {{ ex.dataset_id }}</div>
+                <button
+                  type="button"
+                  class="mt-1 text-[10px] text-gray-400 font-mono hover:text-blue-600 transition-colors"
+                  :title="'点击复制完整 Trace: ' + ex.trace_id"
+                  @click="copyToClipboard(ex.trace_id)"
+                >
+                  Trace {{ ex.trace_id.substring(0, 8) }}…
+                </button>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="flex items-center space-x-1">
+              <td class="px-4 py-3.5 whitespace-nowrap">
+                <div class="flex items-center gap-1.5">
                   <HandThumbUpIcon v-if="ex.feedback_type === 'up'" class="w-5 h-5 text-green-500" />
                   <HandThumbDownIcon v-else class="w-5 h-5 text-red-500" />
-                  <span class="text-xs text-gray-600 font-medium">引用: {{ ex.use_count }}</span>
+                  <span class="text-xs text-gray-500">引用 {{ ex.use_count }}</span>
                 </div>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <span :class="['px-2.5 py-0.5 text-xs rounded-full font-medium border transition-all duration-300', getStatusLabel(ex.status).color]">
+              <td class="px-4 py-3.5 whitespace-nowrap">
+                <span :class="['px-2.5 py-0.5 text-xs rounded-full font-medium border', getStatusLabel(ex.status).color]">
                   {{ getStatusLabel(ex.status).label }}
                 </span>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap">
+              <td class="px-4 py-3.5 whitespace-nowrap">
                 <div class="flex flex-col">
                   <span :class="['text-xs font-semibold', getRagStatusDisplay(ex).color]">
                     {{ getRagStatusDisplay(ex).label }}
@@ -516,36 +608,35 @@ onMounted(async () => {
                   <span v-if="ex.rag_synced_at" class="text-[10px] text-gray-400 font-mono">{{ new Date(ex.rag_synced_at).toLocaleString() }}</span>
                 </div>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap text-xs text-gray-500">
-                <div class="font-mono">{{ new Date(ex.created_at).toLocaleString() }}</div>
-                <div class="mt-1 text-gray-400 flex items-center space-x-1">
-                  <span class="bg-blue-50 text-blue-600 px-1.5 py-0.5 rounded text-[10px] font-medium">{{ ex.agent_display_name || '未知智能体' }}</span>
-                  <span class="text-gray-300">/</span>
-                  <span class="bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded text-[10px]">{{ ex.user_real_name || '系统' }}</span>
-                </div>
+              <td class="px-4 py-3.5 whitespace-nowrap">
+                <div class="text-xs font-medium text-gray-800">{{ ex.agent_display_name || '未知智能体' }}</div>
+                <div class="text-[10px] text-gray-400 mt-0.5">{{ ex.user_real_name || '系统' }} · Dataset {{ ex.dataset_id }}</div>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+              <td class="px-4 py-3.5 whitespace-nowrap text-xs text-gray-500 font-mono">
+                {{ new Date(ex.created_at).toLocaleString() }}
+              </td>
+              <td class="px-4 py-3.5 whitespace-nowrap text-right text-sm font-medium">
                 <div class="flex justify-end space-x-1">
-                  <button @click="viewDetail(ex)" class="p-1.5 rounded-full text-blue-600 hover:bg-blue-50 active:scale-90 transition-all duration-200" title="查看详情">
+                  <button @click="viewDetail(ex)" class="p-1.5 rounded-full text-blue-600 hover:bg-blue-50 active:scale-90 transition-all" title="查看详情">
                     <InformationCircleIcon class="w-5 h-5" />
                   </button>
-                  
+
                   <template v-if="actionLoading[ex.id]">
                     <div class="p-1.5">
                       <ArrowPathIcon class="w-5 h-5 text-gray-400 animate-spin" />
                     </div>
                   </template>
                   <template v-else>
-                    <button v-if="hasPermission('element:chatbi_example:audit') && ex.status === 'pending'" @click="auditExample(ex.id, 'approved')" class="p-1.5 rounded-full text-green-600 hover:bg-green-50 active:scale-90 transition-all duration-200" title="批准">
+                    <button v-if="hasPermission('element:chatbi_example:audit') && ex.status === 'pending'" @click="auditExample(ex.id, 'approved')" class="p-1.5 rounded-full text-green-600 hover:bg-green-50 active:scale-90 transition-all" title="批准">
                       <CheckCircleIcon class="w-5 h-5" />
                     </button>
-                    <button v-if="hasPermission('element:chatbi_example:audit') && ex.status === 'pending'" @click="auditExample(ex.id, 'rejected')" class="p-1.5 rounded-full text-red-600 hover:bg-red-50 active:scale-90 transition-all duration-200" title="驳回">
+                    <button v-if="hasPermission('element:chatbi_example:audit') && ex.status === 'pending'" @click="auditExample(ex.id, 'rejected')" class="p-1.5 rounded-full text-red-600 hover:bg-red-50 active:scale-90 transition-all" title="驳回">
                       <XCircleIcon class="w-5 h-5" />
                     </button>
-                    <button v-if="hasPermission('element:chatbi_example:sync') && ex.status === 'approved'" @click="isEngineReady && !isLocalMode && syncToRag(ex.id)" :disabled="!isEngineReady || isLocalMode" class="p-1.5 rounded-full text-indigo-600 hover:bg-indigo-50 active:scale-90 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed" :title="isLocalMode ? '本地向量模式下已自动同步，无需手动上传' : (!isEngineReady ? 'RAGFlow 服务未就绪' : '同步到 RAGFlow')">
+                    <button v-if="hasPermission('element:chatbi_example:sync') && ex.status === 'approved' && !isLocalMode" @click="isEngineReady && syncToRag(ex.id)" :disabled="!isEngineReady" class="p-1.5 rounded-full text-indigo-600 hover:bg-indigo-50 active:scale-90 transition-all disabled:opacity-50 disabled:cursor-not-allowed" :title="!isEngineReady ? 'RAGFlow 服务未就绪' : '同步到 RAGFlow'">
                       <CloudArrowUpIcon class="w-5 h-5" />
                     </button>
-                    <button v-if="hasPermission('element:chatbi_example:delete') && ex.status !== 'deprecated'" @click="auditExample(ex.id, 'deprecated')" class="p-1.5 rounded-full text-gray-400 hover:bg-gray-100 active:scale-90 transition-all duration-200" title="废弃">
+                    <button v-if="hasPermission('element:chatbi_example:delete') && ex.status !== 'deprecated'" @click="auditExample(ex.id, 'deprecated')" class="p-1.5 rounded-full text-gray-400 hover:bg-gray-100 active:scale-90 transition-all" title="废弃">
                       <TrashIcon class="w-5 h-5" />
                     </button>
                   </template>
@@ -557,32 +648,37 @@ onMounted(async () => {
       </div>
 
       <!-- Footer/Pagination -->
-      <div class="bg-gray-50 px-4 py-3 border-t border-gray-200 flex items-center justify-between sm:px-6">
-        <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
-          <div>
-            <p class="text-sm text-gray-700">
-              第 <span class="font-medium">{{ page }}</span> 页，共 <span class="font-medium">{{ total }}</span> 条结果
-            </p>
-          </div>
-          <div>
-            <nav class="relative z-0 inline-flex rounded-md shadow-sm -space-x-px">
-              <button 
-                @click="page > 1 && (page--, fetchExamples())" 
-                :disabled="page <= 1"
-                class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 active:bg-gray-100 active:scale-90 disabled:opacity-50 transition-all duration-200"
-              >
-                <ChevronLeftIcon class="h-5 w-5" />
-              </button>
-              <button 
-                @click="page * pageSize < total && (page++, fetchExamples())" 
-                :disabled="page * pageSize >= total"
-                class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 active:bg-gray-100 active:scale-90 disabled:opacity-50 transition-all duration-200"
-              >
-                <ChevronRightIcon class="h-5 w-5" />
-              </button>
-            </nav>
-          </div>
+      <div class="bg-gray-50 px-4 py-3 border-t border-gray-200 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div class="flex flex-wrap items-center gap-3 text-sm text-gray-700">
+          <p>
+            第 <span class="font-medium">{{ page }}</span> 页，共 <span class="font-medium">{{ total }}</span> 条
+          </p>
+          <select
+            v-model.number="pageSize"
+            @change="page = 1; fetchExamples()"
+            class="text-sm border border-gray-300 rounded-lg py-1.5 px-2 bg-white shadow-sm focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none"
+          >
+            <option :value="10">10 条/页</option>
+            <option :value="20">20 条/页</option>
+            <option :value="50">50 条/页</option>
+          </select>
         </div>
+        <nav class="inline-flex rounded-md shadow-sm -space-x-px">
+          <button
+            @click="page > 1 && (page--, fetchExamples())"
+            :disabled="page <= 1"
+            class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 transition-all"
+          >
+            <ChevronLeftIcon class="h-5 w-5" />
+          </button>
+          <button
+            @click="page * pageSize < total && (page++, fetchExamples())"
+            :disabled="page * pageSize >= total"
+            class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 transition-all"
+          >
+            <ChevronRightIcon class="h-5 w-5" />
+          </button>
+        </nav>
       </div>
     </div>
 

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -1362,6 +1362,7 @@
       v-model:pinned="skillPinned"
       :pinned-dock-class="skillPinnedDockClass"
       :attached-skill-ids="attachedSkillIds"
+      :agent-id="effectiveEmbedChatAgentId"
       @select="handleSelectSkill"
     />
 

--- a/frontend/src/views/MemoryManagement.vue
+++ b/frontend/src/views/MemoryManagement.vue
@@ -645,13 +645,17 @@ onMounted(async () => {
 
 <template>
   <div class="space-y-5">
-    <!-- Header（与技能管理顶格一致，由 Dashboard main 统一留白） -->
-    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
-      <div class="min-w-0">
-        <h1 class="text-2xl font-bold tracking-normal text-gray-900 dark:text-white">记忆工作台</h1>
-        <p class="text-sm text-gray-500 mt-1">跨会话摘要、向量检索与 Redis 会话明细管理（配置独立于系统设置）</p>
-      </div>
-      <div class="flex gap-1 border-b border-gray-200 dark:border-gray-700 shrink-0">
+    <!-- Header：标题左，与技能/智能体中心一致 -->
+    <div class="flex items-center space-x-3">
+      <h1 class="text-xl sm:text-2xl font-bold tracking-normal text-gray-900 dark:text-white">记忆工作台</h1>
+      <span class="hidden sm:inline text-xs text-gray-400 truncate max-w-md">
+        跨会话摘要 · 向量检索 · Redis 会话明细
+      </span>
+    </div>
+
+    <!-- Tab：全宽底边，移动端可横滑 -->
+    <div class="border-b border-gray-200 dark:border-gray-700 -mt-1">
+      <div class="flex gap-1 overflow-x-auto -mb-px" style="-webkit-overflow-scrolling: touch;">
         <button
           v-for="t in [
             { id: 'config', label: '服务配置' },
@@ -660,7 +664,7 @@ onMounted(async () => {
           ]"
           :key="t.id"
           type="button"
-          class="px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap disabled:opacity-40 disabled:cursor-not-allowed"
+          class="px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 transition-colors whitespace-nowrap disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
           :class="activeTab === t.id ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'"
           :disabled="!memoryFeaturesEnabled && !vectorChecking"
           @click="activeTab = t.id as any"
@@ -681,20 +685,20 @@ onMounted(async () => {
 
     <div
       v-else-if="!vectorReady && vectorHealth"
-      class="bg-amber-50 border border-amber-200 rounded-lg p-5 shadow-sm space-y-4"
+      class="bg-amber-50 border border-amber-200 rounded-lg p-4 sm:p-5 shadow-sm space-y-4"
     >
-      <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-        <div>
+      <div class="flex flex-col gap-3">
+        <div class="min-w-0">
           <h2 class="text-base font-semibold text-amber-900">记忆服务不可用</h2>
-          <p class="text-sm text-amber-800 mt-1">{{ vectorHealth.message }}</p>
-          <p class="text-xs text-amber-700 mt-2 font-mono">
+          <p class="text-sm text-amber-800 mt-1 break-words">{{ vectorHealth.message }}</p>
+          <p class="text-xs text-amber-700 mt-2 font-mono break-all">
             当前连接：{{ vectorHealth.redis_host }}:{{ vectorHealth.redis_port }} / db
             {{ vectorHealth.redis_db }}
           </p>
         </div>
         <button
           type="button"
-          class="shrink-0 px-4 py-2 bg-amber-600 text-white rounded-lg text-sm font-medium hover:bg-amber-700 shadow-sm"
+          class="w-full sm:w-auto self-start px-4 py-2.5 bg-amber-600 text-white rounded-lg text-sm font-medium hover:bg-amber-700 shadow-sm"
           @click="runVectorTest(true)"
         >
           重新检测
@@ -704,26 +708,28 @@ onMounted(async () => {
         <li v-for="(hint, i) in vectorHealth.hints" :key="i">{{ hint }}</li>
       </ul>
       <div v-if="vectorHealth.checks?.length" class="border border-amber-200 rounded-lg overflow-hidden bg-white">
-        <table class="w-full text-xs">
-          <thead class="bg-amber-100/80">
-            <tr>
-              <th class="text-left p-2 font-medium">检查项</th>
-              <th class="text-left p-2 font-medium">结果</th>
-              <th class="text-left p-2 font-medium">说明</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="c in vectorHealth.checks" :key="c.name" class="border-t border-amber-100">
-              <td class="p-2 font-mono">{{ c.name }}</td>
-              <td class="p-2">
-                <span :class="c.passed ? 'text-green-600' : 'text-red-600'">
-                  {{ c.passed ? '通过' : '失败' }}
-                </span>
-              </td>
-              <td class="p-2 text-gray-700">{{ c.message }}</td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="overflow-x-auto">
+          <table class="w-full text-xs min-w-[320px]">
+            <thead class="bg-amber-100/80">
+              <tr>
+                <th class="text-left p-2 font-medium">检查项</th>
+                <th class="text-left p-2 font-medium">结果</th>
+                <th class="text-left p-2 font-medium">说明</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="c in vectorHealth.checks" :key="c.name" class="border-t border-amber-100">
+                <td class="p-2 font-mono whitespace-nowrap">{{ c.name }}</td>
+                <td class="p-2 whitespace-nowrap">
+                  <span :class="c.passed ? 'text-green-600' : 'text-red-600'">
+                    {{ c.passed ? '通过' : '失败' }}
+                  </span>
+                </td>
+                <td class="p-2 text-gray-700">{{ c.message }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
       <p class="text-xs text-amber-800">
         在检测通过前，本页配置、记忆数据、检索测试等功能均已禁用。线上对话中的 memory_search 摘要写入也会受影响。
@@ -732,12 +738,12 @@ onMounted(async () => {
 
     <div
       v-else-if="vectorReady"
-      class="bg-green-50 border border-green-200 rounded-lg px-4 py-2 flex flex-wrap items-center justify-between gap-2 text-sm"
+      class="bg-green-50 border border-green-200 rounded-lg px-3 sm:px-4 py-2 flex flex-col xs:flex-row sm:flex-row sm:items-center sm:justify-between gap-2 text-sm"
     >
-      <span class="text-green-800">{{ vectorHealth?.message || 'Redis 向量环境正常' }}</span>
+      <span class="text-green-800 text-xs sm:text-sm leading-relaxed">{{ vectorHealth?.message || 'Redis 向量环境正常' }}</span>
       <button
         type="button"
-        class="text-green-700 hover:text-green-900 text-xs underline"
+        class="self-start sm:self-auto shrink-0 px-2.5 py-1 text-green-700 hover:text-green-900 text-xs font-medium border border-green-200 rounded-md hover:bg-green-100/60 transition-colors"
         @click="runVectorTest(true)"
       >
         重新检测
@@ -751,54 +757,60 @@ onMounted(async () => {
     >
     <!-- 服务配置 -->
     <div v-show="activeTab === 'config' && memoryFeaturesEnabled" class="space-y-5">
-      <div class="flex flex-wrap gap-2">
+      <div class="flex flex-col sm:flex-row sm:flex-wrap gap-2">
         <button
           v-if="canSave"
           type="button"
-          class="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 shadow-sm"
+          class="w-full sm:w-auto px-4 py-2.5 sm:py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 shadow-sm order-1"
           :disabled="savingConfig"
           @click="saveConfigs"
         >
-          保存配置
+          {{ savingConfig ? '保存中…' : '保存配置' }}
         </button>
-        <button
-          v-if="canSave && summaryEnabled"
-          type="button"
-          class="px-4 py-2 bg-white border border-gray-300 rounded-lg text-sm hover:bg-gray-50 shadow-sm disabled:opacity-40"
-          @click="testEmbedding"
-        >
-          测试 Embedding
-        </button>
-        <button
-          v-if="canIndex && summaryEnabled"
-          type="button"
-          class="px-4 py-2 bg-white border border-gray-300 rounded-lg text-sm hover:bg-gray-50 shadow-sm"
-          @click="loadIndexStatus"
-        >
-          刷新索引状态
-        </button>
-        <button
-          v-if="canIndex && summaryEnabled"
-          type="button"
-          class="px-4 py-2 bg-white border border-amber-200 text-amber-700 rounded-lg text-sm hover:bg-amber-50 shadow-sm"
-          @click="requestRebuildIndex"
-        >
-          检查/创建索引
-        </button>
+        <div class="grid grid-cols-2 sm:flex sm:flex-wrap gap-2 order-2">
+          <button
+            v-if="canSave && summaryEnabled"
+            type="button"
+            class="px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm hover:bg-gray-50 shadow-sm disabled:opacity-40"
+            @click="testEmbedding"
+          >
+            测试 Embedding
+          </button>
+          <button
+            v-if="canIndex && summaryEnabled"
+            type="button"
+            class="px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm hover:bg-gray-50 shadow-sm"
+            @click="loadIndexStatus"
+          >
+            刷新索引状态
+          </button>
+          <button
+            v-if="canIndex && summaryEnabled"
+            type="button"
+            class="col-span-2 sm:col-span-1 px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm hover:bg-gray-50 shadow-sm text-gray-700"
+            @click="requestRebuildIndex"
+          >
+            检查/创建索引
+          </button>
+        </div>
       </div>
 
       <div
         v-if="summaryEnabled && indexStatus"
-        class="bg-white border border-gray-200 rounded-lg px-4 py-3 shadow-sm flex flex-wrap items-center gap-3 text-sm"
+        class="bg-white border border-gray-200 rounded-lg px-4 py-3 shadow-sm flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-2 sm:gap-3 text-sm"
       >
         <span
-          class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
+          class="inline-flex self-start items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
           :class="indexStatus.available ? 'bg-green-100 text-green-800' : 'bg-amber-100 text-amber-800'"
         >
           {{ indexStatus.available ? '索引正常' : '索引未就绪' }}
         </span>
-        <span class="text-gray-600">{{ indexStatusLabel }}</span>
-        <span v-if="indexStatus.index_name" class="text-gray-400 font-mono text-xs">{{ indexStatus.index_name }}</span>
+        <span class="text-gray-600 text-xs sm:text-sm">{{ indexStatusLabel }}</span>
+        <span
+          v-if="indexStatus.index_name"
+          class="text-gray-400 font-mono text-[11px] sm:text-xs break-all"
+          :title="indexStatus.index_name"
+        >{{ indexStatus.index_name }}</span>
       </div>
 
       <div v-if="configLoading" class="flex flex-col items-center justify-center py-16">
@@ -845,11 +857,10 @@ onMounted(async () => {
                           </svg>
                         </button>
                         <!-- 悬浮提示框 -->
-                        <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2.5 hidden group-hover:block w-72 p-3 bg-gray-900/95 dark:bg-gray-950/95 text-white text-xs rounded-xl shadow-xl border border-gray-800 dark:border-gray-800 backdrop-blur-sm z-[100] pointer-events-none">
+                        <div class="absolute left-0 top-full mt-2 hidden group-hover:block group-focus-within:block w-[min(18rem,calc(100vw-2rem))] p-3 bg-gray-900/95 dark:bg-gray-950/95 text-white text-xs rounded-xl shadow-xl border border-gray-800 dark:border-gray-800 backdrop-blur-sm z-[100] pointer-events-none">
                            <div class="leading-relaxed text-left font-normal normal-case break-words whitespace-normal font-sans">
                               {{ CONFIG_TIPS[key] || getConfigItem(key)!.description }}
                            </div>
-                           <div class="absolute right-full top-1/2 -translate-y-1/2 border-4 border-transparent border-r-gray-900/95 dark:border-r-gray-950/95"></div>
                         </div>
                       </div>
                     </div>
@@ -884,11 +895,10 @@ onMounted(async () => {
                         </svg>
                       </button>
                       <!-- 悬浮提示框 -->
-                      <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2.5 hidden group-hover:block w-72 p-3 bg-gray-900/95 dark:bg-gray-950/95 text-white text-xs rounded-xl shadow-xl border border-gray-800 dark:border-gray-800 backdrop-blur-sm z-[100] pointer-events-none">
+                      <div class="absolute left-0 top-full mt-2 hidden group-hover:block group-focus-within:block w-[min(18rem,calc(100vw-2rem))] p-3 bg-gray-900/95 dark:bg-gray-950/95 text-white text-xs rounded-xl shadow-xl border border-gray-800 dark:border-gray-800 backdrop-blur-sm z-[100] pointer-events-none">
                          <div class="leading-relaxed text-left font-normal normal-case break-words whitespace-normal font-sans">
                             {{ CONFIG_TIPS[key] || getConfigItem(key)!.description }}
                          </div>
-                         <div class="absolute right-full top-1/2 -translate-y-1/2 border-4 border-transparent border-r-gray-900/95 dark:border-r-gray-950/95"></div>
                       </div>
                     </div>
                   </div>
@@ -919,11 +929,10 @@ onMounted(async () => {
                         </svg>
                       </button>
                       <!-- 悬浮提示框 -->
-                      <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2.5 hidden group-hover:block w-72 p-3 bg-gray-900/95 dark:bg-gray-950/95 text-white text-xs rounded-xl shadow-xl border border-gray-800 dark:border-gray-800 backdrop-blur-sm z-[100] pointer-events-none">
+                      <div class="absolute left-0 top-full mt-2 hidden group-hover:block group-focus-within:block w-[min(18rem,calc(100vw-2rem))] p-3 bg-gray-900/95 dark:bg-gray-950/95 text-white text-xs rounded-xl shadow-xl border border-gray-800 dark:border-gray-800 backdrop-blur-sm z-[100] pointer-events-none">
                          <div class="leading-relaxed text-left font-normal normal-case break-words whitespace-normal font-sans">
                             {{ CONFIG_TIPS[key] || getConfigItem(key)!.description }}
                          </div>
-                         <div class="absolute right-full top-1/2 -translate-y-1/2 border-4 border-transparent border-r-gray-900/95 dark:border-r-gray-950/95"></div>
                       </div>
                     </div>
                   </div>
@@ -961,11 +970,10 @@ onMounted(async () => {
                         </svg>
                       </button>
                       <!-- 悬浮提示框 -->
-                      <div class="absolute left-full top-1/2 -translate-y-1/2 ml-2.5 hidden group-hover:block w-72 p-3 bg-gray-900/95 dark:bg-gray-950/95 text-white text-xs rounded-xl shadow-xl border border-gray-800 dark:border-gray-800 backdrop-blur-sm z-[100] pointer-events-none">
+                      <div class="absolute left-0 top-full mt-2 hidden group-hover:block group-focus-within:block w-[min(18rem,calc(100vw-2rem))] p-3 bg-gray-900/95 dark:bg-gray-950/95 text-white text-xs rounded-xl shadow-xl border border-gray-800 dark:border-gray-800 backdrop-blur-sm z-[100] pointer-events-none">
                          <div class="leading-relaxed text-left font-normal normal-case break-words whitespace-normal font-sans">
                             {{ CONFIG_TIPS[key] || getConfigItem(key)!.description }}
                          </div>
-                         <div class="absolute right-full top-1/2 -translate-y-1/2 border-4 border-transparent border-r-gray-900/95 dark:border-r-gray-950/95"></div>
                       </div>
                     </div>
                   </div>
@@ -997,9 +1005,9 @@ onMounted(async () => {
     <div v-show="activeTab === 'data' && memoryFeaturesEnabled" class="space-y-4">
       <div v-if="!canViewData" class="text-gray-500 text-sm">无「查看记忆数据」权限</div>
       <template v-else>
-        <div class="flex flex-col gap-3">
-          <div class="flex items-center gap-3">
-            <div class="inline-flex w-fit rounded-lg border border-gray-200 bg-white p-1 shadow-sm">
+          <div class="flex flex-col gap-3">
+          <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+            <div class="inline-flex w-full sm:w-fit rounded-lg border border-gray-200 bg-white p-1 shadow-sm">
               <button
                 v-for="view in [
                   { id: 'daily', label: '每日摘要' },
@@ -1007,7 +1015,7 @@ onMounted(async () => {
                 ]"
                 :key="view.id"
                 type="button"
-                class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors"
+                class="flex-1 sm:flex-none px-3 py-2 sm:py-1.5 text-sm font-medium rounded-md transition-colors"
                 :class="dataView === view.id ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-50'"
                 @click="switchDataView(view.id as 'daily' | 'session')"
               >
@@ -1019,7 +1027,7 @@ onMounted(async () => {
             <button
               v-if="dataView === 'session' && canIndex"
               type="button"
-              class="px-3.5 py-2 text-sm font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-lg hover:bg-emerald-100 transition-colors flex items-center gap-1.5 shadow-sm disabled:opacity-50"
+              class="w-full sm:w-auto px-3.5 py-2 text-sm font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-lg hover:bg-emerald-100 transition-colors flex items-center justify-center gap-1.5 shadow-sm disabled:opacity-50"
               :disabled="consolidating"
               @click="runConsolidation"
             >
@@ -1029,40 +1037,40 @@ onMounted(async () => {
             </button>
           </div>
           <div class="flex flex-wrap gap-3 items-end">
-            <div v-if="canViewAllUsers">
+            <div v-if="canViewAllUsers" class="w-[calc(50%-0.375rem)] sm:w-auto">
               <label class="text-xs text-gray-500 block mb-1">用户 ID</label>
               <input
                 v-model.number="filterUserId"
                 type="number"
-                class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-28 bg-white shadow-sm dark:bg-gray-800"
+                class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-full sm:w-28 bg-white shadow-sm dark:bg-gray-800"
                 placeholder="可选"
               />
             </div>
-            <div v-if="canViewAllUsers">
+            <div v-if="canViewAllUsers" class="w-[calc(50%-0.375rem)] sm:w-auto">
               <label class="text-xs text-gray-500 block mb-1">用户名</label>
               <input
                 v-model="filterUsername"
-                class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-36 bg-white shadow-sm dark:bg-gray-800"
+                class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-full sm:w-36 bg-white shadow-sm dark:bg-gray-800"
                 placeholder="登录名/姓名"
               />
             </div>
-            <div v-if="dataView === 'daily'">
+            <div v-if="dataView === 'daily'" class="w-[calc(50%-0.375rem)] sm:w-auto">
               <label class="text-xs text-gray-500 block mb-1">开始日期</label>
               <input
                 v-model="filterDateFrom"
                 type="date"
-                class="border border-gray-300 rounded-lg px-2 py-2 text-sm bg-white shadow-sm dark:bg-gray-800"
+                class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-full bg-white shadow-sm dark:bg-gray-800"
               />
             </div>
-            <div v-if="dataView === 'daily'">
+            <div v-if="dataView === 'daily'" class="w-[calc(50%-0.375rem)] sm:w-auto">
               <label class="text-xs text-gray-500 block mb-1">结束日期</label>
               <input
                 v-model="filterDateTo"
                 type="date"
-                class="border border-gray-300 rounded-lg px-2 py-2 text-sm bg-white shadow-sm dark:bg-gray-800"
+                class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-full bg-white shadow-sm dark:bg-gray-800"
               />
             </div>
-            <div class="flex-1 min-w-[12rem]">
+            <div class="w-full sm:flex-1 sm:min-w-[12rem]">
               <label class="text-xs text-gray-500 block mb-1">关键词</label>
               <input
                 v-model="filterKeyword"
@@ -1073,7 +1081,7 @@ onMounted(async () => {
             </div>
             <button
               type="button"
-              class="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 shadow-sm disabled:opacity-50"
+              class="w-full sm:w-auto px-4 py-2.5 sm:py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 shadow-sm disabled:opacity-50"
               :disabled="dataLoading"
               @click="fetchMemoryData"
             >
@@ -1251,53 +1259,53 @@ onMounted(async () => {
       <div v-if="!canTestSearch" class="text-gray-500 text-sm">无「记忆检索测试」权限</div>
       <template v-else>
         <div class="flex flex-wrap gap-3 items-end">
-          <div v-if="canViewAllUsers">
+          <div v-if="canViewAllUsers" class="w-[calc(50%-0.375rem)] sm:w-auto">
             <label class="text-xs text-gray-500 block mb-1">用户 ID</label>
             <input
               v-model.number="searchUserId"
               type="number"
-              class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-28 bg-white shadow-sm dark:bg-gray-800"
+              class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-full sm:w-28 bg-white shadow-sm dark:bg-gray-800"
               placeholder="可选"
             />
           </div>
-          <div v-if="canViewAllUsers">
+          <div v-if="canViewAllUsers" class="w-[calc(50%-0.375rem)] sm:w-auto">
             <label class="text-xs text-gray-500 block mb-1">用户名</label>
             <input
               v-model="searchUsername"
-              class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-36 bg-white shadow-sm dark:bg-gray-800"
+              class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-full sm:w-36 bg-white shadow-sm dark:bg-gray-800"
               placeholder="登录名/姓名"
             />
           </div>
-          <div>
+          <div class="w-[calc(50%-0.375rem)] sm:w-auto">
             <label class="text-xs text-gray-500 block mb-1">scope</label>
             <select
               v-model="searchScope"
-              class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-32 bg-white shadow-sm dark:bg-gray-800"
+              class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-full sm:w-32 bg-white shadow-sm dark:bg-gray-800"
             >
               <option value="summary">summary</option>
               <option value="history">history</option>
               <option value="both">both</option>
             </select>
           </div>
-          <div>
-            <label class="text-xs text-gray-500 block mb-1">conversation_id</label>
-            <input
-              v-model="searchConvId"
-              class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-56 bg-white shadow-sm dark:bg-gray-800 font-mono text-xs"
-            />
-          </div>
-          <div>
+          <div class="w-[calc(50%-0.375rem)] sm:w-auto">
             <label class="text-xs text-gray-500 block mb-1">limit</label>
             <input
               v-model.number="searchLimit"
               type="number"
               min="1"
-              class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-20 bg-white shadow-sm dark:bg-gray-800"
+              class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-full sm:w-20 bg-white shadow-sm dark:bg-gray-800"
+            />
+          </div>
+          <div class="w-full sm:w-auto sm:flex-1 sm:min-w-[14rem]">
+            <label class="text-xs text-gray-500 block mb-1">conversation_id</label>
+            <input
+              v-model="searchConvId"
+              class="border border-gray-300 rounded-lg px-2 py-2 text-sm w-full sm:w-56 bg-white shadow-sm dark:bg-gray-800 font-mono text-xs"
             />
           </div>
           <button
             type="button"
-            class="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 shadow-sm disabled:opacity-50"
+            class="w-full sm:w-auto px-4 py-2.5 sm:py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 shadow-sm disabled:opacity-50"
             :disabled="searchLoading"
             @click="runSearchTest"
           >
@@ -1316,7 +1324,7 @@ onMounted(async () => {
         </div>
         <pre
           v-if="searchResult"
-          class="text-xs bg-white border border-gray-200 p-4 rounded-lg overflow-auto max-h-96 shadow-sm"
+          class="text-xs bg-white border border-gray-200 p-3 sm:p-4 rounded-lg overflow-auto max-h-96 shadow-sm break-all whitespace-pre-wrap sm:whitespace-pre sm:break-normal"
         >{{ JSON.stringify(searchResult, null, 2) }}</pre>
       </template>
     </div>

--- a/frontend/src/views/Roles.vue
+++ b/frontend/src/views/Roles.vue
@@ -1,90 +1,178 @@
 <template>
-  <div class="space-y-6">
-    <!-- Header -->
-    <div class="flex justify-between items-center">
-      <h1 class="text-2xl font-bold text-gray-900">角色管理</h1>
-      <button
-        @click="openCreateDialog"
-        class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition flex items-center gap-2"
-      >
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-        </svg>
-        创建角色
-      </button>
-    </div>
+  <div class="space-y-5">
+    <!-- Header：与技能工作台一致，搜索进顶栏 -->
+    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+      <div class="min-w-0">
+        <h1 class="text-xl sm:text-2xl font-bold text-gray-900">角色管理</h1>
+        <p class="text-sm text-gray-500 mt-1">配置角色权限、菜单能力与用户归属</p>
+      </div>
 
-    <!-- Filters -->
-    <div class="bg-white shadow rounded-lg p-4">
-      <div class="flex flex-col sm:flex-row gap-4">
-        <input
-          v-model="searchQuery"
-          @input="debouncedSearch"
-          type="text"
-          placeholder="搜索角色名称或代码..."
-          class="border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 flex-1 text-sm"
-        />
+      <div class="flex flex-col sm:flex-row sm:items-center gap-2.5 sm:gap-3">
+        <div class="relative w-full sm:w-64 lg:w-72">
+          <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </span>
+          <input
+            v-model="searchQuery"
+            @input="debouncedSearch"
+            type="text"
+            placeholder="搜索角色名称或代码..."
+            class="w-full pl-9 pr-3 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none text-sm transition-all shadow-sm"
+          />
+        </div>
+
         <button
+          v-if="searchQuery.trim()"
+          type="button"
           @click="resetFilters"
-          class="border border-gray-300 rounded-lg px-4 py-2 hover:bg-gray-50 transition text-sm font-medium"
+          class="px-3 py-2 text-sm text-gray-500 hover:text-gray-800 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 transition-colors shrink-0 self-start sm:self-auto"
         >
-          重置
+          清除
+        </button>
+
+        <button
+          @click="fetchRoles"
+          class="p-2 text-gray-500 hover:text-primary bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 transition-colors shrink-0 self-start sm:self-auto"
+          title="刷新列表"
+        >
+          <svg class="w-4 h-4" :class="{ 'animate-spin': loading }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+        </button>
+
+        <button
+          @click="openCreateDialog"
+          class="flex items-center justify-center gap-2 px-4 py-2 bg-primary text-white rounded-lg shadow-sm hover:bg-primary-dark transition-all font-medium text-sm shrink-0"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          <span class="hidden sm:inline">创建角色</span>
+          <span class="sm:hidden">创建</span>
         </button>
       </div>
     </div>
 
     <!-- Loading -->
-    <div v-if="loading" class="bg-white shadow rounded-lg p-12 text-center">
-      <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-      <p class="mt-2 text-gray-500">加载中...</p>
+    <div v-if="loading" class="flex flex-col items-center justify-center py-16">
+      <div class="w-10 h-10 border-4 border-primary border-t-transparent rounded-full animate-spin"></div>
+      <p class="text-sm text-gray-500 mt-4 font-medium">加载角色列表...</p>
+    </div>
+
+    <!-- Empty -->
+    <div
+      v-else-if="roles.length === 0"
+      class="flex flex-col items-center justify-center min-h-[320px] bg-white border border-gray-200 rounded-lg shadow-sm px-6"
+    >
+      <svg class="w-14 h-14 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+      </svg>
+      <template v-if="isSearchEmpty">
+        <p class="text-sm text-gray-500 mt-4 font-semibold">无匹配「{{ searchQuery.trim() }}」的角色</p>
+        <p class="text-xs text-gray-400 mt-1">试试其他关键词，或清除搜索后浏览全部</p>
+        <button
+          type="button"
+          @click="resetFilters"
+          class="mt-5 px-4 py-2 text-sm font-medium text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors"
+        >
+          清除搜索
+        </button>
+      </template>
+      <template v-else>
+        <p class="text-sm text-gray-500 mt-4 font-semibold">暂无角色</p>
+        <p class="text-xs text-gray-400 mt-1">创建角色后可为用户分配权限与菜单能力</p>
+        <button
+          type="button"
+          @click="openCreateDialog"
+          class="mt-5 px-4 py-2 text-sm font-medium text-white bg-primary hover:bg-primary-dark rounded-lg transition-colors"
+        >
+          创建角色
+        </button>
+      </template>
     </div>
 
     <!-- Role List -->
-    <div v-else-if="roles.length > 0">
+    <div v-else>
       <!-- Desktop Table -->
-      <div v-if="!isMobile" class="bg-white shadow rounded-lg overflow-hidden">
+      <div v-if="!isMobile" class="bg-white border border-gray-200 shadow-sm rounded-lg overflow-hidden">
         <div class="overflow-x-auto">
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">
               <tr>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">ID</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">角色代码</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">角色名称</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">描述</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">用户数</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">创建时间</th>
-                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">操作</th>
+                <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">角色</th>
+                <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">描述</th>
+                <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">用户数</th>
+                <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">创建时间</th>
+                <th class="px-5 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">操作</th>
               </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
-              <tr v-for="role in roles" :key="role.id" class="hover:bg-gray-50">
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ role.id }}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-mono">{{ role.code }}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-medium">{{ role.name }}</td>
-                <td class="px-6 py-4 text-sm text-gray-500 max-w-xs truncate" :title="role.description">
-                  {{ role.description || '-' }}
+              <tr v-for="role in roles" :key="role.id" class="group hover:bg-gray-50/80 transition-colors">
+                <td class="px-5 py-4 whitespace-nowrap">
+                  <div class="flex items-center gap-2.5 min-w-0">
+                    <div class="flex items-center justify-center w-9 h-9 rounded-xl bg-blue-50 text-blue-600 shrink-0">
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                      </svg>
+                    </div>
+                    <div class="min-w-0">
+                      <div class="flex items-center gap-1.5 flex-wrap">
+                        <span class="text-sm font-semibold text-gray-900">{{ role.name }}</span>
+                        <span
+                          v-if="isSystemRole(role)"
+                          class="shrink-0 px-1.5 py-0.5 text-[9px] font-semibold rounded-full bg-slate-100 text-slate-600"
+                        >系统</span>
+                      </div>
+                      <div class="mt-0.5 flex items-center gap-1.5 text-xs text-gray-400">
+                        <span class="font-mono bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded text-[10px]">{{ role.code }}</span>
+                        <span class="text-gray-300">·</span>
+                        <span class="font-mono">#{{ role.id }}</span>
+                      </div>
+                    </div>
+                  </div>
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                  <span class="bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full text-xs font-medium">{{ role.user_count }}</span>
+                <td class="px-5 py-4 text-sm text-gray-500 max-w-xs truncate" :title="role.description">
+                  {{ role.description || '—' }}
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ formatDate(role.created_at) }}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                  <div class="flex justify-end items-center gap-3">
-                     <button @click="editRole(role)" class="text-blue-600 hover:text-blue-900 transition-colors p-1" title="编辑角色">
-                      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
+                <td class="px-5 py-4 whitespace-nowrap">
+                  <span class="inline-flex items-center bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full text-xs font-medium">
+                    {{ role.user_count }}
+                  </span>
+                </td>
+                <td class="px-5 py-4 whitespace-nowrap text-sm text-gray-500 font-mono">
+                  {{ formatDate(role.created_at) }}
+                </td>
+                <td class="px-5 py-4 whitespace-nowrap text-right text-sm font-medium">
+                  <div class="flex justify-end items-center gap-1">
+                    <button
+                      @click="editRole(role)"
+                      class="p-1.5 rounded-lg text-blue-600 hover:bg-blue-50 transition-colors"
+                      title="编辑角色"
+                    >
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
                     </button>
-                     <button @click="openPermissionDialog(role)" class="text-indigo-600 hover:text-indigo-900 transition-colors p-1" title="分配权限">
-                      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
+                    <button
+                      @click="openPermissionDialog(role)"
+                      class="p-1.5 rounded-lg text-indigo-600 hover:bg-indigo-50 transition-colors"
+                      title="分配权限"
+                    >
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" /></svg>
                     </button>
-                    <button @click="openUserAssignmentDialog(role)" class="text-green-600 hover:text-green-900 transition-colors p-1" title="分配用户">
-                      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" /></svg>
+                    <button
+                      @click="openUserAssignmentDialog(role)"
+                      class="p-1.5 rounded-lg text-emerald-600 hover:bg-emerald-50 transition-colors"
+                      title="分配用户"
+                    >
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" /></svg>
                     </button>
                     <button
                       @click="confirmDelete(role)"
-                      class="text-red-600 hover:text-red-900 transition-colors p-1"
+                      class="p-1.5 rounded-lg text-gray-400 hover:text-red-600 hover:bg-red-50 transition-all opacity-0 group-hover:opacity-100 focus:opacity-100"
                       title="删除角色"
                     >
-                      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
                     </button>
                   </div>
                 </td>
@@ -92,65 +180,81 @@
             </tbody>
           </table>
         </div>
+
+        <div class="bg-gray-50 px-4 py-3 border-t border-gray-200 flex flex-col sm:flex-row items-center justify-between gap-3">
+          <div class="text-sm text-gray-700">
+            共 {{ total }} 条，第 {{ page }}/{{ totalPages }} 页
+          </div>
+          <div class="flex gap-2 w-full sm:w-auto">
+            <button @click="page > 1 && (page--, fetchRoles())" :disabled="page <= 1" class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg bg-white hover:bg-gray-50 disabled:opacity-50 text-sm font-medium">上一页</button>
+            <button @click="page < totalPages && (page++, fetchRoles())" :disabled="page >= totalPages" class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg bg-white hover:bg-gray-50 disabled:opacity-50 text-sm font-medium">下一页</button>
+          </div>
+        </div>
       </div>
 
       <!-- Mobile Card List -->
-      <div v-else class="space-y-4">
-        <div v-for="role in roles" :key="role.id" class="bg-white shadow rounded-lg p-4 space-y-3">
-          <div class="flex justify-between items-start">
-            <div class="flex-1 min-w-0">
-              <h3 class="text-base font-bold text-gray-900 truncate">{{ role.name }}</h3>
-              <p class="text-xs font-mono text-gray-500">{{ role.code }}</p>
+      <div v-else class="space-y-3">
+        <div
+          v-for="role in roles"
+          :key="role.id"
+          class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
+        >
+          <div class="flex justify-between items-start gap-3">
+            <div class="flex items-start gap-3 min-w-0 flex-1">
+              <div class="flex items-center justify-center w-9 h-9 rounded-xl bg-blue-50 text-blue-600 shrink-0">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                </svg>
+              </div>
+              <div class="min-w-0">
+                <div class="flex items-center gap-1.5 flex-wrap">
+                  <h3 class="text-base font-semibold text-gray-900 truncate">{{ role.name }}</h3>
+                  <span
+                    v-if="isSystemRole(role)"
+                    class="shrink-0 px-1.5 py-0.5 text-[9px] font-semibold rounded-full bg-slate-100 text-slate-600"
+                  >系统</span>
+                </div>
+                <p class="text-xs font-mono text-gray-500 mt-0.5">{{ role.code }}</p>
+              </div>
             </div>
-            <div class="bg-blue-50 text-blue-700 px-2 py-0.5 rounded-full text-[10px] font-bold border border-blue-100 whitespace-nowrap">
+            <span class="bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full text-[10px] font-semibold shrink-0">
               {{ role.user_count }} 用户
-            </div>
+            </span>
           </div>
 
-          <p class="text-[11px] text-gray-600 line-clamp-2 leading-relaxed bg-gray-50 p-2 rounded border border-gray-100">
+          <p class="mt-3 text-xs text-gray-500 line-clamp-2 leading-relaxed">
             {{ role.description || '暂无描述' }}
           </p>
 
-          <div class="flex justify-between items-center pt-2 border-t border-gray-50">
-            <span class="text-[10px] text-gray-400">ID: {{ role.id }} · {{ formatDate(role.created_at).split(' ')[0] }}</span>
-            <div class="flex gap-3">
-              <button @click="editRole(role)" class="text-blue-600 flex items-center gap-1 text-xs font-medium">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
-                编辑
+          <div class="flex justify-between items-center pt-3 mt-3 border-t border-gray-100">
+            <span class="text-[10px] text-gray-400 font-mono">#{{ role.id }} · {{ formatDate(role.created_at).split(' ')[0] }}</span>
+            <div class="flex items-center gap-1">
+              <button @click="editRole(role)" class="p-1.5 rounded-lg text-blue-600 hover:bg-blue-50" title="编辑">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
               </button>
-              <button @click="openPermissionDialog(role)" class="text-indigo-600 flex items-center gap-1 text-xs font-medium">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
-                权限
+              <button @click="openPermissionDialog(role)" class="p-1.5 rounded-lg text-indigo-600 hover:bg-indigo-50" title="权限">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" /></svg>
               </button>
-              <button @click="openUserAssignmentDialog(role)" class="text-green-600 flex items-center gap-1 text-xs font-medium">
+              <button @click="openUserAssignmentDialog(role)" class="p-1.5 rounded-lg text-emerald-600 hover:bg-emerald-50" title="用户">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" /></svg>
-                用户
               </button>
-              <button @click="confirmDelete(role)" class="text-red-600 flex items-center gap-1 text-xs font-medium">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
-                删除
+              <button @click="confirmDelete(role)" class="p-1.5 rounded-lg text-gray-400 hover:text-red-600 hover:bg-red-50" title="删除">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
               </button>
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- Pagination -->
-      <div class="bg-white sm:bg-gray-50 px-4 py-3 flex flex-col sm:flex-row items-center justify-between border-t border-gray-200 mt-4 rounded-lg">
-        <div class="text-sm text-gray-700 mb-3 sm:mb-0">
-          共 {{ total }} 条，第 {{ page }}/{{ totalPages }} 页
-        </div>
-        <div class="flex gap-2 w-full sm:w-auto">
-          <button @click="page > 1 && (page--, fetchRoles())" :disabled="page <= 1" class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-200 disabled:opacity-50 text-sm font-medium">上一页</button>
-          <button @click="page < totalPages && (page++, fetchRoles())" :disabled="page >= totalPages" class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-200 disabled:opacity-50 text-sm font-medium">下一页</button>
+        <div class="bg-white border border-gray-200 rounded-lg px-4 py-3 flex flex-col sm:flex-row items-center justify-between gap-3">
+          <div class="text-sm text-gray-700">
+            共 {{ total }} 条，第 {{ page }}/{{ totalPages }} 页
+          </div>
+          <div class="flex gap-2 w-full sm:w-auto">
+            <button @click="page > 1 && (page--, fetchRoles())" :disabled="page <= 1" class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 text-sm font-medium">上一页</button>
+            <button @click="page < totalPages && (page++, fetchRoles())" :disabled="page >= totalPages" class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 text-sm font-medium">下一页</button>
+          </div>
         </div>
       </div>
-    </div>
-
-    <!-- Empty State -->
-    <div v-else class="bg-white shadow rounded-lg p-12 text-center">
-      <h3 class="mt-2 text-sm font-medium text-gray-900">没有找到角色</h3>
-      <p class="mt-1 text-sm text-gray-500">尝试调整筛选条件或创建新角色</p>
     </div>
 
     <!-- Create/Edit Dialog -->
@@ -682,6 +786,14 @@ const size = ref(20)
 const totalPages = ref(0)
 
 const searchQuery = ref('')
+const isSearchEmpty = computed(
+  () => searchQuery.value.trim().length > 0 && roles.value.length === 0
+)
+
+const isSystemRole = (role: { code?: string }) => {
+  const code = (role.code || '').toLowerCase()
+  return code === 'default' || code === 'admin' || code === 'system'
+}
 
 // Dialogs
 const showCreateDialog = ref(false)

--- a/frontend/src/views/SkillsManagement.vue
+++ b/frontend/src/views/SkillsManagement.vue
@@ -13,6 +13,7 @@ interface Skill {
   path: string
   scope?: 'global' | 'personal'
   modified_at?: number
+  enabled?: string
 }
 
 interface FileNode {
@@ -40,10 +41,11 @@ const activeScope = ref<'global' | 'personal'>('global')
 const loading = ref(false)
 const searchQuery = ref('')
 const viewMode = ref<'card' | 'list'>('card')
-const skillSortBy = ref<'name' | 'time'>('name')
-const skillSortOrder = ref<'asc' | 'desc'>('asc')
+const skillSortBy = ref<'name' | 'time'>('time')
+const skillSortOrder = ref<'asc' | 'desc'>('desc')
 const fileTreeSortBy = ref<'name' | 'time'>('name')
 const fileTreeSortOrder = ref<'asc' | 'desc'>('asc')
+const showCreateMenu = ref(false)
 
 // 新建技能相关
 const showCreateModal = ref(false)
@@ -317,6 +319,14 @@ const formatModifiedAt = (ts?: number) => {
   })
 }
 
+const isSearchEmpty = computed(() => {
+  return searchQuery.value.trim().length > 0 && sortedSkills.value.length === 0
+})
+
+const clearSearch = () => {
+  searchQuery.value = ''
+}
+
 // 复制 CLI 命令
 const copyCommand = async () => {
   const cmd = 'npx skills add https://github.com/vercel-labs/skills --skill find-skills'
@@ -576,6 +586,32 @@ const createSkillAsset = async () => {
 const hasUnsavedChanges = computed(() => {
   return editingContent.value !== originalContent.value
 })
+
+const requestCloseDrawer = () => {
+  if (!hasUnsavedChanges.value) {
+    showDrawer.value = false
+    return
+  }
+  confirmState.value = {
+    show: true,
+    title: '未保存修改确认',
+    message: '当前文件有未保存的修改，关闭将丢失这些修改。确定要关闭吗？',
+    type: 'warning',
+    onConfirm: () => {
+      confirmState.value.show = false
+      showDrawer.value = false
+    }
+  }
+}
+
+const handleDrawerKeydown = (e: KeyboardEvent) => {
+  if (e.key !== 'Escape' || !showDrawer.value) return
+  if (confirmState.value.show || showCreateModal.value || showImportModal.value || showCreateAssetModal.value || showStatsModal.value || showHelpModal.value) {
+    return
+  }
+  e.preventDefault()
+  requestCloseDrawer()
+}
 
 // 计算行数以显示在编辑器状态栏
 const lineCount = computed(() => {
@@ -897,6 +933,7 @@ const initCharts = () => {
 
 const closeContextMenu = () => {
   contextMenu.value.show = false
+  showCreateMenu.value = false
 }
 
 const handleContextMenu = (data: { event: MouseEvent, node: any }) => {
@@ -1047,10 +1084,12 @@ onMounted(() => {
   fetchSkills()
   fetchPersonalSkills()
   document.addEventListener('click', closeContextMenu)
+  document.addEventListener('keydown', handleDrawerKeydown)
 })
 
 onUnmounted(() => {
   document.removeEventListener('click', closeContextMenu)
+  document.removeEventListener('keydown', handleDrawerKeydown)
   disposeSkillDrawerChart()
   if (distChartInstance) {
     distChartInstance.dispose()
@@ -1148,31 +1187,60 @@ onUnmounted(() => {
         </div>
         <button 
           @click="openStatsModal"
-          class="flex items-center justify-center gap-2 px-4 py-2 bg-white text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 active:scale-95 transition-all shadow-sm font-medium text-sm"
+          class="flex items-center justify-center p-2 bg-white text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 active:scale-95 transition-all shadow-sm shrink-0"
+          title="统计查看"
         >
           <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
           </svg>
-          统计查看
         </button>
-        <button 
-          @click="openImportModal"
-          class="flex items-center justify-center gap-2 px-4 py-2 bg-white text-blue-600 border border-blue-200 hover:bg-blue-50 active:scale-95 transition-all shadow-sm font-semibold text-sm rounded-lg"
-        >
-          <svg class="w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-          </svg>
-          导入技能 (Zip/Tar)
-        </button>
-        <button 
-          @click="openCreateModal"
-          class="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 active:scale-95 transition-all shadow-sm font-medium text-sm"
-        >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-          </svg>
-          新建技能
-        </button>
+        <div class="relative shrink-0" @click.stop>
+          <div class="flex items-stretch rounded-lg overflow-hidden shadow-sm">
+            <button 
+              @click="openCreateModal"
+              class="flex items-center justify-center gap-2 px-4 py-2 text-white font-medium text-sm transition-all active:scale-[0.98]"
+              :class="activeScope === 'personal' ? 'bg-emerald-600 hover:bg-emerald-700' : 'bg-blue-600 hover:bg-blue-700'"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+              </svg>
+              新建技能
+            </button>
+            <button
+              @click="showCreateMenu = !showCreateMenu"
+              class="px-2 border-l text-white transition-colors"
+              :class="activeScope === 'personal' ? 'bg-emerald-600 hover:bg-emerald-700 border-emerald-500' : 'bg-blue-600 hover:bg-blue-700 border-blue-500'"
+              title="更多创建方式"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+          </div>
+          <div
+            v-if="showCreateMenu"
+            class="absolute right-0 mt-1.5 w-48 bg-white border border-gray-200 rounded-xl shadow-lg py-1 z-20"
+          >
+            <button
+              @click="showCreateMenu = false; openCreateModal()"
+              class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+            >
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+              </svg>
+              空白新建
+            </button>
+            <button
+              @click="showCreateMenu = false; openImportModal()"
+              class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+            >
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+              </svg>
+              导入 Zip/Tar
+            </button>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -1210,12 +1278,49 @@ onUnmounted(() => {
       <p class="text-sm text-gray-500 mt-4 font-medium">智能检索系统文件夹中...</p>
     </div>
 
-    <div v-else-if="sortedSkills.length === 0" class="flex flex-col items-center justify-center min-h-[360px] bg-white border border-gray-200 rounded-lg shadow-sm">
+    <div v-else-if="sortedSkills.length === 0" class="flex flex-col items-center justify-center min-h-[360px] bg-white border border-gray-200 rounded-lg shadow-sm px-6">
       <svg class="w-14 h-14 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5S19.832 5.477 21 6.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
       </svg>
-      <p class="text-sm text-gray-500 mt-4 font-semibold">未发现匹配的智能体技能目录</p>
-      <p class="text-xs text-gray-400 mt-1">您可以新建一个技能，或参考帮助文档安装生态技能</p>
+      <template v-if="isSearchEmpty">
+        <p class="text-sm text-gray-500 mt-4 font-semibold">无匹配「{{ searchQuery.trim() }}」的技能</p>
+        <p class="text-xs text-gray-400 mt-1">试试其他关键词，或清除搜索后浏览全部</p>
+        <button
+          @click="clearSearch"
+          class="mt-5 px-4 py-2 text-sm font-medium text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors"
+        >
+          清除搜索
+        </button>
+      </template>
+      <template v-else>
+        <p class="text-sm text-gray-500 mt-4 font-semibold">
+          {{ activeScope === 'personal' ? '还没有个人技能' : '暂无平台技能' }}
+        </p>
+        <p class="text-xs text-gray-400 mt-1 text-center max-w-sm">
+          <template v-if="activeScope === 'personal'">
+            个人技能仅对自己可见，可新建或导入到「我的技能」目录
+          </template>
+          <template v-else>
+            您可以新建一个技能，或导入 Zip/Tar 压缩包
+          </template>
+        </p>
+        <div class="mt-5 flex items-center gap-3">
+          <button
+            @click="openCreateModal"
+            class="px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors"
+            :class="activeScope === 'personal' ? 'bg-emerald-600 hover:bg-emerald-700' : 'bg-blue-600 hover:bg-blue-700'"
+          >
+            新建技能
+          </button>
+          <button
+            @click="openImportModal"
+            class="px-4 py-2 text-sm font-medium border rounded-lg transition-colors"
+            :class="activeScope === 'personal' ? 'text-emerald-600 border-emerald-200 hover:bg-emerald-50' : 'text-blue-600 border-blue-200 hover:bg-blue-50'"
+          >
+            导入技能
+          </button>
+        </div>
+      </template>
     </div>
 
     <!-- 卡片视图 -->
@@ -1253,6 +1358,10 @@ onUnmounted(() => {
                   v-else
                   class="shrink-0 px-1.5 py-0.5 text-[9px] font-semibold rounded-full bg-blue-100 text-blue-700"
                 >平台</span>
+                <span
+                  v-if="skill.enabled === 'false'"
+                  class="shrink-0 px-1.5 py-0.5 text-[9px] font-semibold rounded-full bg-gray-100 text-gray-500"
+                >已禁用</span>
               </div>
               <p class="text-[10px] text-gray-400 font-mono tracking-wider uppercase mt-0.5">
                 ID: {{ skill.id }}
@@ -1262,7 +1371,7 @@ onUnmounted(() => {
           
           <div class="flex items-center space-x-2 shrink-0" @click.stop>
             <!-- Switch 开关 -->
-            <label class="relative inline-flex items-center cursor-pointer" title="启用/禁用此技能">
+            <label class="relative inline-flex items-center cursor-pointer" title="启用/禁用此技能（禁用后对话不再自动匹配）">
               <input 
                 type="checkbox" 
                 :checked="skill.enabled !== 'false'"
@@ -1272,10 +1381,10 @@ onUnmounted(() => {
               <div class="w-7 h-4 bg-gray-250 dark:bg-gray-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-blue-600"></div>
             </label>
 
-            <!-- 删除物理技能按钮 -->
+            <!-- 删除：仅 hover 显示，降低误触 -->
             <button 
               @click.stop="deleteSkill(skill.id)"
-              class="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+              class="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all opacity-0 group-hover:opacity-100 focus:opacity-100"
               title="注销并彻底删除技能目录"
             >
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1334,6 +1443,18 @@ onUnmounted(() => {
                   <div class="space-y-0.5">
                     <div class="font-bold text-gray-900 group-hover:text-blue-600 transition-colors flex items-center gap-2 flex-wrap">
                       <span>{{ skill.name }}</span>
+                      <span
+                        v-if="skill.scope === 'personal'"
+                        class="shrink-0 px-1.5 py-0.5 text-[9px] font-semibold rounded-full bg-emerald-100 text-emerald-700"
+                      >个人</span>
+                      <span
+                        v-else
+                        class="shrink-0 px-1.5 py-0.5 text-[9px] font-semibold rounded-full bg-blue-100 text-blue-700"
+                      >平台</span>
+                      <span
+                        v-if="skill.enabled === 'false'"
+                        class="shrink-0 px-1.5 py-0.5 text-[9px] font-semibold rounded-full bg-gray-100 text-gray-500"
+                      >已禁用</span>
                       <span class="text-[10px] text-gray-400 font-mono bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200 font-normal">ID: {{ skill.id }}</span>
                     </div>
                     <div class="text-xs text-gray-500 max-w-2xl line-clamp-2" :title="skill.description">
@@ -1349,16 +1470,21 @@ onUnmounted(() => {
                 {{ formatModifiedAt(skill.modified_at) }}
               </td>
               <td class="px-6 py-4 text-center whitespace-nowrap" @click.stop>
-                <!-- Switch 开关 -->
-                <label class="relative inline-flex items-center cursor-pointer" title="启用/禁用此技能">
-                  <input 
-                    type="checkbox" 
-                    :checked="skill.enabled !== 'false'"
-                    @change="toggleSkillStatus(skill)"
-                    class="sr-only peer"
-                  >
-                  <div class="w-7 h-4 bg-gray-250 dark:bg-gray-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-blue-600"></div>
-                </label>
+                <div class="flex flex-col items-center gap-1">
+                  <label class="relative inline-flex items-center cursor-pointer" title="启用/禁用此技能（禁用后对话不再自动匹配）">
+                    <input 
+                      type="checkbox" 
+                      :checked="skill.enabled !== 'false'"
+                      @change="toggleSkillStatus(skill)"
+                      class="sr-only peer"
+                    >
+                    <div class="w-7 h-4 bg-gray-250 dark:bg-gray-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-blue-600"></div>
+                  </label>
+                  <span
+                    class="text-[10px] font-medium"
+                    :class="skill.enabled === 'false' ? 'text-gray-400' : 'text-emerald-600'"
+                  >{{ skill.enabled === 'false' ? '已禁用' : '已启用' }}</span>
+                </div>
               </td>
               <td class="px-6 py-4 text-center whitespace-nowrap" @click.stop>
                 <div class="flex items-center justify-center space-x-2 whitespace-nowrap">
@@ -1554,12 +1680,15 @@ onUnmounted(() => {
       @click.self="showCreateModal = false"
     >
       <div class="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6 border border-gray-150">
-        <h2 class="text-xl font-bold text-gray-800 mb-4 flex items-center gap-2">
-          <svg class="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <h2 class="text-xl font-bold text-gray-800 mb-1 flex items-center gap-2">
+          <svg class="w-5 h-5" :class="activeScope === 'personal' ? 'text-emerald-500' : 'text-blue-500'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5S19.832 5.477 21 6.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
           </svg>
           初始化智能体技能
         </h2>
+        <p class="text-xs text-gray-500 mb-4">
+          将创建到<strong>{{ activeScope === 'personal' ? '我的技能（个人）' : '平台技能（全局）' }}</strong>目录
+        </p>
         <div class="space-y-4">
           <div>
             <label class="block text-xs font-bold text-gray-500 uppercase mb-1">
@@ -1569,7 +1698,8 @@ onUnmounted(() => {
               v-model="newSkill.id"
               type="text" 
               placeholder="例如: search-helper" 
-              class="w-full px-3 py-2 border border-gray-350 rounded-xl focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm transition-all"
+              class="w-full px-3 py-2 border border-gray-350 rounded-xl focus:ring-2 focus:outline-none text-sm transition-all"
+              :class="activeScope === 'personal' ? 'focus:ring-emerald-500' : 'focus:ring-blue-500'"
             />
             <span class="text-[10px] text-gray-400 mt-1 block">物理目录名，创建后不可修改</span>
           </div>
@@ -1582,7 +1712,8 @@ onUnmounted(() => {
               v-model="newSkill.name"
               type="text" 
               placeholder="例如: 全局网页搜索辅助" 
-              class="w-full px-3 py-2 border border-gray-350 rounded-xl focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm transition-all"
+              class="w-full px-3 py-2 border border-gray-350 rounded-xl focus:ring-2 focus:outline-none text-sm transition-all"
+              :class="activeScope === 'personal' ? 'focus:ring-emerald-500' : 'focus:ring-blue-500'"
             />
           </div>
 
@@ -1594,7 +1725,8 @@ onUnmounted(() => {
               v-model="newSkill.description"
               rows="3"
               placeholder="描述此技能的核心能力或针对的典型任务约束..." 
-              class="w-full px-3 py-2 border border-gray-350 rounded-xl focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm transition-all"
+              class="w-full px-3 py-2 border border-gray-350 rounded-xl focus:ring-2 focus:outline-none text-sm transition-all"
+              :class="activeScope === 'personal' ? 'focus:ring-emerald-500' : 'focus:ring-blue-500'"
             ></textarea>
           </div>
         </div>
@@ -1609,9 +1741,10 @@ onUnmounted(() => {
           <button 
             @click="createSkill"
             :disabled="creating"
-            class="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded-xl transition-colors text-sm font-medium"
+            class="px-4 py-2 disabled:opacity-50 text-white rounded-xl transition-colors text-sm font-medium"
+            :class="activeScope === 'personal' ? 'bg-emerald-600 hover:bg-emerald-700' : 'bg-blue-600 hover:bg-blue-700'"
           >
-            {{ creating ? '创建中...' : '提交初始化' }}
+            {{ creating ? '创建中...' : (activeScope === 'personal' ? '创建到我的技能' : '创建到平台技能') }}
           </button>
         </div>
       </div>
@@ -1625,7 +1758,7 @@ onUnmounted(() => {
       <!-- 蒙层 -->
       <div 
         class="absolute inset-0 bg-black/30 backdrop-blur-[2px] transition-opacity"
-        @click="showDrawer = false"
+        @click="requestCloseDrawer"
       ></div>
 
       <!-- 抽屉主体 -->
@@ -1646,7 +1779,7 @@ onUnmounted(() => {
             </div>
             
             <button 
-              @click="showDrawer = false"
+              @click="requestCloseDrawer"
               class="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
             >
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/views/TaskCenter.vue
+++ b/frontend/src/views/TaskCenter.vue
@@ -461,98 +461,113 @@ onMounted(() => { fetchTasks(true); fetchAgents() })
 </script>
 
 <template>
-  <div class="space-y-6">
-    <!-- Header Section -->
-    <div class="flex flex-col md:flex-row md:items-center justify-between gap-4">
-      <div>
-        <h1 class="text-2xl font-bold text-gray-900">任务调度台</h1>
-        <p class="text-gray-500 mt-1 text-sm hidden sm:block">管理并监控智能体的定时自动化巡检与报表任务</p>
-        <p class="text-gray-500 mt-1 text-xs sm:hidden">智能体定时任务与巡检管理</p>
-      </div>
+  <div class="space-y-5">
+    <!-- Header：与技能工作台一致，筛选进顶栏 -->
+    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
       <div class="flex items-center space-x-3">
-        <button 
+        <h1 class="text-xl sm:text-2xl font-bold text-gray-900">任务调度台</h1>
+        <button
+          @click="showSpecsModal = true"
+          class="flex items-center justify-center w-7 h-7 rounded-full bg-white text-blue-600 border border-gray-200 hover:border-blue-300 hover:bg-blue-50 transition-colors shadow-sm"
+          title="设计规范"
+        >
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+        </button>
+      </div>
+
+      <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+        <div class="relative w-full sm:w-56 lg:w-64">
+          <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </span>
+          <input
+            v-model="searchQuery"
+            type="text"
+            placeholder="搜索任务名称或指令..."
+            class="w-full pl-9 pr-3 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none text-sm transition-all shadow-sm"
+          />
+        </div>
+
+        <select
+          v-model="statusFilter"
+          class="text-sm border border-gray-300 rounded-lg py-2 px-2.5 bg-white shadow-sm focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none shrink-0"
+          title="按状态筛选"
+        >
+          <option value="all">状态：全部</option>
+          <option value="running">状态：运行中</option>
+          <option value="stopped">状态：已停止</option>
+        </select>
+
+        <div class="hidden md:flex items-center bg-gray-200/60 p-0.5 rounded-lg border border-gray-300 gap-0.5 select-none shrink-0">
+          <button
+            @click="viewMode = 'grid'"
+            class="p-1.5 rounded-md transition-all"
+            :class="currentViewMode === 'grid' ? 'bg-white shadow-sm text-primary border border-gray-200' : 'text-gray-500 hover:text-gray-800'"
+            title="网格视图"
+          >
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+            </svg>
+          </button>
+          <button
+            @click="viewMode = 'list'"
+            class="p-1.5 rounded-md transition-all"
+            :class="currentViewMode === 'list' ? 'bg-white shadow-sm text-primary border border-gray-200' : 'text-gray-500 hover:text-gray-800'"
+            title="列表视图"
+          >
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+        </div>
+
+        <button
           @click="fetchTasks(false)"
-          class="p-2 text-gray-500 hover:text-primary hover:bg-gray-100 rounded-lg transition-colors"
+          class="p-2 text-gray-500 hover:text-primary bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 transition-colors shrink-0"
           title="刷新列表"
         >
-           <svg class="w-5 h-5" :class="loading ? 'animate-spin' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
+          <svg class="w-4 h-4" :class="loading ? 'animate-spin' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
         </button>
-        <button 
-          @click="showSpecsModal = true"
-          class="px-3 py-2 bg-white border border-gray-200 text-gray-600 rounded-lg shadow-sm hover:bg-gray-50 transition-all flex items-center text-sm font-medium"
-        >
-          <svg class="w-4 h-4 mr-1.5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
-          设计规范
-        </button>
-        <button 
+
+        <button
           v-if="canManage"
           @click="openCreateModal"
-          class="px-4 py-2 bg-primary text-white rounded-lg shadow-sm hover:bg-primary-dark transition-all flex items-center"
+          class="flex items-center justify-center gap-2 px-4 py-2 bg-primary text-white rounded-lg shadow-sm hover:bg-primary-dark transition-all font-medium text-sm shrink-0"
         >
-          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
           <span class="hidden sm:inline">新建任务</span>
           <span class="sm:hidden">新建</span>
         </button>
       </div>
     </div>
 
-    <div class="flex items-center gap-1 overflow-x-auto rounded-xl border border-gray-100 bg-white p-1.5 shadow-sm">
-      <button
-        v-for="tab in taskTypeTabs"
-        :key="tab.value"
-        type="button"
-        class="inline-flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-bold transition-colors"
-        :class="taskTypeFilter === tab.value ? 'bg-primary text-white shadow-sm' : 'text-gray-500 hover:bg-gray-50 hover:text-gray-700'"
-        @click="taskTypeFilter = tab.value"
-      >
-        <span>{{ tab.label }}</span>
-        <span class="min-w-5 rounded-full px-1.5 py-0.5 text-[9px] text-center" :class="taskTypeFilter === tab.value ? 'bg-white/20 text-white' : 'bg-gray-100 text-gray-500'">
-          {{ taskTypeCounts[tab.value] }}
-        </span>
-      </button>
-    </div>
-
-    <!-- Filters & Toolbar -->
-    <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 flex flex-wrap items-center justify-between gap-4">
-      <div class="flex items-center space-x-4">
-        <div class="flex items-center space-x-2">
-          <span class="text-sm text-gray-500">状态:</span>
-          <select v-model="statusFilter" class="text-sm border-gray-300 rounded-md focus:ring-primary focus:border-primary">
-            <option value="all">全部</option>
-            <option value="running">运行中</option>
-            <option value="stopped">已停止</option>
-          </select>
-        </div>
-      </div>
-
-      <div class="flex items-center space-x-3">
-        <!-- Search -->
-        <div class="relative w-64">
-          <input 
-            v-model="searchQuery"
-            placeholder="搜索任务名称或指令..."
-            class="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none transition-all"
-          />
-          <svg class="w-4 h-4 text-gray-400 absolute left-3 top-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
-        </div>
-
-        <!-- View Mode Switch -->
-        <div class="flex items-center bg-gray-100 p-1 rounded-lg border border-gray-200 hidden md:flex">
-          <button 
-            @click="viewMode = 'grid'"
-            class="p-1.5 rounded-md transition-all"
-            :class="currentViewMode === 'grid' ? 'bg-white shadow-sm text-primary' : 'text-gray-400'"
+    <!-- 类型 Tab：全宽底边 -->
+    <div class="border-b border-gray-200 -mt-1">
+      <div class="flex gap-1 overflow-x-auto -mb-px" style="-webkit-overflow-scrolling: touch;">
+        <button
+          v-for="tab in taskTypeTabs"
+          :key="tab.value"
+          type="button"
+          class="inline-flex shrink-0 items-center gap-1.5 px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 transition-colors whitespace-nowrap"
+          :class="taskTypeFilter === tab.value ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'"
+          @click="taskTypeFilter = tab.value"
+        >
+          <span>{{ tab.label }}</span>
+          <span
+            class="min-w-5 rounded-full px-1.5 py-0.5 text-[10px] font-semibold text-center"
+            :class="taskTypeFilter === tab.value ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500'"
           >
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" /></svg>
-          </button>
-          <button 
-            @click="viewMode = 'list'"
-            class="p-1.5 rounded-md transition-all ml-0.5"
-            :class="currentViewMode === 'list' ? 'bg-white shadow-sm text-primary' : 'text-gray-400'"
-          >
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
-          </button>
-        </div>
+            {{ taskTypeCounts[tab.value] }}
+          </span>
+        </button>
       </div>
     </div>
 

--- a/frontend/src/views/Users.vue
+++ b/frontend/src/views/Users.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="space-y-6 relative">
+  <div class="space-y-5 relative" @click="closeMenus">
     <!-- Full-page Sync Overlay -->
     <div
       v-if="syncingSso"
@@ -10,169 +10,200 @@
       <p class="text-gray-300 mt-2 text-sm">正在为您生成 API Key 并同步权限，请勿刷新页面</p>
     </div>
 
-    <!-- Header -->
-    <div class="flex justify-between items-center">
-      <h1 class="text-2xl font-bold text-gray-900">用户管理</h1>
-      <div class="flex gap-2">
-        <button
-          v-if="showSsoSync"
-          @click="openSsoModal"
-          class="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition flex items-center gap-2 shadow-sm"
-        >
-          <UserGroupIcon class="w-5 h-5" />
-          同步 SSO 用户
-        </button>
-        <button
-          @click="showThirdPartyDrawer = true"
-          class="bg-violet-600 text-white px-4 py-2 rounded-lg hover:bg-violet-700 transition flex items-center gap-2 shadow-sm"
-        >
-          <ArrowPathIcon class="w-5 h-5" />
-          同步第三方用户
-        </button>
-        <button
-          @click="showSystemQuotaModal = true"
-          class="bg-amber-600 text-white px-4 py-2 rounded-lg hover:bg-amber-700 transition flex items-center gap-2 shadow-sm"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-          </svg>
-          系统默认额度
-        </button>
-        <button
-          @click="openCreateDialog"
-          class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition flex items-center gap-2"
-        >
-          <PlusIcon class="w-5 h-5" />
-          创建用户
-        </button>
+    <!-- Header：筛选进顶栏，低频操作用「更多」收纳 -->
+    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+      <div class="min-w-0">
+        <h1 class="text-xl sm:text-2xl font-bold text-gray-900">用户管理</h1>
+        <p class="text-sm text-gray-500 mt-1">管理账号、身份角色与 API 访问凭证</p>
       </div>
-    </div>
 
-    <!-- Filters -->
-    <div class="bg-white shadow rounded-lg p-4">
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <input
-          v-model="searchQuery"
-          @input="debouncedSearch"
-          type="text"
-          placeholder="搜索用户名或姓名..."
-          class="border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
-        />
+      <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-2.5 sm:gap-3">
+        <div class="relative w-full sm:w-52 lg:w-60">
+          <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </span>
+          <input
+            v-model="searchQuery"
+            @input="debouncedSearch"
+            type="text"
+            placeholder="搜索用户名或姓名..."
+            class="w-full pl-9 pr-3 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none text-sm shadow-sm"
+          />
+        </div>
+
         <select
           v-model="roleFilter"
-          @change="fetchUsers"
-          class="border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+          @change="page = 1; fetchUsers()"
+          class="w-full sm:w-auto text-sm border border-gray-300 rounded-lg py-2 px-2.5 bg-white shadow-sm focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none shrink-0"
         >
-          <option value="">所有身份</option>
+          <option value="">身份：全部</option>
           <option value="admin">管理员</option>
           <option value="user">普通用户</option>
         </select>
+
         <select
           v-model="statusFilter"
-          @change="fetchUsers"
-          class="border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+          @change="page = 1; fetchUsers()"
+          class="w-full sm:w-auto text-sm border border-gray-300 rounded-lg py-2 px-2.5 bg-white shadow-sm focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none shrink-0"
         >
-          <option value="">所有状态</option>
+          <option value="">状态：全部</option>
           <option value="1">启用</option>
           <option value="0">禁用</option>
         </select>
+
         <button
+          v-if="hasActiveFilters"
+          type="button"
           @click="resetFilters"
-          class="border border-gray-300 rounded-lg px-4 py-2 hover:bg-gray-50 transition text-sm font-medium"
+          class="px-3 py-2 text-sm text-gray-500 hover:text-gray-800 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 transition-colors shrink-0"
         >
-          重置
+          清除
+        </button>
+
+        <button
+          type="button"
+          @click="fetchUsers"
+          class="p-2 text-gray-500 hover:text-primary bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 transition-colors shrink-0 self-start sm:self-auto"
+          title="刷新列表"
+        >
+          <ArrowPathIcon class="w-4 h-4" :class="{ 'animate-spin': loading }" />
+        </button>
+
+        <div class="relative shrink-0" @click.stop>
+          <button
+            type="button"
+            @click="showMoreMenu = !showMoreMenu; openRowMenuId = null"
+            class="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 transition-colors"
+          >
+            更多
+            <ChevronDownIcon class="w-4 h-4 text-gray-400" :class="{ 'rotate-180': showMoreMenu }" />
+          </button>
+          <div
+            v-if="showMoreMenu"
+            class="absolute right-0 mt-1.5 w-52 bg-white border border-gray-200 rounded-xl shadow-lg py-1 z-30"
+          >
+            <button
+              v-if="showSsoSync"
+              type="button"
+              class="w-full text-left px-3 py-2.5 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+              @click="showMoreMenu = false; openSsoModal()"
+            >
+              <UserGroupIcon class="w-4 h-4 text-indigo-500" />
+              同步 SSO 用户
+            </button>
+            <button
+              type="button"
+              class="w-full text-left px-3 py-2.5 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+              @click="showMoreMenu = false; showThirdPartyDrawer = true"
+            >
+              <ArrowPathIcon class="w-4 h-4 text-violet-500" />
+              同步第三方用户
+            </button>
+            <button
+              type="button"
+              class="w-full text-left px-3 py-2.5 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+              @click="showMoreMenu = false; showSystemQuotaModal = true"
+            >
+              <ChartBarIcon class="w-4 h-4 text-amber-500" />
+              系统默认额度
+            </button>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          @click="openCreateDialog"
+          class="flex items-center justify-center gap-2 px-4 py-2 bg-primary text-white rounded-lg shadow-sm hover:bg-primary-dark transition-all font-medium text-sm shrink-0"
+        >
+          <PlusIcon class="w-4 h-4" />
+          <span class="hidden sm:inline">创建用户</span>
+          <span class="sm:hidden">创建</span>
         </button>
       </div>
     </div>
 
     <!-- Loading -->
-    <div v-if="loading" class="bg-white shadow rounded-lg p-12 text-center">
-      <div
-        class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"
-      ></div>
-      <p class="mt-2 text-gray-500">加载中...</p>
+    <div v-if="loading" class="flex flex-col items-center justify-center py-16">
+      <div class="w-10 h-10 border-4 border-primary border-t-transparent rounded-full animate-spin"></div>
+      <p class="text-sm text-gray-500 mt-4 font-medium">加载用户列表...</p>
+    </div>
+
+    <!-- Empty -->
+    <div
+      v-else-if="users.length === 0"
+      class="flex flex-col items-center justify-center min-h-[320px] bg-white border border-gray-200 rounded-lg shadow-sm px-6"
+    >
+      <svg class="w-14 h-14 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+      </svg>
+      <template v-if="isSearchEmpty">
+        <p class="text-sm text-gray-500 mt-4 font-semibold">没有符合当前筛选条件的用户</p>
+        <p class="text-xs text-gray-400 mt-1">可调整关键词、身份或状态后重试</p>
+        <button
+          type="button"
+          @click="resetFilters"
+          class="mt-5 px-4 py-2 text-sm font-medium text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors"
+        >
+          清除筛选
+        </button>
+      </template>
+      <template v-else>
+        <p class="text-sm text-gray-500 mt-4 font-semibold">暂无用户</p>
+        <p class="text-xs text-gray-400 mt-1">创建账号，或从「更多」同步 SSO / 第三方用户</p>
+        <button
+          type="button"
+          @click="openCreateDialog"
+          class="mt-5 px-4 py-2 text-sm font-medium text-white bg-primary hover:bg-primary-dark rounded-lg transition-colors"
+        >
+          创建用户
+        </button>
+      </template>
     </div>
 
     <!-- User List -->
-    <div v-else-if="users.length > 0">
+    <div v-else>
       <!-- Desktop Table -->
-      <div v-if="!isMobile" class="bg-white shadow rounded-lg overflow-hidden">
+      <div v-if="!isMobile" class="bg-white border border-gray-200 shadow-sm rounded-lg overflow-hidden">
         <div class="overflow-x-auto">
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">
               <tr>
-                <th
-                  class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
-                >
-                  ID
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
-                >
-                  用户名
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
-                >
-                  真实姓名
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
-                >
-                  系统身份/角色
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
-                >
-                  备注
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
-                >
-                  状态
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
-                >
-                  创建时间
-                </th>
-                <th
-                  class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
-                >
-                  操作
-                </th>
+                <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">用户</th>
+                <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">身份 / 角色</th>
+                <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">备注</th>
+                <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">状态</th>
+                <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">创建时间</th>
+                <th class="px-5 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">操作</th>
               </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
-              <tr v-for="user in users" :key="user.id" class="hover:bg-gray-50">
-                <td
-                  class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-mono"
-                >
-                  {{ user.id }}
+              <tr v-for="user in users" :key="user.id" class="group hover:bg-gray-50/80 transition-colors">
+                <td class="px-5 py-4 whitespace-nowrap">
+                  <div class="min-w-0">
+                    <div class="text-sm font-semibold text-gray-900 truncate max-w-[14rem]" :title="user.user_name">
+                      {{ user.user_name }}
+                    </div>
+                    <div class="mt-0.5 flex items-center gap-1.5 text-xs text-gray-400">
+                      <span>{{ user.real_name || "未设置姓名" }}</span>
+                      <span class="text-gray-300">·</span>
+                      <span class="font-mono">#{{ user.id }}</span>
+                    </div>
+                  </div>
                 </td>
-                <td
-                  class="px-6 py-4 whitespace-nowrap font-medium text-gray-900"
-                >
-                  {{ user.user_name }}
-                </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                  {{ user.real_name || "-" }}
-                </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                <td class="px-5 py-4 whitespace-nowrap text-sm">
                   <div class="flex flex-col gap-1.5 items-start">
-                    <!-- System Role -->
                     <span
                       :class="
                         user.role === 'admin'
-                          ? 'bg-purple-100 text-purple-800 border-purple-200'
-                          : 'bg-blue-100 text-blue-800 border-blue-200'
+                          ? 'bg-purple-50 text-purple-700 border-purple-100'
+                          : 'bg-blue-50 text-blue-700 border-blue-100'
                       "
-                      class="px-2 py-0.5 text-[11px] font-bold rounded-md border"
+                      class="px-2 py-0.5 text-[11px] font-semibold rounded-md border"
                     >
                       {{ user.role === "admin" ? "系统管理员" : "普通用户" }}
                     </span>
-
-                    <!-- Business Roles -->
                     <RoleList
                       v-if="user.role_names && user.role_names.length > 0"
                       :roles="user.role_names"
@@ -180,10 +211,10 @@
                     />
                   </div>
                 </td>
-                <td class="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
-                  {{ user.remark || "-" }}
+                <td class="px-5 py-4 text-sm text-gray-500 max-w-[10rem] truncate" :title="user.remark">
+                  {{ user.remark || "—" }}
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap">
+                <td class="px-5 py-4 whitespace-nowrap">
                   <div class="flex items-center">
                     <Switch
                       :model-value="user.status === 1"
@@ -191,89 +222,125 @@
                     />
                     <span
                       class="ml-2 text-xs"
-                      :class="
-                        user.status === 1 ? 'text-green-600' : 'text-gray-400'
-                      "
+                      :class="user.status === 1 ? 'text-emerald-600' : 'text-gray-400'"
                     >
                       {{ user.status === 1 ? "已启用" : "已禁用" }}
                     </span>
                   </div>
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <td class="px-5 py-4 whitespace-nowrap text-sm text-gray-500 font-mono">
                   {{ formatDate(user.created_at) }}
                 </td>
-                <td
-                  class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium"
-                >
-                  <div class="flex justify-end items-center gap-3">
-                    <button
-                      @click="viewApiKey(user)"
-                      class="text-indigo-600 hover:text-indigo-900 transition-colors p-1"
-                      title="查看 API Key"
-                    >
-                      <KeyIcon class="w-5 h-5" />
-                    </button>
+                <td class="px-5 py-4 whitespace-nowrap text-right text-sm font-medium">
+                  <div class="flex justify-end items-center gap-0.5">
                     <button
                       @click="editUser(user)"
-                      class="text-blue-600 hover:text-blue-900 transition-colors p-1"
-                      title="编辑用户/权限"
+                      class="p-1.5 rounded-lg text-blue-600 hover:bg-blue-50 transition-colors"
+                      title="编辑用户"
                     >
-                      <PencilSquareIcon class="w-5 h-5" />
+                      <PencilSquareIcon class="w-4 h-4" />
                     </button>
                     <button
-                      @click="openSetPasswordDialog(user)"
-                      class="text-emerald-600 hover:text-emerald-900 transition-colors p-1"
-                      title="设置密码"
+                      @click="viewApiKey(user)"
+                      class="p-1.5 rounded-lg text-gray-500 hover:text-indigo-600 hover:bg-indigo-50 transition-colors"
+                      title="查看 API Key"
                     >
-                      <LockClosedIcon class="w-5 h-5" />
+                      <KeyIcon class="w-4 h-4" />
                     </button>
-                    <button
-                      @click="regenerateApiKey(user)"
-                      class="text-amber-600 hover:text-amber-900 transition-colors p-1"
-                      title="重置 API Key"
-                    >
-                      <ArrowPathIcon class="w-5 h-5" />
-                    </button>
-                    <button
-                      v-if="user.user_name !== 'admin'"
-                      @click="confirmDelete(user)"
-                      class="text-red-600 hover:text-red-900 transition-colors p-1"
-                      title="删除用户"
-                    >
-                      <TrashIcon class="w-5 h-5" />
-                    </button>
+                    <div class="relative" @click.stop>
+                      <button
+                        type="button"
+                        @click="toggleRowMenu(user.id)"
+                        class="p-1.5 rounded-lg text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                        title="更多操作"
+                      >
+                        <EllipsisHorizontalIcon class="w-4 h-4" />
+                      </button>
+                      <div
+                        v-if="openRowMenuId === user.id"
+                        class="absolute right-0 mt-1 w-40 bg-white border border-gray-200 rounded-xl shadow-lg py-1 z-20"
+                      >
+                        <button
+                          type="button"
+                          class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+                          @click="openRowMenuId = null; openSetPasswordDialog(user)"
+                        >
+                          <LockClosedIcon class="w-4 h-4 text-emerald-500" />
+                          设置密码
+                        </button>
+                        <button
+                          type="button"
+                          class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+                          @click="openRowMenuId = null; regenerateApiKey(user)"
+                        >
+                          <ArrowPathIcon class="w-4 h-4 text-amber-500" />
+                          重置 API Key
+                        </button>
+                        <button
+                          v-if="user.user_name !== 'admin'"
+                          type="button"
+                          class="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2"
+                          @click="openRowMenuId = null; confirmDelete(user)"
+                        >
+                          <TrashIcon class="w-4 h-4" />
+                          删除用户
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </td>
               </tr>
             </tbody>
           </table>
         </div>
+
+        <div class="bg-gray-50 px-4 py-3 border-t border-gray-200 flex flex-col sm:flex-row items-center justify-between gap-3">
+          <div class="text-sm text-gray-700">
+            共 {{ total }} 条，第 {{ page }}/{{ totalPages }} 页
+          </div>
+          <div class="flex gap-2 w-full sm:w-auto">
+            <button
+              @click="page > 1 && (page--, fetchUsers())"
+              :disabled="page <= 1"
+              class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg bg-white hover:bg-gray-50 disabled:opacity-50 text-sm font-medium"
+            >
+              上一页
+            </button>
+            <button
+              @click="page < totalPages && (page++, fetchUsers())"
+              :disabled="page >= totalPages"
+              class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg bg-white hover:bg-gray-50 disabled:opacity-50 text-sm font-medium"
+            >
+              下一页
+            </button>
+          </div>
+        </div>
       </div>
 
       <!-- Mobile Card List -->
-      <div v-else class="space-y-4">
+      <div v-else class="space-y-3">
         <div
           v-for="user in users"
           :key="user.id"
-          class="bg-white shadow rounded-lg p-4 space-y-3"
+          class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
         >
-          <div class="flex justify-between items-start">
-            <div class="flex-1 min-w-0">
-              <h3 class="text-base font-bold text-gray-900 truncate">
+          <div class="flex justify-between items-start gap-3">
+            <div class="min-w-0 flex-1">
+              <h3 class="text-base font-semibold text-gray-900 truncate">
                 {{ user.user_name }}
               </h3>
-              <p class="text-xs text-gray-500">
-                {{ user.real_name || "无真实姓名" }}
+              <p class="text-xs text-gray-500 mt-0.5">
+                {{ user.real_name || "未设置姓名" }} · #{{ user.id }}
               </p>
             </div>
-            <div class="flex items-center gap-2">
+            <div class="flex items-center gap-2 shrink-0">
               <span
                 :class="
                   user.role === 'admin'
-                    ? 'bg-purple-100 text-purple-800'
-                    : 'bg-blue-100 text-blue-800'
+                    ? 'bg-purple-50 text-purple-700'
+                    : 'bg-blue-50 text-blue-700'
                 "
-                class="px-2 py-0.5 text-[10px] font-bold rounded"
+                class="px-2 py-0.5 text-[10px] font-semibold rounded"
               >
                 {{ user.role === "admin" ? "管理员" : "普通用户" }}
               </span>
@@ -284,25 +351,11 @@
             </div>
           </div>
 
-          <div
-            class="grid grid-cols-2 gap-2 text-[11px] text-gray-500 border-t border-gray-50 pt-2"
-          >
-            <div>
-              <span class="opacity-60">ID:</span>
-              <span class="font-mono">{{ user.id }}</span>
-            </div>
-            <div>
-              <span class="opacity-60">创建:</span>
-              {{ formatDate(user.created_at).split(" ")[0] }}
-            </div>
-            <div class="col-span-2 truncate">
-              <span class="opacity-60">备注:</span> {{ user.remark || "-" }}
-            </div>
-          </div>
+          <p v-if="user.remark" class="mt-2 text-xs text-gray-500 truncate">{{ user.remark }}</p>
 
           <div
             v-if="user.role_names && user.role_names.length > 0"
-            class="flex flex-wrap gap-1"
+            class="flex flex-wrap gap-1 mt-2"
           >
             <span
               v-for="(rname, idx) in user.role_names"
@@ -313,80 +366,55 @@
             </span>
           </div>
 
-          <div
-            class="flex justify-between items-center pt-2 border-t border-gray-50"
-          >
-            <div class="flex gap-4">
-              <button
-                @click="viewApiKey(user)"
-                class="text-indigo-600 flex items-center gap-1 text-xs"
-              >
-                <KeyIcon class="w-4 h-4" /> 密钥
+          <div class="flex justify-between items-center pt-3 mt-3 border-t border-gray-100">
+            <span class="text-[10px] text-gray-400 font-mono">{{ formatDate(user.created_at).split(" ")[0] }}</span>
+            <div class="flex items-center gap-1">
+              <button @click="editUser(user)" class="p-1.5 rounded-lg text-blue-600 hover:bg-blue-50" title="编辑">
+                <PencilSquareIcon class="w-4 h-4" />
               </button>
-              <button
-                @click="editUser(user)"
-                class="text-blue-600 flex items-center gap-1 text-xs"
-              >
-                <PencilSquareIcon class="w-4 h-4" /> 编辑
+              <button @click="viewApiKey(user)" class="p-1.5 rounded-lg text-gray-500 hover:bg-indigo-50" title="密钥">
+                <KeyIcon class="w-4 h-4" />
               </button>
-            </div>
-            <div class="flex gap-4">
-              <button
-                @click="openSetPasswordDialog(user)"
-                class="text-emerald-600 flex items-center gap-1 text-xs"
-              >
-                <LockClosedIcon class="w-4 h-4" /> 密码
+              <button @click="openSetPasswordDialog(user)" class="p-1.5 rounded-lg text-gray-500 hover:bg-emerald-50" title="密码">
+                <LockClosedIcon class="w-4 h-4" />
               </button>
-              <button
-                @click="regenerateApiKey(user)"
-                class="text-amber-600 flex items-center gap-1 text-xs"
-              >
-                <ArrowPathIcon class="w-4 h-4" /> 重置
+              <button @click="regenerateApiKey(user)" class="p-1.5 rounded-lg text-gray-500 hover:bg-amber-50" title="重置 Key">
+                <ArrowPathIcon class="w-4 h-4" />
               </button>
               <button
                 v-if="user.user_name !== 'admin'"
                 @click="confirmDelete(user)"
-                class="text-red-600 flex items-center gap-1 text-xs"
+                class="p-1.5 rounded-lg text-gray-400 hover:text-red-600 hover:bg-red-50"
+                title="删除"
               >
-                <TrashIcon class="w-4 h-4" /> 删除
+                <TrashIcon class="w-4 h-4" />
               </button>
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- Pagination -->
-      <div
-        class="bg-white sm:bg-gray-50 px-4 py-3 flex flex-col sm:flex-row items-center justify-between border-t border-gray-200 mt-4 rounded-lg shadow sm:shadow-none"
-      >
-        <div class="text-sm text-gray-700 mb-3 sm:mb-0">
-          共 {{ total }} 条，第 {{ page }}/{{ totalPages }} 页
-        </div>
-        <div class="flex gap-2 w-full sm:w-auto">
-          <button
-            @click="page > 1 && (page--, fetchUsers())"
-            :disabled="page <= 1"
-            class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-200 disabled:opacity-50 text-sm font-medium transition-colors"
-          >
-            上一页
-          </button>
-          <button
-            @click="page < totalPages && (page++, fetchUsers())"
-            :disabled="page >= totalPages"
-            class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-200 disabled:opacity-50 text-sm font-medium transition-colors"
-          >
-            下一页
-          </button>
+        <div class="bg-white border border-gray-200 rounded-lg px-4 py-3 flex flex-col sm:flex-row items-center justify-between gap-3">
+          <div class="text-sm text-gray-700">
+            共 {{ total }} 条，第 {{ page }}/{{ totalPages }} 页
+          </div>
+          <div class="flex gap-2 w-full sm:w-auto">
+            <button
+              @click="page > 1 && (page--, fetchUsers())"
+              :disabled="page <= 1"
+              class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 text-sm font-medium"
+            >
+              上一页
+            </button>
+            <button
+              @click="page < totalPages && (page++, fetchUsers())"
+              :disabled="page >= totalPages"
+              class="flex-1 sm:flex-none px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 text-sm font-medium"
+            >
+              下一页
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-
-    <!-- Empty State -->
-    <div
-      v-else
-      class="bg-white shadow rounded-lg p-12 text-center text-gray-500"
-    >
-      没有找到用户
     </div>
 
     <!-- Create/Edit Dialog -->
@@ -1533,6 +1561,9 @@ import {
   PlusIcon,
   UserGroupIcon,
   LockClosedIcon,
+  ChevronDownIcon,
+  EllipsisHorizontalIcon,
+  ChartBarIcon,
 } from "@heroicons/vue/24/outline";
 
 const { showToast } = useToast();
@@ -1546,9 +1577,11 @@ const handleResize = () => {
 
 onMounted(() => {
   window.addEventListener("resize", handleResize);
+  document.addEventListener("click", closeMenus);
 });
 onUnmounted(() => {
   window.removeEventListener("resize", handleResize);
+  document.removeEventListener("click", closeMenus);
 });
 
 // State
@@ -1569,6 +1602,27 @@ const searchQuery = ref("");
 const roleFilter = ref("");
 const statusFilter = ref("");
 const roleSearchQuery = ref("");
+const showMoreMenu = ref(false);
+const openRowMenuId = ref<number | null>(null);
+
+const hasActiveFilters = computed(
+  () =>
+    Boolean(searchQuery.value.trim()) ||
+    Boolean(roleFilter.value) ||
+    Boolean(statusFilter.value)
+);
+const isSearchEmpty = computed(
+  () => hasActiveFilters.value && users.value.length === 0
+);
+
+const closeMenus = () => {
+  showMoreMenu.value = false;
+  openRowMenuId.value = null;
+};
+const toggleRowMenu = (id: number) => {
+  openRowMenuId.value = openRowMenuId.value === id ? null : id;
+  showMoreMenu.value = false;
+};
 
 // Dialogs
 const showCreateDialog = ref(false);

--- a/tests/ai/test_agent_custom_skills.py
+++ b/tests/ai/test_agent_custom_skills.py
@@ -1,0 +1,136 @@
+"""智能体自定义 Skills：白名单过滤与 schema 校验。"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import PropertyMock, patch
+
+import pytest
+
+from app.schemas.agent import AIAgentVersionBase
+from app.services.ai.runtime.agentscope.workspace import discover_platform_skill_paths
+from app.services.ai.skill_resolver import list_skill_metas, skill_filter_kwargs_from_config
+
+
+def _write_skill(root: Path, skill_id: str, *, enabled: bool = True, name: str | None = None) -> None:
+    skill_dir = root / skill_id
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    display = name or skill_id
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {display}\ndescription: test {skill_id}\nenabled: {str(enabled).lower()}\n---\n\n# {display}\n",
+        encoding="utf-8",
+    )
+
+
+def test_version_schema_requires_skills_when_custom():
+    # 请求侧：空列表在 schema 层仅归一化；强制校验由服务层负责
+    data = AIAgentVersionBase(
+        system_prompt="hi",
+        skills_custom=True,
+        skills=[],
+    )
+    assert data.skills_custom is True
+    assert data.skills == []
+
+
+def test_version_schema_clears_skills_when_not_custom():
+    data = AIAgentVersionBase(
+        system_prompt="hi",
+        skills_custom=False,
+        skills=["a", "b"],
+    )
+    assert data.skills == []
+
+
+def test_version_response_accepts_null_skills():
+    from datetime import datetime
+    from app.schemas.agent import AIAgentVersionResponse
+
+    resp = AIAgentVersionResponse.model_validate(
+        {
+            "id": "v1",
+            "agent_id": "a1",
+            "system_prompt": "hi",
+            "skills_custom": False,
+            "skills": None,
+            "tools": [],
+            "created_at": datetime.now(),
+        }
+    )
+    assert resp.skills == []
+    assert resp.skills_custom is False
+
+
+def test_validate_skills_config_rejects_empty_custom():
+    from app.services.ai.agent_manager import AgentManagerService
+
+    with pytest.raises(ValueError, match="至少选择一个"):
+        AgentManagerService._validate_skills_config(True, [])
+    AgentManagerService._validate_skills_config(True, ["brainstorming"])
+    AgentManagerService._validate_skills_config(False, [])
+
+
+def test_discover_platform_skill_paths_respects_allowlist(tmp_path, monkeypatch):
+    global_root = tmp_path / "global"
+    personal_root = tmp_path / "personal"
+    _write_skill(global_root, "alpha")
+    _write_skill(global_root, "beta")
+    _write_skill(global_root, "gamma", enabled=False)
+    _write_skill(personal_root, "mine")
+
+    monkeypatch.setattr(
+        "app.services.ai.skill_resolver.get_user_personal_skills_dir",
+        lambda _user: str(personal_root),
+    )
+
+    with patch("app.core.config.Settings.SKILLS_DIR", new_callable=PropertyMock) as mock_dir:
+        mock_dir.return_value = str(global_root)
+        all_paths = discover_platform_skill_paths(user_info={"id": 1})
+        all_ids = {os.path.basename(p) for p in all_paths}
+        assert all_ids == {"alpha", "beta", "mine"}
+
+        custom_paths = discover_platform_skill_paths(
+            user_info={"id": 1},
+            skills_custom=True,
+            allowed_global_skills=["beta", "gamma"],
+        )
+        custom_ids = {os.path.basename(p) for p in custom_paths}
+        # gamma disabled → skipped; personal always kept
+        assert custom_ids == {"beta", "mine"}
+
+
+def test_list_skill_metas_custom_keeps_personal(tmp_path, monkeypatch):
+    global_root = tmp_path / "global"
+    personal_root = tmp_path / "personal"
+    _write_skill(global_root, "alpha")
+    _write_skill(global_root, "beta")
+    _write_skill(personal_root, "mine")
+
+    monkeypatch.setattr(
+        "app.services.ai.skill_resolver.get_user_personal_skills_dir",
+        lambda _user: str(personal_root),
+    )
+
+    with patch("app.core.config.Settings.SKILLS_DIR", new_callable=PropertyMock) as mock_dir:
+        mock_dir.return_value = str(global_root)
+        metas = list_skill_metas(
+            user_info={"id": 1},
+            skills_custom=True,
+            allowed_global_skills=["alpha"],
+        )
+        ids = {m["id"] for m in metas}
+        assert ids == {"alpha", "mine"}
+
+
+def test_skill_filter_kwargs_from_config():
+    assert skill_filter_kwargs_from_config(None) == {
+        "skills_custom": False,
+        "allowed_global_skills": None,
+    }
+    kwargs = skill_filter_kwargs_from_config(
+        {"skills_custom": True, "skills": [" a ", "", "b"]}
+    )
+    assert kwargs == {
+        "skills_custom": True,
+        "allowed_global_skills": ["a", "b"],
+    }

--- a/tests/services/ai/test_skill_discovery_tools.py
+++ b/tests/services/ai/test_skill_discovery_tools.py
@@ -44,6 +44,65 @@ def test_skill_discovery_tools_list_and_read_skill(tmp_path):
         assert "非法技能 ID" in bad
 
 
+def test_list_available_skills_respects_agent_custom_allowlist(tmp_path, monkeypatch):
+    from app.core.context import AgentContext, agent_context, set_agent_context
+    from app.services.ai.tools.system_executive_tools import (
+        list_available_skills,
+        read_skill_instruction,
+    )
+    from app.utils.context import current_user_info
+
+    global_root = tmp_path / "global"
+    personal = tmp_path / "personal"
+    for skill_id, name in (("alpha", "Alpha"), ("beta", "Beta")):
+        d = global_root / skill_id
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: desc-{skill_id}\nenabled: true\n---\n\n# {name}\n",
+            encoding="utf-8",
+        )
+
+    mine = personal / "mine"
+    mine.mkdir(parents=True)
+    (mine / "SKILL.md").write_text(
+        "---\nname: Mine\ndescription: personal\nenabled: true\n---\n\n# Mine\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "app.services.ai.skill_resolver.get_user_personal_skills_dir",
+        lambda _user: str(personal),
+    )
+
+    user_token = current_user_info.set({"id": 1, "user_name": "u1"})
+    set_agent_context(
+        AgentContext(
+            agent_id="a1",
+            agent_name="agent",
+            skills_custom=True,
+            skills=["beta"],
+        )
+    )
+
+    try:
+        with patch("app.core.config.Settings.SKILLS_DIR", new_callable=PropertyMock) as mock_skills_dir:
+            mock_skills_dir.return_value = str(global_root)
+            listing = list_available_skills.invoke({})
+            assert "beta" in listing
+            assert "alpha" not in listing
+            assert "mine" in listing
+
+            ok = read_skill_instruction.invoke({"skill_id": "beta"})
+            assert "Beta" in ok
+            denied = read_skill_instruction.invoke({"skill_id": "alpha"})
+            assert "不在当前智能体可用 Skills 范围内" in denied or "不存在" in denied
+            personal_ok = read_skill_instruction.invoke({"skill_id": "mine"})
+            assert "Mine" in personal_ok
+    finally:
+        current_user_info.reset(user_token)
+        agent_context.set(None)
+
+
 def test_general_chat_implicit_tools_include_safe_skill_lookup():
     from app.services.ai.tools.registry import ToolRegistry
 


### PR DESCRIPTION
# Pull Request: 管理页顶栏优化 + 智能体自定义 Skills 白名单

## 概要 (Overview)
本 PR 包含两部分：一是收敛多个管理页的顶栏筛选与低频操作，降低表格噪音并完善 AgentDebug 全屏引导；二是为智能体版本增加自定义 Skills 配置能力，使运行时加载、技能选择框与 `list_available_skills` / `read_skill_instruction` 统一按「勾选公共技能 + 当前用户个人技能」过滤。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)
- [x] 智能体版本支持 `skills_custom` + `skills[]`：开启自定义后仅勾选公共（全局）已启用技能，保存时至少选 1 个
- [x] 运行时加载：未自定义=全部已启用公共+个人；自定义=白名单公共+个人
- [x] 聊天「调用技能工作流」选择框按当前智能体配置过滤平台技能（个人技能不受限）
- [x] `list_available_skills` / `read_skill_instruction` 对齐同一过滤语义（含 AgentContext 透传）
- [x] 新增迁移 `db-prod/V99-agent-version-custom-skills.sql`

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)
- [x] 技能/智能体/记忆/任务/案例集/角色/用户等管理页：收敛筛选与低频操作层级，降低顶栏与表格噪音
- [x] AgentDebug：补充可关闭的全屏提示，便于获得更大调试视野
- [x] 版本编辑器工具步骤新增 Skills Tab（自定义开关 + 公共技能多选）

### 3. 🐞 关键修复 (Bug Fixes)
- [x] 修复版本列表接口因历史 `skills=NULL` 导致的 ResponseValidationError（列表空白）
- [x] 自定义 Skills 的「至少选一个」校验下沉到保存服务层，避免阻断版本列表响应

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `f6c6550` | 优化多管理页顶栏布局与操作层级，并完善 AgentDebug 全屏引导 |
| `7107d7d` | feat: 智能体支持自定义 Skills 白名单，运行时与选择框/工具统一过滤 |

---

## 测试覆盖 (Testing)
- [ ] **UI 兼容性**: 已验证不同浏览器下的展示效果。
- [x] **核心功能**: 自动化单测覆盖白名单过滤、schema 归一化、`list/read` 工具过滤（`tests/ai/test_agent_custom_skills.py`、`tests/services/ai/test_skill_discovery_tools.py`）。
- [ ] **回归测试**: 确认未引入已知回归错误。
- [ ] **手动验证建议**:
  - 执行 V99 迁移后，打开智能体版本管理应能看到历史版本
  - 开启自定义 Skills 并勾选若干公共技能 → 发布 → 对话中「调用技能工作流」仅见勾选公共 + 个人
  - Agent 调用 `list_available_skills` 结果与配置一致

> [!IMPORTANT]
> 提交前请务必确认已更新 `tests/CHECKLIST.md` 中的自动化测试清单。

---

## 其他备注 (Notes)
- **必须执行 DB 迁移**：`db-prod/V99-agent-version-custom-skills.sql`（为 `ai_agent_versions` 增加 `skills_custom` / `skills`）
- 设计说明见：`docs/superpowers/specs/2026-07-18-agent-custom-skills-design.md`
- 个人技能永不写入智能体版本配置；自定义模式下个人技能仍始终可用


Made with [Cursor](https://cursor.com)