### PR TITLE
fix: 修复从工作台进入会话后新会话被钉回旧会话

### DIFF
--- a/frontend/src/views/Chat.vue
+++ b/frontend/src/views/Chat.vue
@@ -54,6 +54,8 @@ const loading = ref(true);
 const isInitTimedOut = ref(false);
 const widgetReady = ref(false);
 let timeoutTimer: any = null;
+/** 挂件主动新开会话后清 URL 钉选时，跳过一次 query watch 触发的 INIT，避免重复初始化 */
+let skipNextQueryInit = false;
 
 const initChat = () => {
     // 基础路径
@@ -130,10 +132,26 @@ const handleSavedReportOpenEvent = (event: Event) => {
     sendSavedReportOpenRequest((event as CustomEvent<SavedReportOpenRequest>).detail);
 };
 
+const clearHostConversationPin = () => {
+    if (!route.query.conversation_id) return;
+    const nextQuery = { ...route.query };
+    delete nextQuery.conversation_id;
+    skipNextQueryInit = true;
+    router.replace({ path: route.path, query: nextQuery });
+};
+
 const handleMessage = (event: MessageEvent) => {
     const data = event.data;
     if (data.source === 'nanzi-agent-embed' && data.type === 'OPEN_DATA_PORTAL_FULL') {
         router.push({ path: '/dashboard/personal', query: { tab: 'data' } });
+        return;
+    }
+    if (
+        data.source === 'nanzi-agent-embed' &&
+        data.type === 'CONVERSATION_CHANGED' &&
+        data.clear_host_conversation_pin
+    ) {
+        clearHostConversationPin();
         return;
     }
     
@@ -159,6 +177,10 @@ watch(
         route.query.run_id,
     ],
     () => {
+        if (skipNextQueryInit) {
+            skipNextQueryInit = false;
+            return;
+        }
         if (widgetReady.value) {
             sendInitConfig();
         }

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -3152,6 +3152,9 @@ const generateNewConversation = () => {
   if (previousId) {
     finalizeConversationInBackground(previousId);
   }
+  // 工作台等入口通过 INIT_CONFIG 写入的 resume id，新会话时必须清掉，
+  // 否则随后 initChat() 会再次强制切回旧会话并重载历史。
+  requestedConversationId = "";
   conversationId.value = createConversationId();
   localStorage.setItem("yovole_embed_conv_id", conversationId.value);
   updateActiveConversationOnServer(conversationId.value);
@@ -4389,6 +4392,7 @@ const handlePostMessage = (event: MessageEvent) => {
             // 未指定会话：新开对话，避免仍停在上一会话内容
             messages.value = [];
             generateNewConversation();
+            // 钉住本次新会话，供紧随其后的 initChat 加载空历史（而非服务端旧 active）
             requestedConversationId = conversationId.value;
           }
         }
@@ -4396,6 +4400,9 @@ const handlePostMessage = (event: MessageEvent) => {
           requestedConversationId = String(data.conversation_id);
           conversationId.value = requestedConversationId;
           localStorage.setItem("yovole_embed_conv_id", requestedConversationId);
+        } else if (!data.agent_id) {
+          // 父页已取消会话钉选时，勿保留陈旧 resume id
+          requestedConversationId = "";
         }
         if (data.instance_id) config.instanceId = data.instance_id;
         if (data.theme) applyTheme(data.theme, data.styleVars);
@@ -4508,6 +4515,12 @@ const resetSession = (newToken?: string) => {
     axios.defaults.headers.common["X-API-Key"] = newToken;
   }
   initChat();
+  // 通知门户父页去掉 URL 中的 conversation_id，避免再次 INIT 或刷新又钉回旧会话
+  postMessageToHost({
+    type: "CONVERSATION_CHANGED",
+    conversation_id: conversationId.value,
+    clear_host_conversation_pin: true,
+  });
 };
 const handleConfirmClearSession = () => {
   resetSession();

--- a/tests/frontend/test_personal_workbench_contract.py
+++ b/tests/frontend/test_personal_workbench_contract.py
@@ -123,6 +123,20 @@ def test_chat_host_forwards_workbench_conversation_and_agent_targets():
     assert "if (data.agent_id)" in embed
 
 
+def test_new_session_clears_workbench_conversation_pin():
+    """从工作台带 conversation_id 进入后，新会话不得再被 resume id / URL 钉回旧会话。"""
+    chat = _read("frontend/src/views/Chat.vue")
+    embed = _read("frontend/src/views/EmbedChat.vue")
+
+    assert "requestedConversationId = \"\"" in embed
+    assert "clear_host_conversation_pin" in embed
+    assert 'type: "CONVERSATION_CHANGED"' in embed
+    assert "clearHostConversationPin" in chat
+    assert "clear_host_conversation_pin" in chat
+    assert "skipNextQueryInit" in chat
+    assert "delete nextQuery.conversation_id" in chat
+
+
 def test_scenario_browse_routes_allow_chat_users():
     router = _read("frontend/src/router/index.ts")
     assert "path: 'scenario-templates'" in router


### PR DESCRIPTION
## Summary
- 从工作台带 `conversation_id` 进入会话后，「新会话」会因 `requestedConversationId` / URL 钉选被重新加载回旧会话
- 新会话时清除 resume 钉选，并通知父页去掉 URL 中的 `conversation_id`

## Test plan
- [ ] 从「我的工作台」打开某会话
- [ ] 点击「新会话」并确认：应清空为新对话，不再回到原会话历史
- [ ] 确认地址栏已去掉 `conversation_id` 参数


Made with [Cursor](https://cursor.com)