### PR TITLE
Pull Request: 精简数据/知识库门户视觉，路由切换改用 Toast

### DIFF
--- a/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
+++ b/frontend/src/components/chatbi/DatasetCapabilityMenu.vue
@@ -15,19 +15,19 @@
     </div>
 
     <!-- Header -->
-    <div class="bg-gray-50/40 dark:bg-gray-800/10 backdrop-blur-sm border border-gray-150 dark:border-gray-800/80 rounded-xl p-3 flex flex-row items-center justify-between gap-2">
+    <div class="border border-gray-200 dark:border-gray-800 rounded-lg px-3 py-2.5 flex flex-row items-center justify-between gap-2">
       <div class="flex items-center gap-2.5 min-w-0">
-        <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-blue-600 dark:bg-blue-500 text-white shadow-sm flex-shrink-0">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div class="flex items-center justify-center w-7 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 flex-shrink-0">
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2v-4z"/>
           </svg>
         </div>
         <div class="min-w-0">
-          <h3 class="text-sm font-bold text-gray-900 dark:text-gray-100 tracking-wide">我的数据门户</h3>
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">数据门户</h3>
           <div class="flex flex-wrap items-center gap-1.5 mt-0.5 text-[10px]">
             <span
               v-if="payload.dataset_count !== undefined"
-              class="font-semibold text-blue-600 dark:text-blue-400"
+              class="font-medium text-gray-500 dark:text-gray-400"
             >
               {{ payload.dataset_count }} 个数据集
             </span>
@@ -138,28 +138,28 @@
         </div>
       </div>
     </transition>
-    <!-- 📌 我的黄金报表 (Redis 暂存版) -->
+    <!-- 黄金报表（次要区块，默认收起） -->
     <div
       v-if="!initialLoading"
-      class="rounded-xl border border-blue-150/70 dark:border-blue-900/40 bg-blue-50/10 dark:bg-blue-950/5 p-3.5 space-y-2.5 animate-fade-in-up"
+      class="rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-50/40 dark:bg-gray-900/40 px-3 py-2.5 space-y-2"
     >
       <div
-        class="flex items-center justify-between w-full text-[11px] font-bold text-blue-700 dark:text-blue-400 uppercase tracking-wider transition-colors select-none cursor-pointer"
+        class="flex items-center justify-between w-full text-[11px] font-semibold text-gray-600 dark:text-gray-400 transition-colors select-none cursor-pointer"
         @click="showSavedReportsCollapse = !showSavedReportsCollapse; if (!showSavedReportsCollapse) fetchSavedReports();"
       >
         <span class="flex items-center gap-1.5">
-          <span>📌</span> 我的黄金报表
-          <span 
+          黄金报表
+          <span
             v-if="savedReports.length > 0"
-            class="rounded-full px-1.5 py-0.5 text-[9px] font-bold bg-blue-100 dark:bg-blue-900/60 text-blue-700 dark:text-blue-355"
+            class="rounded px-1.5 py-0.5 text-[9px] font-semibold bg-gray-200/80 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
           >
-            {{ savedReports.length }} 个
+            {{ savedReports.length }}
           </span>
         </span>
-        <div class="flex items-center space-x-2">
+        <div class="flex items-center space-x-1">
           <button
             type="button"
-            class="p-1 rounded hover:bg-blue-100/80 dark:hover:bg-blue-900/40 text-blue-700 dark:text-blue-400 transition-colors cursor-pointer flex items-center justify-center"
+            class="p-1 rounded hover:bg-gray-200/80 dark:hover:bg-gray-800 text-gray-500 dark:text-gray-400 transition-colors cursor-pointer flex items-center justify-center"
             title="放大浏览"
             @click.stop="openSavedReportBrowser"
           >
@@ -169,7 +169,7 @@
           </button>
           <button
             type="button"
-            class="p-1 rounded hover:bg-blue-100/80 dark:hover:bg-blue-900/40 text-blue-700 dark:text-blue-400 transition-colors cursor-pointer flex items-center justify-center"
+            class="p-1 rounded hover:bg-gray-200/80 dark:hover:bg-gray-800 text-gray-500 dark:text-gray-400 transition-colors cursor-pointer flex items-center justify-center"
             title="刷新黄金报表"
             @click.stop="fetchSavedReports"
           >
@@ -265,7 +265,7 @@
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
           </svg>
-          正在加载暂存报表...
+          正在加载黄金报表...
         </div>
         <div v-else-if="filteredSavedReports.length === 0" class="text-center py-6 border border-dashed border-gray-200 dark:border-gray-800 rounded-xl text-gray-400 dark:text-gray-500 text-[11px] select-none">
           暂无已存报表。您可以在 ChatBI 结果中点击 SQL 上方的「添加黄金报表」按钮进行快捷收藏。
@@ -709,16 +709,16 @@
         </div>
       </transition>
 
-      <div class="grid gap-4" :class="{ 'pointer-events-none select-none': showRefreshBusy }">
+      <div class="grid gap-3" :class="{ 'pointer-events-none select-none': showRefreshBusy }">
         <article
           v-for="{ group, visuals } in visibleDisplayGroups"
           :key="group.id || group.title"
-          class="group/card relative overflow-hidden rounded-xl border shadow-sm hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300"
+          class="group/card relative overflow-hidden rounded-lg border transition-colors duration-200"
           :class="[
-            isCardCollapsed(group) ? 'p-2.5 sm:p-3' : 'p-3.5 sm:p-4',
+            isCardCollapsed(group) ? 'p-2.5 sm:p-3' : 'p-3 sm:p-3.5',
             visuals.card, visuals.cardBorder, visuals.cardHover,
             canDragCards ? 'cursor-grab active:cursor-grabbing' : '',
-            dragOverId === (group.id || group.title) ? 'ring-2 ring-blue-400/60 dark:ring-blue-500/60 scale-[1.01]' : '',
+            dragOverId === (group.id || group.title) ? 'border-blue-400 dark:border-blue-500' : '',
             dragSourceId === (group.id || group.title) ? 'opacity-50' : '',
           ]"
           :draggable="canDragCards"
@@ -738,28 +738,18 @@
               <circle cx="4" cy="8" r="1.2"/><circle cx="8" cy="8" r="1.2"/><circle cx="12" cy="8" r="1.2"/>
             </svg>
           </div>
-          <div
-            class="pointer-events-none absolute -right-10 -top-10 h-28 w-28 rounded-full opacity-[0.18] blur-2xl transition-opacity duration-300 group-hover/card:opacity-[0.28]"
-            :class="visuals.decor"
-          />
-          <div
-            class="pointer-events-none absolute -left-6 bottom-0 h-20 w-20 rounded-full opacity-[0.08] blur-xl"
-            :class="visuals.decor"
-          />
 
           <!-- Card Header -->
 
           <div class="relative space-y-2.5">
             <div class="flex items-start gap-2.5 min-w-0">
               <div
-                class="portal-card-icon flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-xl shadow-sm border text-white"
-                :class="visuals.iconBorder"
+                class="portal-card-icon flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-md text-white"
                 :data-theme="visuals.key"
                 v-html="visuals.icon"
               />
               <h4
-                class="flex-1 min-w-0 text-sm font-bold leading-snug break-words pt-0.5"
-                :class="visuals.title"
+                class="flex-1 min-w-0 text-sm font-semibold leading-snug break-words pt-0.5 text-gray-900 dark:text-gray-100"
                 :title="group.title"
               >
                 {{ group.title }}
@@ -798,28 +788,28 @@
                   >
                     <button
                       type="button"
-                      class="flex w-full flex-col text-left px-2.5 py-1.5 rounded-lg transition-colors hover:bg-emerald-50/80 dark:hover:bg-emerald-900/20 group/btn"
+                      class="flex w-full flex-col text-left px-2.5 py-1.5 rounded-lg transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 group/btn"
                       @click="handleToggleTurnMount(group)"
                     >
-                      <span class="text-xs font-bold text-gray-800 dark:text-gray-200 group-hover/btn:text-emerald-600 dark:group-hover/btn:text-emerald-400 flex items-center justify-between">
-                        <span>⚡ {{ isTurnMounted(group) ? '取消本轮挂载' : '本轮挂载' }}</span>
+                      <span class="text-xs font-semibold text-gray-800 dark:text-gray-200 group-hover/btn:text-gray-900 dark:group-hover/btn:text-white flex items-center justify-between">
+                        <span>{{ isTurnMounted(group) ? '取消仅本次' : '仅本次' }}</span>
                         <span v-if="isTurnMounted(group)" class="text-[10px] text-emerald-600 dark:text-emerald-400 font-normal">已开启</span>
                       </span>
                       <span class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5 leading-tight">
-                        {{ isTurnMounted(group) ? '已限定下一次提问在此范围内' : '仅对下一次提问生效，精准锁定范围' }}
+                        {{ isTurnMounted(group) ? '下一次提问不再限定此范围' : '只对下一次提问生效' }}
                       </span>
                     </button>
                     <button
                       type="button"
-                      class="flex w-full flex-col text-left px-2.5 py-1.5 rounded-lg transition-colors hover:bg-blue-50/80 dark:hover:bg-blue-900/20 group/btn"
+                      class="flex w-full flex-col text-left px-2.5 py-1.5 rounded-lg transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 group/btn"
                       @click="handlePinToSession(group)"
                     >
-                      <span class="text-xs font-bold text-gray-800 dark:text-gray-200 group-hover/btn:text-blue-600 dark:group-hover/btn:text-blue-400 flex items-center justify-between">
-                        <span>📌 {{ isSessionMounted(group) ? '取消会话挂载' : '固定到会话' }}</span>
+                      <span class="text-xs font-semibold text-gray-800 dark:text-gray-200 group-hover/btn:text-gray-900 dark:group-hover/btn:text-white flex items-center justify-between">
+                        <span>{{ isSessionMounted(group) ? '取消本会话默认' : '本会话默认' }}</span>
                         <span v-if="isSessionMounted(group)" class="text-[10px] text-blue-600 dark:text-blue-400 font-normal">已固定</span>
                       </span>
                       <span class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5 leading-tight">
-                        {{ isSessionMounted(group) ? '作为会话默认范围持续生效中' : '作为会话默认范围，后续提问持续生效' }}
+                        {{ isSessionMounted(group) ? '后续提问恢复默认权限范围' : '后续提问默认限定此范围' }}
                       </span>
                     </button>
                   </div>
@@ -874,13 +864,12 @@
             >
             <div
               v-if="group.tags?.length"
-              class="flex flex-wrap gap-1 pl-11 min-w-0"
+              class="flex flex-wrap gap-1 pl-10 min-w-0"
             >
               <span
-                v-for="tag in group.tags.slice(0, 3)"
+                v-for="tag in group.tags.slice(0, 2)"
                 :key="tag"
-                class="inline-block max-w-full rounded-full border px-2 py-0.5 text-[9px] font-bold leading-tight line-clamp-2 break-all"
-                :class="visuals.tag"
+                class="inline-block max-w-full rounded border px-1.5 py-0.5 text-[9px] font-medium leading-tight line-clamp-2 break-all bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-800/60 dark:text-gray-300 dark:border-gray-700"
                 :title="tag"
               >
                 {{ formatTagLabel(tag) }}
@@ -889,14 +878,13 @@
 
             <blockquote
               v-if="group.summary"
-              class="portal-card-summary relative w-full m-0 px-3.5 py-2.5 text-xs leading-relaxed rounded-r-lg border-l-[3px]"
-              :class="visuals.quote"
-              :style="{ '--summary-strong': visuals.strongColor }"
+              class="portal-card-summary relative w-full m-0 px-3 py-2 text-xs leading-relaxed rounded-r-md border-l-2 border-gray-300 bg-gray-50/80 text-gray-600 dark:border-gray-600 dark:bg-gray-800/40 dark:text-gray-300"
+              :style="{ '--summary-strong': 'rgb(55 65 81)' }"
               v-html="formatGroupSummary(group.summary)"
             />
 
             <div v-if="group.metrics?.length" class="relative mt-2.5">
-              <div class="mb-1.5 text-[10px] font-bold uppercase tracking-wider flex items-center gap-1 select-none" :class="visuals.sectionLabel">
+              <div class="mb-1.5 text-[10px] font-semibold tracking-wide flex items-center gap-1 select-none text-gray-500 dark:text-gray-400">
                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>
                 </svg>
@@ -907,122 +895,104 @@
                   v-for="metric in group.metrics"
                   :key="`${group.id || group.title}-${metric}`"
                   type="button"
-                  class="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-semibold rounded-lg border transition-all active:scale-95"
-                  :class="visuals.questionBtn"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium rounded-md border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300 dark:hover:bg-gray-800 transition-colors"
                   :title="`点击查询「${metric}」趋势`"
                   @click.stop="handleMetricClick(metric, group)"
                 >
                   <span>{{ metric }}</span>
-                  <svg class="w-2.5 h-2.5 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg class="w-2.5 h-2.5 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M9 5l7 7-7 7"/>
                   </svg>
                 </button>
               </div>
             </div>
 
-          <!-- You Can Ask Section -->
-          <div v-if="group.questions?.length" class="relative mt-4">
-            <div class="mb-2 flex items-center justify-between select-none">
-              <span
-                class="text-[10px] font-bold uppercase tracking-wider flex items-center gap-1"
-                :class="visuals.sectionLabel"
-              >
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                </svg>
-                你可以这样问
+            <!-- You Can Ask Section -->
+            <div v-if="group.questions?.length" class="relative mt-3">
+              <div class="mb-2 flex items-center justify-between select-none">
                 <span
-                  class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full text-[9px] font-bold text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 cursor-help border border-gray-300/70 dark:border-gray-600/70"
-                  :title="QUESTIONS_SECTION_TIP"
-                  aria-label="你可以这样问说明"
-                  @click.stop
-                >?</span>
-              </span>
-              <button
-                type="button"
-                class="inline-flex items-center gap-1 text-[10px] font-bold transition-all duration-200 cursor-pointer active:scale-95 px-2 py-0.5 rounded-md border disabled:opacity-50"
-                :class="visuals.refreshBtn"
-                :disabled="isQuestionsRefreshDisabled(group)"
-                @click.stop="handleRefreshGroupQuestions(group)"
-              >
-                <svg
-                  class="w-3 h-3 opacity-70"
-                  :class="{ 'animate-spin': refreshingGroupIds[group.id || group.title] }"
-                  fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                  class="text-[10px] font-semibold tracking-wide flex items-center gap-1 text-gray-500 dark:text-gray-400"
                 >
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
-                </svg>
-                <span>换一批</span>
-              </button>
-            </div>
-
-            <div v-if="refreshingGroupIds[group.id || group.title]" class="flex flex-wrap gap-2 animate-pulse-slow">
-              <div
-                v-for="i in 3"
-                :key="i"
-                class="inline-flex items-center h-8 w-32 rounded-lg border"
-                :class="visuals.questionSkeleton"
-              ></div>
-            </div>
-            <div v-else class="flex flex-wrap gap-2">
-              <div
-                v-for="question in sortedQuestions(group.questions)"
-                :key="question.query"
-                class="group/qbtn inline-flex items-stretch rounded-lg border transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-sm overflow-hidden"
-                :class="visuals.questionBtn"
-              >
+                  你可以这样问
+                  <span
+                    class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full text-[9px] font-bold text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 cursor-help border border-gray-300/70 dark:border-gray-600/70"
+                    :title="QUESTIONS_SECTION_TIP"
+                    aria-label="你可以这样问说明"
+                    @click.stop
+                  >?</span>
+                </span>
                 <button
                   type="button"
-                  class="inline-flex items-center gap-1.5 px-3 py-2 text-left text-xs font-semibold cursor-pointer select-none bg-transparent hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
-                  @click="handleQuestionClick(question, group, 'send')"
+                  class="inline-flex items-center gap-1 text-[10px] font-medium transition-colors duration-200 cursor-pointer active:scale-95 px-2 py-0.5 rounded-md border border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 disabled:opacity-50"
+                  :disabled="isQuestionsRefreshDisabled(group)"
+                  @click.stop="handleRefreshGroupQuestions(group)"
                 >
                   <svg
-                    class="w-3.5 h-3.5 flex-shrink-0 opacity-80"
+                    class="w-3 h-3 opacity-70"
+                    :class="{ 'animate-spin': refreshingGroupIds[group.id || group.title] }"
                     fill="none" stroke="currentColor" viewBox="0 0 24 24"
                   >
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
                   </svg>
-                  <span>{{ question.label }}</span>
-                  <span
-                    v-if="question.click_count"
-                    class="ml-1 inline-flex items-center px-1 py-0.5 rounded bg-amber-500/10 text-[9px] font-bold text-amber-600 border border-amber-500/20 dark:bg-amber-500/20 dark:text-amber-300 dark:border-amber-500/30 shadow-sm"
-                  >
-                    🔥 常用 {{ question.click_count }}
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  class="opacity-0 group-hover/qbtn:opacity-100 flex items-center justify-center px-2 border-l transition-all duration-200 cursor-pointer bg-transparent hover:bg-black/5 dark:hover:bg-white/5"
-                  :class="[
-                    visuals.key === 'blue' ? 'border-blue-200/80 dark:border-blue-800/50' :
-                    visuals.key === 'violet' ? 'border-violet-200/80 dark:border-violet-800/50' :
-                    visuals.key === 'emerald' ? 'border-emerald-200/80 dark:border-emerald-800/50' :
-                    visuals.key === 'amber' ? 'border-amber-200/80 dark:border-amber-800/50' :
-                    visuals.key === 'rose' ? 'border-rose-200/80 dark:border-rose-800/50' :
-                    'border-cyan-200/80 dark:border-cyan-800/50'
-                  ]"
-                  title="填入输入框微调"
-                  aria-label="填入输入框微调"
-                  @click.stop="handleQuestionClick(question, group, 'fill')"
-                >
-                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.83 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125" />
-                  </svg>
+                  <span>换一批</span>
                 </button>
               </div>
-            </div>
-          </div>
 
+              <div v-if="refreshingGroupIds[group.id || group.title]" class="flex flex-wrap gap-2 animate-pulse-slow">
+                <div
+                  v-for="i in 3"
+                  :key="i"
+                  class="inline-flex items-center h-8 w-32 rounded-lg border bg-gray-50 border-gray-100 dark:bg-gray-800/40 dark:border-gray-700"
+                ></div>
+              </div>
+              <div v-else class="flex flex-wrap gap-2">
+                <div
+                  v-for="question in sortedQuestions(group.questions)"
+                  :key="question.query"
+                  class="group/qbtn inline-flex items-stretch rounded-lg border border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-200 overflow-hidden hover:border-gray-300 dark:hover:border-gray-600 transition-colors"
+                >
+                  <button
+                    type="button"
+                    class="inline-flex items-center gap-1.5 px-3 py-2 text-left text-xs font-medium cursor-pointer select-none bg-transparent hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
+                    @click="handleQuestionClick(question, group, 'send')"
+                  >
+                    <svg
+                      class="w-3 h-3 opacity-50 flex-shrink-0"
+                      fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                    >
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
+                    </svg>
+                    <span>{{ question.label || question.query }}</span>
+                    <span
+                      v-if="question.click_count"
+                      class="ml-1 inline-flex items-center px-1 py-0.5 rounded text-[9px] font-medium text-amber-700 bg-amber-50 border border-amber-200/80 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800/50"
+                    >
+                      常用 {{ question.click_count }}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    class="opacity-0 group-hover/qbtn:opacity-100 flex items-center justify-center px-2 border-l border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-150 cursor-pointer text-gray-400 hover:text-gray-600"
+                    title="填入输入框微调"
+                    aria-label="填入输入框微调"
+                    @click.stop="handleQuestionClick(question, group, 'fill')"
+                  >
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.83 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
 
           <!-- Related Data Section -->
           <div
             v-if="group.related_data?.length"
-            class="relative mt-4 border-t pt-3"
-            :class="visuals.divider"
+            class="relative mt-4 border-t pt-3 border-gray-100 dark:border-gray-800"
           >
             <button
               type="button"
-              class="flex items-center justify-between w-full text-left text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider hover:text-gray-600 dark:hover:text-gray-300 transition-colors select-none"
+              class="flex items-center justify-between w-full text-left text-[10px] font-semibold text-gray-400 dark:text-gray-500 tracking-wide hover:text-gray-600 dark:hover:text-gray-300 transition-colors select-none"
               @click="toggleGroup(group.id || group.title)"
             >
               <span class="flex items-center gap-1.5">
@@ -1030,7 +1000,7 @@
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
                 </svg>
                 相关数据
-                <span class="rounded-full px-1.5 py-0.5 text-[9px] font-bold bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 normal-case tracking-normal">
+                <span class="rounded px-1.5 py-0.5 text-[9px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 normal-case tracking-normal">
                   {{ countRelatedTables(group) }} 张表
                 </span>
               </span>
@@ -1147,7 +1117,7 @@
                                 @click.stop="handleRecommendQuestions(group, related, table)"
                               >
                                 <span v-if="tableRecommendState[buildTableDictionaryKey(group, related, table)]?.loading">生成中…</span>
-                                <span v-else>💡 推荐提问</span>
+                                <span v-else>推荐提问</span>
                               </button>
                             </div>
                             <div
@@ -1642,10 +1612,10 @@ const isSessionMounted = (group: DatasetCapabilityGroup) => {
 };
 
 const mountButtonTitle = (group: DatasetCapabilityGroup) => {
-  if (isTurnMounted(group) && isSessionMounted(group)) return "本轮已挂载 · 会话已挂载";
-  if (isTurnMounted(group)) return "本轮已挂载";
-  if (isSessionMounted(group)) return "会话已挂载";
-  return "挂载数据集";
+  if (isTurnMounted(group) && isSessionMounted(group)) return "仅本次 · 本会话默认";
+  if (isTurnMounted(group)) return "仅本次";
+  if (isSessionMounted(group)) return "本会话默认";
+  return "限定问数范围";
 };
 
 const toggleMountMenu = (group: DatasetCapabilityGroup) => {
@@ -1659,7 +1629,7 @@ const handleToggleTurnMount = (group: DatasetCapabilityGroup) => {
   const wasMounted = isTurnMounted(group);
   emit("toggle-metadata-dataset", id);
   openMountMenuGroupKey.value = null;
-  showToast(wasMounted ? `已取消本轮挂载「${group.title}」` : `已本轮挂载「${group.title}」`, "success");
+  showToast(wasMounted ? `已取消仅本次「${group.title}」` : `已限定仅本次「${group.title}」`, "success");
 };
 
 const handlePinToSession = (group: DatasetCapabilityGroup) => {
@@ -2318,7 +2288,7 @@ const openSavedReportBrowser = async () => {
 const handleDeleteReport = async (report: any) => {
   try {
     await axios.delete(`/api/portal/saved-reports/${report.id}`);
-    showToast("删除暂存报表成功", "success");
+    showToast("删除黄金报表成功", "success");
     await fetchSavedReports();
   } catch (error: any) {
     console.error("Failed to delete saved report:", error);
@@ -2746,111 +2716,111 @@ interface GroupVisualTheme {
 const CARD_THEMES: GroupVisualTheme[] = [
   {
     key: "blue",
-    card: "bg-gradient-to-br from-blue-50/95 via-white to-sky-50/50 dark:from-blue-950/35 dark:via-gray-900/50 dark:to-sky-950/15",
-    cardBorder: "border-blue-100/90 dark:border-blue-900/45",
-    cardHover: "hover:border-blue-200 dark:hover:border-blue-700/60",
+    card: "bg-white dark:bg-gray-900",
+    cardBorder: "border-gray-200 dark:border-gray-700 border-l-[3px] border-l-blue-500 dark:border-l-blue-400",
+    cardHover: "hover:border-gray-300 dark:hover:border-gray-600",
     decor: "bg-blue-400",
-    iconBorder: "border-blue-400/20",
+    iconBorder: "",
     icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>`,
-    title: "text-blue-950 dark:text-blue-100",
-    tag: "bg-blue-100/90 text-blue-700 border-blue-200/70 dark:bg-blue-900/50 dark:text-blue-200 dark:border-blue-800/60",
-    quote: "border-l-blue-500 bg-blue-50/70 text-blue-900/75 dark:bg-blue-950/35 dark:text-blue-200/90 dark:border-l-blue-400",
-    strongColor: "#1d4ed8",
-    sectionLabel: "text-blue-500/80 dark:text-blue-400/80",
-    refreshBtn: "text-blue-700 bg-white/70 border-blue-200/70 hover:bg-blue-50 dark:text-blue-300 dark:bg-blue-950/40 dark:border-blue-800/50 dark:hover:bg-blue-900/50",
-    questionBtn: "border-blue-200/80 bg-white/80 text-blue-800 hover:bg-blue-50 hover:border-blue-300 dark:border-blue-800/50 dark:bg-blue-950/25 dark:text-blue-200 dark:hover:bg-blue-900/40",
-    questionSkeleton: "bg-blue-50/40 border-blue-100/30 dark:bg-blue-950/15 dark:border-blue-900/20",
-    divider: "border-blue-100/80 dark:border-blue-900/35",
+    title: "text-gray-900 dark:text-gray-100",
+    tag: "bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700",
+    quote: "border-l-gray-300 bg-gray-50/80 text-gray-600 dark:bg-gray-800/40 dark:text-gray-300 dark:border-l-gray-600",
+    strongColor: "#374151",
+    sectionLabel: "text-gray-500 dark:text-gray-400",
+    refreshBtn: "text-gray-600 bg-white border-gray-200 hover:bg-gray-50 dark:text-gray-300 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800",
+    questionBtn: "border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-200 dark:hover:bg-gray-800",
+    questionSkeleton: "bg-gray-50 border-gray-100 dark:bg-gray-800/40 dark:border-gray-700",
+    divider: "border-gray-100 dark:border-gray-800",
   },
   {
     key: "violet",
-    card: "bg-gradient-to-br from-violet-50/95 via-white to-purple-50/40 dark:from-violet-950/35 dark:via-gray-900/50 dark:to-purple-950/15",
-    cardBorder: "border-violet-100/90 dark:border-violet-900/45",
-    cardHover: "hover:border-violet-200 dark:hover:border-violet-700/60",
+    card: "bg-white dark:bg-gray-900",
+    cardBorder: "border-gray-200 dark:border-gray-700 border-l-[3px] border-l-violet-500 dark:border-l-violet-400",
+    cardHover: "hover:border-gray-300 dark:hover:border-gray-600",
     decor: "bg-violet-400",
-    iconBorder: "border-violet-400/20",
+    iconBorder: "",
     icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>`,
-    title: "text-violet-950 dark:text-violet-100",
-    tag: "bg-violet-100/90 text-violet-700 border-violet-200/70 dark:bg-violet-900/50 dark:text-violet-200 dark:border-violet-800/60",
-    quote: "border-l-violet-500 bg-violet-50/70 text-violet-900/75 dark:bg-violet-950/35 dark:text-violet-200/90 dark:border-l-violet-400",
-    strongColor: "#6d28d9",
-    sectionLabel: "text-violet-500/80 dark:text-violet-400/80",
-    refreshBtn: "text-violet-700 bg-white/70 border-violet-200/70 hover:bg-violet-50 dark:text-violet-300 dark:bg-violet-950/40 dark:border-violet-800/50 dark:hover:bg-violet-900/50",
-    questionBtn: "border-violet-200/80 bg-white/80 text-violet-800 hover:bg-violet-50 hover:border-violet-300 dark:border-violet-800/50 dark:bg-violet-950/25 dark:text-violet-200 dark:hover:bg-violet-900/40",
-    questionSkeleton: "bg-violet-50/40 border-violet-100/30 dark:bg-violet-950/15 dark:border-violet-900/20",
-    divider: "border-violet-100/80 dark:border-violet-900/35",
+    title: "text-gray-900 dark:text-gray-100",
+    tag: "bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700",
+    quote: "border-l-gray-300 bg-gray-50/80 text-gray-600 dark:bg-gray-800/40 dark:text-gray-300 dark:border-l-gray-600",
+    strongColor: "#374151",
+    sectionLabel: "text-gray-500 dark:text-gray-400",
+    refreshBtn: "text-gray-600 bg-white border-gray-200 hover:bg-gray-50 dark:text-gray-300 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800",
+    questionBtn: "border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-200 dark:hover:bg-gray-800",
+    questionSkeleton: "bg-gray-50 border-gray-100 dark:bg-gray-800/40 dark:border-gray-700",
+    divider: "border-gray-100 dark:border-gray-800",
   },
   {
     key: "emerald",
-    card: "bg-gradient-to-br from-emerald-50/95 via-white to-teal-50/40 dark:from-emerald-950/35 dark:via-gray-900/50 dark:to-teal-950/15",
-    cardBorder: "border-emerald-100/90 dark:border-emerald-900/45",
-    cardHover: "hover:border-emerald-200 dark:hover:border-emerald-700/60",
+    card: "bg-white dark:bg-gray-900",
+    cardBorder: "border-gray-200 dark:border-gray-700 border-l-[3px] border-l-emerald-500 dark:border-l-emerald-400",
+    cardHover: "hover:border-gray-300 dark:hover:border-gray-600",
     decor: "bg-emerald-400",
-    iconBorder: "border-emerald-400/20",
+    iconBorder: "",
     icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>`,
-    title: "text-emerald-950 dark:text-emerald-100",
-    tag: "bg-emerald-100/90 text-emerald-700 border-emerald-200/70 dark:bg-emerald-900/50 dark:text-emerald-200 dark:border-emerald-800/60",
-    quote: "border-l-emerald-500 bg-emerald-50/70 text-emerald-900/75 dark:bg-emerald-950/35 dark:text-emerald-200/90 dark:border-l-emerald-400",
-    strongColor: "#047857",
-    sectionLabel: "text-emerald-500/80 dark:text-emerald-400/80",
-    refreshBtn: "text-emerald-700 bg-white/70 border-emerald-200/70 hover:bg-emerald-50 dark:text-emerald-300 dark:bg-emerald-950/40 dark:border-emerald-800/50 dark:hover:bg-emerald-900/50",
-    questionBtn: "border-emerald-200/80 bg-white/80 text-emerald-800 hover:bg-emerald-50 hover:border-emerald-300 dark:border-emerald-800/50 dark:bg-emerald-950/25 dark:text-emerald-200 dark:hover:bg-emerald-900/40",
-    questionSkeleton: "bg-emerald-50/40 border-emerald-100/30 dark:bg-emerald-950/15 dark:border-emerald-900/20",
-    divider: "border-emerald-100/80 dark:border-emerald-900/35",
+    title: "text-gray-900 dark:text-gray-100",
+    tag: "bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700",
+    quote: "border-l-gray-300 bg-gray-50/80 text-gray-600 dark:bg-gray-800/40 dark:text-gray-300 dark:border-l-gray-600",
+    strongColor: "#374151",
+    sectionLabel: "text-gray-500 dark:text-gray-400",
+    refreshBtn: "text-gray-600 bg-white border-gray-200 hover:bg-gray-50 dark:text-gray-300 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800",
+    questionBtn: "border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-200 dark:hover:bg-gray-800",
+    questionSkeleton: "bg-gray-50 border-gray-100 dark:bg-gray-800/40 dark:border-gray-700",
+    divider: "border-gray-100 dark:border-gray-800",
   },
   {
     key: "amber",
-    card: "bg-gradient-to-br from-amber-50/95 via-white to-orange-50/35 dark:from-amber-950/30 dark:via-gray-900/50 dark:to-orange-950/15",
-    cardBorder: "border-amber-100/90 dark:border-amber-900/45",
-    cardHover: "hover:border-amber-200 dark:hover:border-amber-700/60",
+    card: "bg-white dark:bg-gray-900",
+    cardBorder: "border-gray-200 dark:border-gray-700 border-l-[3px] border-l-amber-500 dark:border-l-amber-400",
+    cardHover: "hover:border-gray-300 dark:hover:border-gray-600",
     decor: "bg-amber-400",
-    iconBorder: "border-amber-400/20",
+    iconBorder: "",
     icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>`,
-    title: "text-amber-950 dark:text-amber-100",
-    tag: "bg-amber-100/90 text-amber-800 border-amber-200/70 dark:bg-amber-900/50 dark:text-amber-200 dark:border-amber-800/60",
-    quote: "border-l-amber-500 bg-amber-50/70 text-amber-900/75 dark:bg-amber-950/35 dark:text-amber-200/90 dark:border-l-amber-400",
-    strongColor: "#b45309",
-    sectionLabel: "text-amber-600/80 dark:text-amber-400/80",
-    refreshBtn: "text-amber-800 bg-white/70 border-amber-200/70 hover:bg-amber-50 dark:text-amber-300 dark:bg-amber-950/40 dark:border-amber-800/50 dark:hover:bg-amber-900/50",
-    questionBtn: "border-amber-200/80 bg-white/80 text-amber-900 hover:bg-amber-50 hover:border-amber-300 dark:border-amber-800/50 dark:bg-amber-950/25 dark:text-amber-200 dark:hover:bg-amber-900/40",
-    questionSkeleton: "bg-amber-50/40 border-amber-100/30 dark:bg-amber-950/15 dark:border-amber-900/20",
-    divider: "border-amber-100/80 dark:border-amber-900/35",
+    title: "text-gray-900 dark:text-gray-100",
+    tag: "bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700",
+    quote: "border-l-gray-300 bg-gray-50/80 text-gray-600 dark:bg-gray-800/40 dark:text-gray-300 dark:border-l-gray-600",
+    strongColor: "#374151",
+    sectionLabel: "text-gray-500 dark:text-gray-400",
+    refreshBtn: "text-gray-600 bg-white border-gray-200 hover:bg-gray-50 dark:text-gray-300 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800",
+    questionBtn: "border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-200 dark:hover:bg-gray-800",
+    questionSkeleton: "bg-gray-50 border-gray-100 dark:bg-gray-800/40 dark:border-gray-700",
+    divider: "border-gray-100 dark:border-gray-800",
   },
   {
     key: "rose",
-    card: "bg-gradient-to-br from-rose-50/95 via-white to-pink-50/35 dark:from-rose-950/30 dark:via-gray-900/50 dark:to-pink-950/15",
-    cardBorder: "border-rose-100/90 dark:border-rose-900/45",
-    cardHover: "hover:border-rose-200 dark:hover:border-rose-700/60",
+    card: "bg-white dark:bg-gray-900",
+    cardBorder: "border-gray-200 dark:border-gray-700 border-l-[3px] border-l-rose-500 dark:border-l-rose-400",
+    cardHover: "hover:border-gray-300 dark:hover:border-gray-600",
     decor: "bg-rose-400",
-    iconBorder: "border-rose-400/20",
+    iconBorder: "",
     icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/></svg>`,
-    title: "text-rose-950 dark:text-rose-100",
-    tag: "bg-rose-100/90 text-rose-700 border-rose-200/70 dark:bg-rose-900/50 dark:text-rose-200 dark:border-rose-800/60",
-    quote: "border-l-rose-500 bg-rose-50/70 text-rose-900/75 dark:bg-rose-950/35 dark:text-rose-200/90 dark:border-l-rose-400",
-    strongColor: "#be123c",
-    sectionLabel: "text-rose-500/80 dark:text-rose-400/80",
-    refreshBtn: "text-rose-700 bg-white/70 border-rose-200/70 hover:bg-rose-50 dark:text-rose-300 dark:bg-rose-950/40 dark:border-rose-800/50 dark:hover:bg-rose-900/50",
-    questionBtn: "border-rose-200/80 bg-white/80 text-rose-800 hover:bg-rose-50 hover:border-rose-300 dark:border-rose-800/50 dark:bg-rose-950/25 dark:text-rose-200 dark:hover:bg-rose-900/40",
-    questionSkeleton: "bg-rose-50/40 border-rose-100/30 dark:bg-rose-950/15 dark:border-rose-900/20",
-    divider: "border-rose-100/80 dark:border-rose-900/35",
+    title: "text-gray-900 dark:text-gray-100",
+    tag: "bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700",
+    quote: "border-l-gray-300 bg-gray-50/80 text-gray-600 dark:bg-gray-800/40 dark:text-gray-300 dark:border-l-gray-600",
+    strongColor: "#374151",
+    sectionLabel: "text-gray-500 dark:text-gray-400",
+    refreshBtn: "text-gray-600 bg-white border-gray-200 hover:bg-gray-50 dark:text-gray-300 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800",
+    questionBtn: "border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-200 dark:hover:bg-gray-800",
+    questionSkeleton: "bg-gray-50 border-gray-100 dark:bg-gray-800/40 dark:border-gray-700",
+    divider: "border-gray-100 dark:border-gray-800",
   },
   {
     key: "cyan",
-    card: "bg-gradient-to-br from-cyan-50/95 via-white to-sky-50/35 dark:from-cyan-950/30 dark:via-gray-900/50 dark:to-sky-950/15",
-    cardBorder: "border-cyan-100/90 dark:border-cyan-900/45",
-    cardHover: "hover:border-cyan-200 dark:hover:border-cyan-700/60",
+    card: "bg-white dark:bg-gray-900",
+    cardBorder: "border-gray-200 dark:border-gray-700 border-l-[3px] border-l-cyan-500 dark:border-l-cyan-400",
+    cardHover: "hover:border-gray-300 dark:hover:border-gray-600",
     decor: "bg-cyan-400",
-    iconBorder: "border-cyan-400/20",
+    iconBorder: "",
     icon: `<svg fill="none" stroke="#ffffff" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>`,
-    title: "text-cyan-950 dark:text-cyan-100",
-    tag: "bg-cyan-100/90 text-cyan-800 border-cyan-200/70 dark:bg-cyan-900/50 dark:text-cyan-200 dark:border-cyan-800/60",
-    quote: "border-l-cyan-500 bg-cyan-50/70 text-cyan-900/75 dark:bg-cyan-950/35 dark:text-cyan-200/90 dark:border-l-cyan-400",
-    strongColor: "#0e7490",
-    sectionLabel: "text-cyan-600/80 dark:text-cyan-400/80",
-    refreshBtn: "text-cyan-800 bg-white/70 border-cyan-200/70 hover:bg-cyan-50 dark:text-cyan-300 dark:bg-cyan-950/40 dark:border-cyan-800/50 dark:hover:bg-cyan-900/50",
-    questionBtn: "border-cyan-200/80 bg-white/80 text-cyan-900 hover:bg-cyan-50 hover:border-cyan-300 dark:border-cyan-800/50 dark:bg-cyan-950/25 dark:text-cyan-200 dark:hover:bg-cyan-900/40",
-    questionSkeleton: "bg-cyan-50/40 border-cyan-100/30 dark:bg-cyan-950/15 dark:border-cyan-900/20",
-    divider: "border-cyan-100/80 dark:border-cyan-900/35",
+    title: "text-gray-900 dark:text-gray-100",
+    tag: "bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700",
+    quote: "border-l-gray-300 bg-gray-50/80 text-gray-600 dark:bg-gray-800/40 dark:text-gray-300 dark:border-l-gray-600",
+    strongColor: "#374151",
+    sectionLabel: "text-gray-500 dark:text-gray-400",
+    refreshBtn: "text-gray-600 bg-white border-gray-200 hover:bg-gray-50 dark:text-gray-300 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800",
+    questionBtn: "border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-200 dark:hover:bg-gray-800",
+    questionSkeleton: "bg-gray-50 border-gray-100 dark:bg-gray-800/40 dark:border-gray-700",
+    divider: "border-gray-100 dark:border-gray-800",
   },
 ];
 
@@ -3409,33 +3379,27 @@ const handleRecommendedQuestionClick = (
 }
 
 .portal-card-icon[data-theme="blue"] {
-  background: linear-gradient(135deg, #3b82f6, #2563eb);
-  box-shadow: 0 4px 12px rgb(59 130 246 / 0.25);
+  background: #2563eb;
 }
 
 .portal-card-icon[data-theme="violet"] {
-  background: linear-gradient(135deg, #8b5cf6, #7c3aed);
-  box-shadow: 0 4px 12px rgb(139 92 246 / 0.25);
+  background: #7c3aed;
 }
 
 .portal-card-icon[data-theme="emerald"] {
-  background: linear-gradient(135deg, #10b981, #0d9488);
-  box-shadow: 0 4px 12px rgb(16 185 129 / 0.25);
+  background: #059669;
 }
 
 .portal-card-icon[data-theme="amber"] {
-  background: linear-gradient(135deg, #f59e0b, #ea580c);
-  box-shadow: 0 4px 12px rgb(245 158 11 / 0.25);
+  background: #d97706;
 }
 
 .portal-card-icon[data-theme="rose"] {
-  background: linear-gradient(135deg, #f43f5e, #db2777);
-  box-shadow: 0 4px 12px rgb(244 63 94 / 0.25);
+  background: #e11d48;
 }
 
 .portal-card-icon[data-theme="cyan"] {
-  background: linear-gradient(135deg, #06b6d4, #0284c7);
-  box-shadow: 0 4px 12px rgb(6 182 212 / 0.25);
+  background: #0891b2;
 }
 
 .portal-card-summary :deep(strong) {

--- a/frontend/src/components/chatbi/DatasetPortalDrawer.vue
+++ b/frontend/src/components/chatbi/DatasetPortalDrawer.vue
@@ -97,7 +97,7 @@
                 <svg class="w-4 h-4 text-blue-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 16a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 01-2-2v-4z" />
                 </svg>
-                <span class="truncate">数据门户导航</span>
+                <span class="truncate">数据门户</span>
                 <span
                   v-if="pinned"
                   class="hidden sm:inline-flex shrink-0 items-center px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wide whitespace-nowrap text-blue-600 bg-blue-50 border border-blue-100 dark:text-blue-300 dark:bg-blue-500/10 dark:border-blue-500/20"

--- a/frontend/src/components/knowledge/KnowledgePortalDrawer.vue
+++ b/frontend/src/components/knowledge/KnowledgePortalDrawer.vue
@@ -146,19 +146,21 @@
 
              <!-- Content List -->
             <div class="flex-1 overflow-y-auto p-4 bg-gray-50/50 dark:bg-gray-900/40 min-h-0 space-y-3 scrollbar-thin">
-              <div v-if="props.projectResourceScope" class="rounded-lg border border-blue-100 bg-blue-50 px-3 py-2 text-xs font-semibold text-blue-700 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-300">
-                🔒 {{ props.projectResourceScope }}
+              <div v-if="props.projectResourceScope" class="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs font-medium text-gray-600 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300">
+                {{ props.projectResourceScope }}
               </div>
               <!-- Overview Card -->
-              <div class="bg-white dark:bg-gray-800/80 backdrop-blur-xs border border-gray-150 dark:border-gray-800 rounded-xl p-3 flex flex-row items-center justify-between gap-2 shadow-xs select-none">
+              <div class="border border-gray-200 dark:border-gray-800 rounded-lg px-3 py-2.5 flex flex-row items-center justify-between gap-2 select-none">
                 <div class="flex items-center gap-2.5 min-w-0">
-                  <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-green-600 dark:bg-green-500 text-white shadow-sm flex-shrink-0 text-xs font-bold">
-                    📚
+                  <div class="flex items-center justify-center w-7 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 flex-shrink-0">
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                    </svg>
                   </div>
                   <div class="min-w-0">
-                    <h3 class="text-xs font-bold text-gray-900 dark:text-gray-100 tracking-wide">我的知识库中心</h3>
-                    <div class="flex flex-wrap items-center gap-1.5 mt-0.5 text-[9px]">
-                      <span class="font-semibold text-green-600 dark:text-green-400">
+                    <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">知识库</h3>
+                    <div class="flex flex-wrap items-center gap-1.5 mt-0.5 text-[10px]">
+                      <span class="font-medium text-gray-500 dark:text-gray-400">
                         {{ datasets.length }} 个知识库
                       </span>
                       <template v-if="generatedAt">
@@ -266,14 +268,14 @@
                 </div>
               </transition>
 
-              <!-- ⚙️ 高级选项 (Collapsible) -->
-              <div class="rounded-xl border border-gray-150 dark:border-gray-800 bg-gray-50/20 dark:bg-gray-900/10 p-3 space-y-2.5 transition-all duration-300">
+              <!-- 高级配置 (Collapsible) -->
+              <div class="rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-50/40 dark:bg-gray-900/40 px-3 py-2.5 space-y-2">
                 <div
-                  class="flex items-center justify-between w-full text-[10px] font-bold text-gray-500 hover:text-green-600 dark:text-gray-400 dark:hover:text-green-400 uppercase tracking-wider transition-colors select-none cursor-pointer"
+                  class="flex items-center justify-between w-full text-[11px] font-semibold text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors select-none cursor-pointer"
                   @click="showAdvancedConfig = !showAdvancedConfig"
                 >
                   <span class="flex items-center gap-1.5">
-                    <span class="text-xs">⚙️</span> 高级配置
+                    高级配置
                   </span>
                   <svg
                     class="w-3.5 h-3.5 transform transition-transform duration-300 pointer-events-none"
@@ -490,28 +492,20 @@
                 v-else
                 v-for="ds in sortedDatasets"
                 :key="ds.id"
-                class="group/card relative overflow-hidden rounded-xl border p-3.5 sm:p-4 shadow-sm hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300"
+                class="group/card relative overflow-hidden rounded-lg border p-3 sm:p-3.5 transition-colors duration-200"
                 :class="[
                   activeDatasetIds.includes(ds.id)
-                    ? 'border-green-200 dark:border-green-950 bg-green-50/5'
-                    : 'border-gray-150 dark:border-gray-800 bg-white dark:bg-gray-850'
+                    ? 'border-green-300 dark:border-green-800 border-l-[3px] border-l-green-500 bg-white dark:bg-gray-900'
+                    : 'border-gray-200 dark:border-gray-700 border-l-[3px] border-l-transparent bg-white dark:bg-gray-900'
                 ]"
               >
-                <!-- Background decor bubbles matching data portal -->
-                <div
-                  class="pointer-events-none absolute -right-10 -top-10 h-28 w-28 rounded-full opacity-[0.12] blur-2xl transition-opacity duration-300 group-hover/card:opacity-[0.20] bg-green-500"
-                />
-                <div
-                  class="pointer-events-none absolute -left-6 bottom-0 h-20 w-20 rounded-full opacity-[0.05] blur-xl bg-green-500"
-                />
-
                 <div class="relative space-y-2.5">
                   <!-- Header Row -->
                   <div class="flex items-start gap-2.5 min-w-0">
                     <!-- Collapse Toggle Chevron -->
                     <button
                       type="button"
-                      class="flex-shrink-0 flex items-center justify-center w-5 h-9 rounded text-gray-400 hover:text-green-500 hover:bg-green-50/30 dark:hover:bg-green-950/20 transition-all duration-200 cursor-pointer"
+                      class="flex-shrink-0 flex items-center justify-center w-5 h-8 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200 cursor-pointer"
                       @click.stop="toggleCollapse(ds.id)"
                       :title="isCollapsed(ds.id) ? '展开卡片' : '收起卡片'"
                     >
@@ -529,20 +523,22 @@
 
                     <div
                       @click.stop="toggleCollapse(ds.id)"
-                      class="flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-xl shadow-xs border text-[18px] bg-green-50/10 border-green-500/20 text-green-600 dark:bg-green-500/20 dark:border-green-500/30 dark:text-green-400 cursor-pointer hover:opacity-80 transition-opacity select-none"
+                      class="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-md bg-green-600 text-white cursor-pointer hover:opacity-90 transition-opacity select-none"
                     >
-                      📚
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                      </svg>
                     </div>
                     
                     <h4
                       @click.stop="toggleCollapse(ds.id)"
-                      class="flex-1 min-w-0 text-sm font-bold leading-snug break-words pt-0.5 text-gray-800 dark:text-gray-100 flex items-center flex-wrap gap-1.5 cursor-pointer hover:text-green-600 dark:hover:text-green-400 transition-colors select-none"
+                      class="flex-1 min-w-0 text-sm font-semibold leading-snug break-words pt-0.5 text-gray-900 dark:text-gray-100 flex items-center flex-wrap gap-1.5 cursor-pointer hover:text-gray-700 dark:hover:text-gray-200 transition-colors select-none"
                       :title="ds.platform_name || ds.name"
                     >
                       <span>{{ ds.platform_name || ds.name }}</span>
                       <span
                         v-if="isMyCreated(ds)"
-                        class="inline-flex items-center px-1.5 py-0.5 rounded-md text-[9px] font-bold tracking-wider uppercase bg-green-50/50 text-green-600 border border-green-200/30 dark:bg-green-950/20 dark:border-green-800/30 dark:text-green-400 select-none"
+                        class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-medium bg-gray-100 text-gray-600 border border-gray-200 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300 select-none"
                       >
                         自建
                       </span>
@@ -585,45 +581,45 @@
                   <div v-show="!isCollapsed(ds.id)" class="space-y-2.5 pt-0.5">
 
                   <!-- Badges list matching pl-11.5 indentation -->
-                  <div class="flex flex-wrap gap-1.5 pl-11.5 min-w-0">
+                  <div class="flex flex-wrap gap-1 pl-10 min-w-0">
                     <template v-if="ds.tags && ds.tags.length">
                       <span
-                        v-for="tag in ds.tags.slice(0, 3)"
+                        v-for="tag in ds.tags.slice(0, 2)"
                         :key="tag"
-                        class="inline-block max-w-full rounded-full border px-2 py-0.5 text-[9px] font-bold leading-tight bg-blue-50 border-blue-200 text-blue-600 dark:bg-blue-950/20 dark:border-blue-800 dark:text-blue-400"
+                        class="inline-block max-w-full rounded border px-1.5 py-0.5 text-[9px] font-medium leading-tight bg-gray-50 border-gray-200 text-gray-600 dark:bg-gray-800/60 dark:border-gray-700 dark:text-gray-300"
                       >
-                        🏷️ {{ tag }}
+                        {{ tag }}
                       </span>
                       <button
-                        v-if="ds.tags.length > 3"
+                        v-if="ds.tags.length > 2"
                         type="button"
-                        class="inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-[9px] font-bold leading-tight bg-gray-100 hover:bg-gray-200 border-gray-250 text-gray-600 dark:bg-gray-850 dark:hover:bg-gray-750 dark:border-gray-700 dark:text-gray-300 transition-all cursor-pointer active:scale-90"
+                        class="inline-flex items-center justify-center rounded border px-1.5 py-0.5 text-[9px] font-medium leading-tight bg-gray-50 hover:bg-gray-100 border-gray-200 text-gray-500 dark:bg-gray-800 dark:hover:bg-gray-750 dark:border-gray-700 dark:text-gray-300 transition-colors cursor-pointer"
                         @click.stop="openAllTagsModal(ds.platform_name || ds.name, ds.tags)"
                         title="查看全部标签"
                       >
-                        +{{ ds.tags.length - 3 }}
+                        +{{ ds.tags.length - 2 }}
                       </button>
                     </template>
                     <span
                       v-else
-                      class="inline-block max-w-full rounded-full border px-2 py-0.5 text-[9px] font-bold leading-tight bg-gray-50 border-gray-200 text-gray-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400"
+                      class="inline-block max-w-full rounded border px-1.5 py-0.5 text-[9px] font-medium leading-tight bg-gray-50 border-gray-200 text-gray-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400"
                     >
-                      🏷️ 未分类
+                      未分类
                     </span>
                     <span
-                      class="inline-block max-w-full rounded-full border px-2 py-0.5 text-[9px] font-bold leading-tight"
+                      class="inline-block max-w-full rounded border px-1.5 py-0.5 text-[9px] font-medium leading-tight"
                       :class="activeDatasetIds.includes(ds.id)
-                        ? 'bg-green-50 border-green-200 text-green-600 dark:bg-green-950/20 dark:border-green-800 dark:text-green-400'
-                        : 'bg-gray-50 border-gray-150 text-gray-400 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-500'"
+                        ? 'bg-green-50 border-green-200 text-green-700 dark:bg-green-950/20 dark:border-green-800 dark:text-green-400'
+                        : 'bg-gray-50 border-gray-200 text-gray-400 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-500'"
                     >
-                      {{ activeDatasetIds.includes(ds.id) ? '● 已启用' : '未启用' }}
+                      {{ activeDatasetIds.includes(ds.id) ? '已启用' : '未启用' }}
                     </span>
                   </div>
 
                   <!-- Description Summary Box (blockquote) -->
                   <blockquote
                     v-if="ds.platform_description || ds.description"
-                    class="relative w-full m-0 px-3.5 py-2.5 text-[11px] leading-relaxed rounded-r-lg border-l-[3px] bg-green-50/40 dark:bg-green-950/10 border-green-500 text-gray-600 dark:text-gray-400 font-medium"
+                    class="relative w-full m-0 px-3 py-2 text-[11px] leading-relaxed rounded-r-md border-l-2 border-gray-300 bg-gray-50/80 text-gray-600 dark:border-gray-600 dark:bg-gray-800/40 dark:text-gray-300 font-medium"
                   >
                     {{ ds.platform_description || ds.description }}
                   </blockquote>
@@ -727,7 +723,7 @@
                                 class="mt-2 pl-4 pr-1 border-t border-dashed border-gray-150 dark:border-gray-800 pt-2 flex flex-col gap-1.5 overflow-hidden"
                               >
                                 <div class="text-[9px] text-gray-400 dark:text-gray-500 flex items-center gap-1 select-none">
-                                  <span class="text-green-500 font-bold">💡</span> 针对该文件的专属提问：
+                                  针对该文件的提问：
                                 </div>
                                 
                                 <div v-if="documentRecommendations[doc.id]?.loading" class="space-y-2 py-1">
@@ -791,10 +787,7 @@
                     class="relative pt-2.5 border-t border-gray-100 dark:border-gray-700/60"
                   >
                     <div class="mb-2 flex items-center justify-between select-none">
-                      <span class="text-[10px] font-bold uppercase tracking-wider flex items-center gap-1.5 text-gray-500 dark:text-gray-400">
-                        <svg class="w-3.5 h-3.5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                        </svg>
+                      <span class="text-[10px] font-semibold tracking-wide flex items-center gap-1.5 text-gray-500 dark:text-gray-400">
                         你可以这样问
                       </span>
                       
@@ -848,17 +841,14 @@
                     <div v-else-if="(recommendations[ds.id]?.questions?.length || 0) > 0 || (recommendations[ds.id]?.custom_questions?.length || 0) > 0" class="space-y-3.5 w-full">
                       <!-- 置顶快捷推荐 -->
                       <div v-if="(recommendations[ds.id]?.custom_questions?.length || 0) > 0" class="space-y-1.5 w-full">
-                        <div class="flex items-center gap-1 text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase select-none">
-                          <svg class="w-3 h-3 text-amber-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                          </svg>
-                          <span>📌 置顶快捷提问 / 业务指南</span>
+                        <div class="flex items-center gap-1 text-[10px] font-medium text-gray-400 dark:text-gray-500 select-none">
+                          <span>置顶提问</span>
                         </div>
                         <div class="flex flex-wrap gap-2">
                           <div
                             v-for="(q, idx) in (recommendations[ds.id]?.custom_questions || [])"
                             :key="'c_'+idx"
-                            class="inline-flex items-stretch rounded-lg border border-amber-250 dark:border-amber-900/40 bg-amber-50/20 dark:bg-amber-950/10 shadow-sm hover:shadow hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200 overflow-hidden"
+                            class="inline-flex items-stretch rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 overflow-hidden hover:border-gray-300 dark:hover:border-gray-600 transition-colors"
                           >
                             <!-- Left Question Body (Direct Send) -->
                             <button
@@ -888,17 +878,14 @@
 
                       <!-- 智能生成提问 -->
                       <div v-if="(recommendations[ds.id]?.questions?.length || 0) > 0" class="space-y-1.5 w-full">
-                        <div class="flex items-center gap-1 text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase select-none">
-                          <svg class="w-3 h-3 text-green-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-                          </svg>
-                          <span>智能提问推荐（LLM 动态推断）</span>
+                        <div class="flex items-center gap-1 text-[10px] font-medium text-gray-400 dark:text-gray-500 select-none">
+                          <span>推荐提问</span>
                         </div>
                         <div class="flex flex-wrap gap-2">
                           <div
                             v-for="(q, idx) in (recommendations[ds.id]?.questions || [])"
                             :key="'d_'+idx"
-                            class="inline-flex items-stretch rounded-lg border border-gray-150 dark:border-gray-750 bg-white dark:bg-gray-800 shadow-sm hover:shadow hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200 overflow-hidden"
+                            class="inline-flex items-stretch rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 overflow-hidden hover:border-gray-300 dark:hover:border-gray-600 transition-colors"
                           >
                             <!-- Left Question Body (Direct Send) -->
                             <button
@@ -969,7 +956,7 @@
         >
           <div class="flex items-center justify-between">
             <h4 class="text-xs font-bold text-gray-800 dark:text-gray-100 select-none">
-              🏷️ {{ activeModalDatasetName }} 的所有标签
+              {{ activeModalDatasetName }} 的所有标签
             </h4>
             <button
               type="button"

--- a/frontend/src/views/AgentDebug.vue
+++ b/frontend/src/views/AgentDebug.vue
@@ -2304,7 +2304,7 @@ const pinMetadataDatasetToSession = async (datasetId: string) => {
     );
     const scope = res.data?.data || { project_name: "", datasets: [], knowledge_bases: [], skills: [] };
     if ((scope.datasets || []).some((item: any) => String(item.id || "").trim() === id)) {
-      showToast("该数据集已固定到会话", "info");
+      showToast("该数据集已设为本会话默认", "info");
       return;
     }
     const dataset = metadataMountableDatasets.value.find((item) => item.id === id);
@@ -2322,10 +2322,10 @@ const pinMetadataDatasetToSession = async (datasetId: string) => {
       .map((item: any) => String(item.id || "").trim())
       .filter(Boolean);
     const dsName = selected.name || dataset?.name || id;
-    showToast(`已固定到会话：后续所有提问将默认锁定在【${dsName}】范围内`, "success");
+    showToast(`已设为本会话默认：后续提问将默认锁定在【${dsName}】`, "success");
   } catch (error) {
     console.warn("Failed to pin metadata dataset to session", error);
-    showToast("固定会话数据集失败", "error");
+    showToast("设置会话默认范围失败", "error");
   }
 };
 
@@ -2351,10 +2351,10 @@ const unpinMetadataDatasetFromSession = async (datasetId: string) => {
     sessionMountedMetadataDatasetIds.value = (saved.data?.data?.datasets || nextDatasets)
       .map((item: any) => String(item.id || "").trim())
       .filter(Boolean);
-    showToast("已取消会话挂载，问数将恢复默认权限范围", "info");
+    showToast("已取消本会话默认，问数将恢复默认权限范围", "info");
   } catch (error) {
     console.warn("Failed to unpin metadata dataset from session", error);
-    showToast("取消会话挂载失败", "error");
+    showToast("取消会话默认失败", "error");
   }
 };
 

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -131,19 +131,6 @@
         </div>
       </div>
 
-      <ExpertCapsule
-          v-if="!isUrlAgentPinned"
-          :config="config"
-          :current-expert-agent="currentExpertAgent"
-          :show-auto-routing-hint="showAutoRoutingHint"
-          :show-multi-agent-hint="showMultiAgentHint"
-          :multi-agent-hint-message="multiAgentHintMessage"
-          :show-expert-switch-hint="showExpertSwitchHint"
-          :expert-switch-hint-name="expertSwitchHintName"
-          :is-mobile="isMobile"
-          @switch-to-auto="switchToAuto"
-      />
-
       <!-- Project / Session resource scope bar -->
       <div v-if="resourceScope.project_name || resourceScopeCount > 0" class="flex-shrink-0 px-4 py-2 flex items-center gap-2 text-[11px] text-gray-500 dark:text-gray-400 overflow-x-auto border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/20">
         <span class="font-bold shrink-0">{{ resourceScope.project_name ? `📁 ${resourceScope.project_name}` : '📌 会话固定资源' }}</span>
@@ -2611,7 +2598,6 @@ import CitationPopover from "@/components/CitationPopover.vue";
 import RagPreviewDrawer from "@/components/RagPreviewDrawer.vue";
 import ChatHistorySidebar from "@/components/ChatHistorySidebar.vue";
 import ConfirmModal from "@/components/ConfirmModal.vue";
-import ExpertCapsule from "@/components/embed/ExpertCapsule.vue";
 import ChatSettings from "@/components/embed/ChatSettings.vue";
 import ChatCanvas from "@/components/embed/ChatCanvas.vue";
 import ChatThinkingHeader from "@/components/chat/ChatThinkingHeader.vue";
@@ -3317,13 +3303,7 @@ const loadWelcomeCards = async (agentId?: string) => {
     welcomeCards.value = [];
   }
 };
-const showAutoRoutingHint = ref(false);
-const showMultiAgentHint = ref(false);
-const showExpertSwitchHint = ref(false);
-const expertSwitchHintName = ref("");
 const showConfirmModal = ref(false);
-const multiAgentHintMessage = ref("");
-let expertSwitchHintTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** URL ?agent_id= 深链锁定：禁止切换专家 / 自动路由 / @提及 */
 const urlPinnedAgentKey = ref("");
@@ -3433,12 +3413,7 @@ const saveRoutingSettings = () => {
     localStorage.setItem("yovole_markdown_theme", config.markdownTheme || "default");
 };
 const triggerMultiAgentHint = (enabled: boolean) => {
-    multiAgentHintMessage.value = enabled ? "已开启多智能体协同模式" : "已切换为单智能体模式";
-    showExpertSwitchHint.value = false;
-    showMultiAgentHint.value = true;
-    setTimeout(() => {
-        showMultiAgentHint.value = false;
-    }, 3000);
+    showToast(enabled ? "已开启多智能体协同模式" : "已切换为单智能体模式", "info");
 };
 const switchToAuto = () => {
     if (isUrlAgentPinned.value) {
@@ -3447,11 +3422,7 @@ const switchToAuto = () => {
     }
     config.routingMode = "auto";
     saveRoutingSettings();
-    showExpertSwitchHint.value = false;
-    showAutoRoutingHint.value = true;
-    setTimeout(() => {
-        showAutoRoutingHint.value = false;
-    }, 3000);
+    showToast("已切换为自动路由模式", "success");
 };
 const switchToExpert = (agentId: string) => {
     if (isUrlAgentPinned.value && pinnedAgentId.value && agentId !== pinnedAgentId.value) {
@@ -3461,24 +3432,17 @@ const switchToExpert = (agentId: string) => {
     config.expertAgentId = agentId;
     config.routingMode = "expert";
     saveRoutingSettings();
-    const agent = allowedAgents.value.find((a: any) => a.id === agentId) || pinnedAgent.value;
-    expertSwitchHintName.value = agent?.display_name || agent?.name || "专家";
-    showAutoRoutingHint.value = false;
-    showMultiAgentHint.value = false;
-    showExpertSwitchHint.value = !isUrlAgentPinned.value;
-    if (expertSwitchHintTimer) clearTimeout(expertSwitchHintTimer);
-    expertSwitchHintTimer = setTimeout(() => {
-        showExpertSwitchHint.value = false;
-        expertSwitchHintTimer = null;
-    }, 3000);
+    // URL 深链锁定初始化时不提示，避免首屏弹出
+    if (!isUrlAgentPinned.value) {
+      const agent = allowedAgents.value.find((a: any) => a.id === agentId) || pinnedAgent.value;
+      const name = agent?.display_name || agent?.name || "专家";
+      showToast(`已切换至专家：${name}`, "success");
+    }
 };
 const onModeChange = (mode: string) => {
     saveRoutingSettings();
     if (mode === "auto") {
-        showAutoRoutingHint.value = true;
-        setTimeout(() => {
-            showAutoRoutingHint.value = false;
-        }, 3000);
+        showToast("已切换为自动路由模式", "success");
     }
 };
 watch(() => config.enableMultiAgent, (newVal, oldVal) => {
@@ -5870,7 +5834,6 @@ const handleSystemCommand = async (cmd: string): Promise<boolean> => {
       return true;
     }
     switchToAuto();
-    showToast("已切换为自动路由模式", "success");
     return true;
   }
   if (normalizedCmd.startsWith("/switch_agent_expert?agent_id=")) {
@@ -5882,7 +5845,6 @@ const handleSystemCommand = async (cmd: string): Promise<boolean> => {
         return true;
       }
       switchToExpert(agentId);
-      showToast("已切换到指定智能体", "success");
     }
     return true;
   }
@@ -6413,10 +6375,7 @@ watch(showKnowledgePortal, (val) => {
       config.routingMode = "auto";
       config.expertAgentId = "";
       saveRoutingSettings();
-      showAutoRoutingHint.value = true;
-      setTimeout(() => {
-        showAutoRoutingHint.value = false;
-      }, 3000);
+      showToast("已切换为自动路由模式", "success");
     }
   }
 });

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -3806,7 +3806,7 @@ const pinMetadataDatasetToSession = async (datasetId: string) => {
   const id = String(datasetId || '').trim();
   if (!id) return;
   if (resourceScope.value.datasets.some((item: any) => String(item.id) === id)) {
-    showToast('该数据集已固定到会话', 'info');
+    showToast('该数据集已设为本会话默认', 'info');
     return;
   }
   const selected =
@@ -3819,9 +3819,9 @@ const pinMetadataDatasetToSession = async (datasetId: string) => {
   try {
     await persistResourceScope(buildPersistableScope(nextScope));
     const dsName = selected.name || selected.display_name || selected.dataset_name || id;
-    showToast(`已固定到会话：后续所有提问将默认锁定在【${dsName}】范围内`, 'success');
+    showToast(`已设为本会话默认：后续提问将默认锁定在【${dsName}】`, 'success');
   } catch (error) {
-    showToast('固定会话数据集失败', 'error');
+    showToast('设置会话默认范围失败', 'error');
   } finally {
     resourceScopeSaving.value = false;
   }
@@ -3841,9 +3841,9 @@ const unpinMetadataDatasetFromSession = async (datasetId: string) => {
   resourceScopeSaving.value = true;
   try {
     await persistResourceScope(buildPersistableScope(nextScope));
-    showToast('已取消会话挂载，问数将恢复默认权限范围', 'info');
+    showToast('已取消本会话默认，问数将恢复默认权限范围', 'info');
   } catch (error) {
-    showToast('取消会话挂载失败', 'error');
+    showToast('取消会话默认失败', 'error');
   } finally {
     resourceScopeSaving.value = false;
   }
@@ -6400,6 +6400,16 @@ const pinnedDrawerDockOffsetRem = (exclude?: "portal" | "workspace" | "memory" |
   if (exclude !== "memory" && showMemoryDrawer.value && memoryPinned.value) rem += 28;
   return rem;
 };
+
+const pinnedDrawerRightRem = computed(() => pinnedDrawerDockOffsetRem());
+const saveReportModalOverlayStyle = computed(() => {
+  const rem = pinnedDrawerRightRem.value;
+  return { right: rem > 0 ? `${rem}rem` : "0" };
+});
+const saveReportModalOverlayClass = computed(() => {
+  const isPinned = (showPortalDrawer.value && portalPinned.value) || (showKnowledgePortal.value && knowledgePinned.value);
+  return isPinned ? 'right-[28rem]' : 'right-0';
+});
 
 // 响应式抽屉宽度 refs（由各抽屉组件通过 v-model:drawerWidth / v-model:canvasWidth 实时同步）
 const portalDrawerWidthReactive = ref(448);

--- a/tests/frontend/test_dataset_menu_loading_contract.py
+++ b/tests/frontend/test_dataset_menu_loading_contract.py
@@ -78,7 +78,7 @@ def test_dataset_capability_menu_component_contract():
     assert "showRefreshBusy.value" in source
     assert "|| props.payload?.has_datasets === false" not in source
     assert "cacheAgeLabel" in source
-    assert "我的数据门户" in source
+    assert "数据门户" in source
     assert "click_count" in source
     assert "handleQuestionClick" in source
     assert "props.payload.groups" in source

--- a/tests/frontend/test_metadata_dataset_turn_mount_contract.py
+++ b/tests/frontend/test_metadata_dataset_turn_mount_contract.py
@@ -32,8 +32,8 @@ def test_chat_input_renders_metadata_dataset_chip():
 
 def test_dataset_capability_menu_exposes_card_mount_dropdown():
     source = _source("frontend/src/components/chatbi/DatasetCapabilityMenu.vue")
-    assert "本轮挂载" in source
-    assert "固定到会话" in source
+    assert "仅本次" in source
+    assert "本会话默认" in source
     assert "resolveDatasetIdForGroup" in source
     assert "toggle-metadata-dataset" in source
     assert "pin-metadata-dataset" in source


### PR DESCRIPTION

# Pull Request: 精简数据/知识库门户视觉，路由切换改用 Toast

## 概要 (Overview)
降低嵌入聊天侧栏「数据门户 / 知识库门户」的 AI 装饰味与布局抖动：卡片去渐变光斑与 hover 上浮，挂载文案口语化；路由/专家切换提示从顶栏横幅改为 Toast，避免显示隐藏时页面抖动。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)
- 无

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)
- [x] 数据门户：白底 + 左侧色条，去掉彩虹渐变/模糊光斑/hover 上浮；挂载改为「仅本次 / 本会话默认」；黄金报表区块视觉降级但仍保留名称
- [x] 知识库门户：对齐同款减脂（去光斑/上浮/emoji 装饰），标题与提问分区文案收敛；高级配置仍默认收起
- [x] EmbedChat 路由切换、专家切换、多智能体提示改为右上角 Toast，移除 ExpertCapsule 顶栏横幅
- [x] 补齐 EmbedChat 报表弹层在钉住抽屉时的 `saveReportModalOverlayClass` 偏移

### 3. 🐞 缺陷修复 (Bug Fixes)
- [x] 修复 EmbedChat 引用但未定义 `saveReportModalOverlayClass` / `saveReportModalOverlayStyle` 导致合同测试与钉住态遮罩异常的问题

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| 89c2a5b7 | refactor(knowledge): 精简知识库门户视觉与文案装饰 |
| ad0ef675 | refactor(portal): 精简数据门户视觉与挂载文案 |
| 9d09808a | fix(embed): 路由切换提示改用 Toast，避免顶栏横幅导致页面抖动 |

---

## 测试覆盖 (Testing)
- [x] **核心功能**: `tests/frontend/test_metadata_dataset_turn_mount_contract.py`、`tests/frontend/test_dataset_menu_loading_contract.py` 已更新并通过（20 passed）
- [x] **门户抽屉合同**: `test_portal_drawers_resizer_contract.py`、`test_resource_scope_portal_and_skill_contract.py` 通过
- [ ] **UI 兼容性**: 请在嵌入聊天中手动确认数据门户/知识库门户视觉与挂载、Toast 切换
- [ ] **回归测试**: 请确认会话固定资源、仅本次挂载、钉住侧栏下报表弹层不被遮挡

> [!IMPORTANT]
> 提交前请务必确认已更新 `tests/CHECKLIST.md` 中的自动化测试清单。
>
> 本次以合同测试断言更新为主；若合入前需严格对齐清单，请补一行「数据/知识库门户视觉减脂与挂载文案」条目。

---

## 其他备注 (Notes)
- 无后端/配置变更，纯前端。
- 会话「本会话默认」挂载逻辑未改：关闭门户不会自动释放；需主动取消或顶栏移除。
- Agent 不代跑 `./dev.sh`，请本地刷新验证。
