### PR TITLE
K8s 沙箱冷启动加速（网关预置镜像）+ 初始化超时兜底与自动预热

### DIFF
--- a/app/services/ai/agent_service.py
+++ b/app/services/ai/agent_service.py
@@ -2135,13 +2135,19 @@ class AgentService:
                     pass
 
                 with _measure("workspace_prewarm"):
-                    await get_local_workspace(
-                        user_id=runtime_user_id,
-                        conversation_id=conversation_id,
-                        user_name=runtime_user_name,
-                        user_info=user_info,
-                        skills_custom=bool(getattr(agent_config, "skills_custom", False)),
-                        allowed_global_skills=list(getattr(agent_config, "skills", None) or []),
+                    # 预热只是“抢跑”，绝不允许它拖死整轮：沙箱初始化（拉镜像/k8s
+                    # bootstrap/等待锁）可能长时间挂起，这里强制上限，超时按失败返回
+                    # error log，由主流程继续（不在此 await 上无限等待）。
+                    await asyncio.wait_for(
+                        get_local_workspace(
+                            user_id=runtime_user_id,
+                            conversation_id=conversation_id,
+                            user_name=runtime_user_name,
+                            user_info=user_info,
+                            skills_custom=bool(getattr(agent_config, "skills_custom", False)),
+                            allowed_global_skills=list(getattr(agent_config, "skills", None) or []),
+                        ),
+                        timeout=60.0,
                     )
                 elapsed_ms = (time.monotonic() - start_time) * 1000.0
                 return _build_workspace_sandbox_log(

--- a/app/services/ai/runners/assistant_agent_runner.py
+++ b/app/services/ai/runners/assistant_agent_runner.py
@@ -2294,15 +2294,29 @@ class AssistantAgentRunner(BaseExecutor):
             _workspace_native_name_for_spec(spec) == "Bash" for spec in tools
         )
         try:
-            workspace = await get_local_workspace(
-                user_id=self._runtime_user_id(),
-                user_name=self._runtime_user_name(),
-                user_info=self.user_info,
-                conversation_id=self.conversation_id,
-                skills_custom=bool(getattr(self.config, "skills_custom", False)),
-                allowed_global_skills=list(getattr(self.config, "skills", None) or []),
+            workspace = await asyncio.wait_for(
+                get_local_workspace(
+                    user_id=self._runtime_user_id(),
+                    user_name=self._runtime_user_name(),
+                    user_info=self.user_info,
+                    conversation_id=self.conversation_id,
+                    skills_custom=bool(getattr(self.config, "skills_custom", False)),
+                    allowed_global_skills=list(getattr(self.config, "skills", None) or []),
+                ),
+                timeout=90.0,
             )
-        except (DockerSandboxUnavailableError, K8sSandboxUnavailableError) as exc:
+        except (DockerSandboxUnavailableError, K8sSandboxUnavailableError, asyncio.TimeoutError) as exc:
+            if isinstance(exc, asyncio.TimeoutError):
+                logger.warning(
+                    "[agent] Sandbox workspace init timed out (conversation=%s); treating as unavailable: %s",
+                    self.conversation_id,
+                    exc,
+                )
+                exc = K8sSandboxUnavailableError(
+                    "sandbox workspace init timeout",
+                    reason_code="k8s_workspace_init_timeout",
+                    user_message="沙箱启动超时（可能镜像拉取或集群调度较慢），已按沙箱不可用处理，可稍后重试。",
+                )
             if requires_sandbox_bash:
                 raise
             logger.warning(

--- a/app/services/ai/runtime/agentscope/k8s_workspace.py
+++ b/app/services/ai/runtime/agentscope/k8s_workspace.py
@@ -205,12 +205,16 @@ def build_k8s_workspace_with_nanzi_adapter(
             except ImportError:
                 POD_WORKDIR = "/workspace"
 
-            container_env = None
-            if self.env:
-                container_env = [
-                    k8s_client.V1EnvVar(name=k, value=v)
-                    for k, v in self.env.items()
-                ]
+            # 沙箱 Pod 可能因平台重启/缓存丢失被重复 initialize：bootstrap 会再次执行
+            # `uv venv /root/.agentscope/.venv`。uv 默认拒绝覆盖已存在的 venv（exit 2），
+            # 导致整条初始化失败（状态异常、Bash MCP 不可用）。注入 UV_VENV_CLEAR=1
+            # 使 venv 创建幂等：已存在则 clear 重建，不存在则正常创建。
+            merged_env = dict(self.env or {})
+            merged_env.setdefault("UV_VENV_CLEAR", "1")
+            container_env = [
+                k8s_client.V1EnvVar(name=k, value=str(v))
+                for k, v in merged_env.items()
+            ] if merged_env else None
 
             user_subpath = f"agent_workspaces/{self._nanzi_sandbox_user_key}/sandbox"
 

--- a/frontend/src/views/EmbedChat.vue
+++ b/frontend/src/views/EmbedChat.vue
@@ -4185,9 +4185,13 @@ const dismissSandboxWorkspaceBanner = () => {
   sandboxWorkspaceBannerDismissed.value = true;
 };
 
+/** 沙箱状态查询防重入（starting 状态下也允许手动刷新，仅拦并发请求）。 */
+let sandboxStatusRefreshInFlight = false;
+
 const refreshSandboxWorkspaceStatus = async (showFeedback = false) => {
   if (!isSandboxWorkspacePolicy.value || !conversationId.value) return;
-  if (sandboxWorkspaceStatus.value === "starting") return;
+  if (sandboxStatusRefreshInFlight) return;
+  sandboxStatusRefreshInFlight = true;
   const requestedConversationId = conversationId.value;
   try {
     const response = await axios.get(
@@ -4230,12 +4234,19 @@ const refreshSandboxWorkspaceStatus = async (showFeedback = false) => {
     if (conversationId.value === requestedConversationId) {
       sandboxWorkspaceStatusLoaded.value = true;
     }
+    sandboxStatusRefreshInFlight = false;
   }
 };
 
-/** 启动后轻量轮询 status，直到 Pod 进入 running 或超时，避免一直停在“创建中”。 */
-const pollSandboxWorkspaceUntilRunning = async (cid: string) => {
-  for (let attempt = 0; attempt < 8; attempt += 1) {
+/** 启动后自动轮询 status（每 2s，最长 ~60s），直到 Pod 就绪，避免一直停在“创建中”。 */
+/** 启动后自动轮询 status（每 2s，最长 ~60s），直到 Pod 就绪；readyToast=false 时为静默预热。 */
+const pollSandboxWorkspaceUntilRunning = async (
+  cid: string,
+  opts: { readyToast?: boolean } = {},
+) => {
+  const { readyToast = true } = opts;
+  const MAX_ATTEMPTS = 30; // 60s
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
     await new Promise((resolve) => setTimeout(resolve, 2000));
     if (conversationId.value !== cid) return;
     try {
@@ -4252,12 +4263,52 @@ const pollSandboxWorkspaceUntilRunning = async (cid: string) => {
         ? data.uptime_seconds
         : null;
       if (mapped === "running") {
-        showToast("沙箱已就绪", "success");
+        if (readyToast) {
+          showToast("沙箱已就绪", "success");
+        }
         return;
       }
     } catch {
       // 单次查询失败不中断轮询，继续尝试
     }
+  }
+  // 超时仍未就绪：停留在当前状态并提示可手动刷新
+  if (conversationId.value === cid && sandboxWorkspaceStatus.value !== "running") {
+    showToast("Pod 仍在创建中（可能镜像拉取较慢），可稍后点「刷新」查看", "info");
+  }
+};
+
+/** 会话打开/新建后自动预热一次（每个会话仅一次、静默；仅当查询确认未运行且当前无任务）。 */
+let autoWarmedConversationKey = "";
+
+const maybeAutoWarmSandbox = async () => {
+  if (!isSandboxWorkspacePolicy.value || !conversationId.value) return;
+  if (isProcessing.value || remoteRunActive.value) return;
+  if (!sandboxWorkspaceStatusLoaded.value) return;
+  const status = sandboxWorkspaceStatus.value;
+  if (status === "running" || status === "starting" || status === "error") return;
+  const key = `${conversationId.value}::${sandboxBackend.value}`;
+  if (autoWarmedConversationKey === key) return;
+  autoWarmedConversationKey = key;
+  try {
+    const response = await axios.post(
+      `${sandboxWorkspaceBaseEndpoint.value}/ensure`,
+      { conversation_id: conversationId.value },
+      { headers: embedAuthHeaders() },
+    );
+    const data = response.data?.data ?? response.data;
+    const mapped = mapSandboxStatus(String(data?.status || "idle"));
+    sandboxWorkspaceStatus.value = mapped;
+    sandboxWorkspaceInstanceId.value = instanceIdFromData(data);
+    sandboxWorkspaceStartedAt.value = data?.started_at || null;
+    sandboxWorkspaceUptimeSeconds.value = typeof data?.uptime_seconds === "number"
+      ? data.uptime_seconds
+      : null;
+    if (mapped !== "running") {
+      void pollSandboxWorkspaceUntilRunning(String(conversationId.value), { readyToast: false });
+    }
+  } catch {
+    // 自动预热失败静默：用户可手动「启动」，或发送消息时按既有降级逻辑处理
   }
 };
 
@@ -4398,7 +4449,7 @@ const restartSandboxWorkspace = async () => {
 
 watch(
   [conversationId, effectiveSandboxPolicy],
-  ([conversation, policy], previous) => {
+  async ([conversation, policy], previous) => {
     const previousConversation = String(previous?.[0] || "");
     const previousPolicy = String(previous?.[1] || "");
     if (
@@ -4409,7 +4460,9 @@ watch(
     ) {
       resetSandboxWorkspaceState();
       if (isSandboxWorkspacePolicy.value && conversation) {
-        void refreshSandboxWorkspaceStatus();
+        await refreshSandboxWorkspaceStatus();
+        // 打开/新建会话后自动预热沙箱（默认开启，每个会话一次、静默）
+        void maybeAutoWarmSandbox();
       }
     }
   },

--- a/frontend/src/views/SystemConfig.vue
+++ b/frontend/src/views/SystemConfig.vue
@@ -1876,7 +1876,7 @@ const configShortDescriptions: Record<string, string> = {
   sandbox_policy: '安全沙箱执行策略。local 表示在宿主机扩展进程内直接执行（当前默认）；docker 表示在自动构建的 Docker 容器内执行；e2b 表示在 E2B 云端沙箱内执行；ssh 表示在 SSH 远程主机上执行。',
   sandbox_docker_base_image: 'docker 策略使用的容器基础镜像（留空默认使用官方标准镜像 python:3.11-slim）。',
   sandbox_k8s_namespace: 'k8s 策略沙箱 Pod 运行的命名空间（默认 agent-sandboxes）。',
-  sandbox_k8s_image: 'k8s 策略沙箱容器运行的基础镜像（默认 python:3.11-slim）。',
+  sandbox_k8s_image: 'k8s 策略沙箱容器运行的基础镜像（默认 python:3.11-slim）。可填自动构建的“网关预置镜像” nanzi-sandbox-k8s:<版本> 加速冷启动（构建方式见下方提示）。',
   sandbox_k8s_existing_pvc: 'k8s 策略可选已存在的共享 PVC 名称（留空表示动态独立临时卷；填写如 nanzi-app-data，通过 subPath 挂载到 /workspace）。',
   sandbox_k8s_storage_class: 'k8s 策略动态创建独立 PVC 时的存储类名称（StorageClass，留空表示使用集群默认 StorageClass）。',
   sandbox_k8s_storage_size: 'k8s 策略动态创建独立 PVC 时的申请容量（默认 1Gi）。',
@@ -4106,6 +4106,18 @@ onUnmounted(() => {
                               <p class="mt-1 text-[11px] text-gray-500">
                                 请填写平台可在集群中拉取到的容器镜像完整路径（需内置 Python 3.11 与 Debian/Ubuntu 基础环境）。
                               </p>
+                            </div>
+
+                            <!-- 可选加速：K8s 沙箱网关预置镜像构建提示 -->
+                            <div class="mt-2 space-y-1.5 rounded-xl border border-sky-200 bg-sky-50/70 p-3 text-[11px] leading-relaxed text-sky-900 dark:border-sky-500/30 dark:bg-sky-950/40 dark:text-sky-100">
+                              <div class="font-semibold text-sky-800 dark:text-sky-100">🚀 可选加速：K8s 沙箱“网关预置镜像”</div>
+                              <div>沙箱每次冷启动都会初始化 AgentScope 网关环境（装 venv/依赖），较慢。可先手动构建一个预置镜像（把网关环境直接打进镜像），把本项填为该镜像后，新沙箱 Pod 冷启动会直接复用、从几十秒降到秒级。</div>
+                              <div>在可访问 Docker 的构建机（k8s_deploy 目录）执行构建与导入：
+                                <code class="mt-1 block rounded bg-white/70 px-1.5 py-0.5 font-mono text-sky-800 dark:bg-gray-900/60 dark:text-sky-100">./build-k8s-sandbox-image.sh --version 1.0.0</code>
+                                <span class="block">脚本会自动 docker build → save → 导入节点 containerd（ctr -n k8s.io / k3s ctr）。</span>
+                              </div>
+                              <div>本项填写格式：<span class="font-mono">nanzi-sandbox-k8s:&lt;版本&gt;</span>（可选用上方预置列表或“自定义镜像地址”）。未使用预置镜像时留空/保持默认 <span class="font-mono">python:3.11-slim</span>，由集群直接拉取即可，无需预置。</div>
+                              <div>想先确认节点已导入该镜像：<span class="font-mono">./install.sh check-sandbox-image nanzi-sandbox-k8s:&lt;版本&gt;</span></div>
                             </div>
                           </div>
                           <div v-else>

--- a/k8s_deploy/README.md
+++ b/k8s_deploy/README.md
@@ -339,6 +339,21 @@ cd k8s_deploy
 * `./nanzi-k8s.sh test`：快速探测 Service Endpoint 与 ClusterIP 连通性。
 * 镜像更新与滚动发布详见 [upgrade.md](./upgrade.md)。
 
+#### K8s 沙箱“网关预置镜像”（可选加速）
+
+K8s 沙箱（`sandbox_policy = k8s`）每次冷启动都会初始化 AgentScope 网关环境（在 Pod 内装 venv/依赖），较慢。可选用 [build-k8s-sandbox-image.sh](./build-k8s-sandbox-image.sh) 手动构建一个“网关预置镜像”（把网关环境与 gateway 脚本打进镜像），构建/导入后把系统配置 `sandbox_k8s_image` 填为 `nanzi-sandbox-k8s:<版本>`，新沙箱 Pod 冷启动将直接复用、从数十秒降到秒级。
+
+```bash
+# 在可访问 Docker 的构建机（本目录）执行：构建 + 导出 + 自动导入节点 containerd
+./build-k8s-sandbox-image.sh --version 1.0.0
+./build-k8s-sandbox-image.sh --dry-run            # 只预览 Dockerfile 与命令
+# 复核节点是否已导入：
+./install.sh check-sandbox-image nanzi-sandbox-k8s:1.0.0
+```
+
+* 不构建预置镜像也能正常使用：默认 `python:3.11-slim` 由集群直接拉取，AgentScope 会在 Pod 内自动初始化网关环境。
+* 详细说明（构建内容/依赖版本/升级后重建时机）见 [upgrade.md](./upgrade.md) 顶部“可选加速”章节；系统配置页 `sandbox_k8s_image` 下方也有操作提示。
+
 ---
 
 ### 手动逐步部署：第 0 步：确认你手里有什么

--- a/k8s_deploy/build-k8s-sandbox-image.sh
+++ b/k8s_deploy/build-k8s-sandbox-image.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# NanZi AI 开源智能体平台 · K8s 沙箱网关预置镜像构建脚本
+# ==============================================================================
+# 背景：
+#   AgentScope K8sWorkspace 网关环境位于 Pod 内 /root/.agentscope（临时写层），
+#   每次新 Pod 冷启动都要执行 bootstrap（apt + uv + venv + 安装依赖）——这是 K8s
+#   沙箱比 Docker 冷启动慢的根本原因。且只要 /root/.agentscope/_mcp_gateway_app.py
+#   存在，AgentScope 会整体跳过 bootstrap（含 Docker 镜像构建也走此快路径）。
+#
+#   本脚本构建一个“预置镜像”：把网关 venv（mcp/fastapi/uvicorn/httpx + agentscope）
+#   与 gateway 脚本模板直接打进镜像。配置 sandbox_k8s_image 指向该镜像后，
+#   新 Pod 起来直接可用，冷启动从数十秒降到秒级。
+#
+# 用法（在可访问 Docker daemon 的构建机/节点执行）：
+#   ./build-k8s-sandbox-image.sh                          # 默认 python:3.11-slim -> nanzi-sandbox-k8s:latest
+#   ./build-k8s-sandbox-image.sh --version 1.0.0          # 指定产物版本 tag
+#   ./build-k8s-sandbox-image.sh --base-image python:3.11-slim
+#   ./build-k8s-sandbox-image.sh --proxy http://127.0.0.1:7890   # 构建机走代理
+#   ./build-k8s-sandbox-image.sh --dry-run                # 只生成 Dockerfile/命令，不实际构建
+#   ./build-k8s-sandbox-image.sh --no-import              # 构建+save 后不自动导入，打印导入命令
+#   ./build-k8s-sandbox-image.sh --sync-template          # 从本机 agentscope 刷新 gateway 模板副本
+# ==============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTEXT_DIR="$SCRIPT_DIR/sandbox-image"
+TEMPLATE_FILE="$CONTEXT_DIR/_mcp_gateway_app.py"
+
+# 颜色（POSIX 兼容，非 TTY 自动空）
+if [ -t 1 ]; then
+  C_GREEN='\033[32m'; C_CYAN='\033[36m'; C_YELLOW='\033[33m'
+  C_RED='\033[31m'; C_BOLD='\033[1m'; C_RESET='\033[0m'
+else
+  C_GREEN=''; C_CYAN=''; C_YELLOW=''; C_RED=''; C_BOLD=''; C_RESET=''
+fi
+
+log_info()   { printf "%bℹ%b  %s\n" "${C_CYAN}" "${C_RESET}" "$*"; }
+log_success(){ printf "%b✔%b  %s\n" "${C_GREEN}" "${C_RESET}" "$*"; }
+log_warn()   { printf "%b⚠%b  %s\n" "${C_YELLOW}" "${C_RESET}" "$*"; }
+log_error()  { printf "%b✖%b  %s\n" "${C_RED}" "${C_RESET}" "$*"; }
+
+# ---- 常量（与 agentscope workspace._k8s/_utils 布局严格一致）----
+GATEWAY_HOME="/root/.agentscope"
+GATEWAY_VENV="$GATEWAY_HOME/.venv"
+GATEWAY_SCRIPT_NAME="_mcp_gateway_app.py"
+# agentscope.workspace._utils._GATEWAY_BASE_REQUIREMENTS + agentscope(--no-deps)
+BASE_REQS=("mcp<2.0.0" "uvicorn" "fastapi" "httpx")
+
+# ---- 参数 ----
+BASE_IMAGE="python:3.11-slim"
+IMAGE_NAME="nanzi-sandbox-k8s"
+IMAGE_TAG="latest"
+PROXY_URL=""
+DO_IMPORT=true
+DRY_RUN=false
+SYNC_TEMPLATE=false
+AGENTSCOPE_VERSION=""
+
+usage() {
+  cat <<'EOF'
+用法: ./build-k8s-sandbox-image.sh [选项]
+
+构建 K8s 沙箱“网关预置”镜像（新 Pod 冷启动跳过 AgentScope bootstrap）。
+
+选项:
+  --base-image <img>      基础镜像，默认 python:3.11-slim
+  --image-name <name>     产物镜像名，默认 nanzi-sandbox-k8s
+  --version <ver>         产物 Tag，默认 latest
+  --proxy <url>           构建网络代理，如 http://127.0.0.1:7890
+  --agentscope-version    覆盖安装的 agentscope 版本（默认跟随本机平台 agentscope，无则最新）
+  --no-import             构建+save 后不自动导入节点（打印导入命令）
+  --dry-run               只生成 Dockerfile 与命令清单，不实际构建/导入
+  --sync-template         从本机 agentscope 刷新 sandbox-image/_mcp_gateway_app.py
+  -h, --help              帮助
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base-image) BASE_IMAGE="$2"; shift 2 ;;
+    --image-name) IMAGE_NAME="$2"; shift 2 ;;
+    --version)    IMAGE_TAG="$2"; shift 2 ;;
+    --proxy)      PROXY_URL="$2"; shift 2 ;;
+    --agentscope-version) AGENTSCOPE_VERSION="$2"; shift 2 ;;
+    --no-import)  DO_IMPORT=false; shift ;;
+    --dry-run)    DRY_RUN=true; shift ;;
+    --sync-template) SYNC_TEMPLATE=true; shift ;;
+    -h|--help)    usage; exit 0 ;;
+    *) log_error "未知参数: $1（-h 查看帮助）"; exit 1 ;;
+  esac
+done
+
+if [ "$SYNC_TEMPLATE" = "true" ]; then
+  PY="${PYTHON:-}"
+  if [ -z "$PY" ] && [ -x "$SCRIPT_DIR/../.venv/bin/python" ]; then
+    PY="$SCRIPT_DIR/../.venv/bin/python"
+  fi
+  PY="${PY:-python3}"
+  if ! "$PY" -c "import agentscope.workspace._mcp_gateway._mcp_gateway_app" 2>/dev/null; then
+    log_error "无法在 [${PY}] import agentscope（请使用平台 venv：$SCRIPT_DIR/../.venv/bin/python，或 PYTHON=...）。"
+    exit 1
+  fi
+  mkdir -p "$CONTEXT_DIR"
+  "$PY" - <<PY
+import agentscope.workspace._mcp_gateway._mcp_gateway_app as _src
+import pathlib
+src = pathlib.Path(_src.__file__)
+dst = pathlib.Path("$TEMPLATE_FILE")
+dst.write_bytes(src.read_bytes())
+print(f"synced -> {dst}")
+PY
+  log_success "已从 agentscope 刷新模板副本：$TEMPLATE_FILE"
+  exit 0
+fi
+
+# 尝试读取平台 agentscope 版本（未指定时优先跟随平台版本，避免协议漂移）
+if [ -z "$AGENTSCOPE_VERSION" ]; then
+  if [ -x "$SCRIPT_DIR/../.venv/bin/python" ]; then
+    AGENTSCOPE_VERSION="$("$SCRIPT_DIR/../.venv/bin/python" -c "import agentscope; print(getattr(agentscope,'__version__',''))" 2>/dev/null || true)"
+  fi
+fi
+if [ -z "$AGENTSCOPE_VERSION" ]; then
+  log_warn "未读取到平台 agentscope 版本（当前不在平台代码目录/无 .venv）。将安装 PyPI 最新 agentscope，"
+  log_warn "可能与平台运行版本不一致（网关协议漂移风险）。建议显式指定：--agentscope-version <平台版本>。"
+fi
+
+if [ ! -f "$TEMPLATE_FILE" ]; then
+  log_warn "缺少 gateway 模板副本：$TEMPLATE_FILE"
+  log_info "请先在平台代码目录执行：${0} --sync-template（需要可 import agentscope 的 Python）"
+  exit 1
+fi
+
+FULL_IMAGE="$IMAGE_NAME:$IMAGE_TAG"
+BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/k8s-sandbox-img.XXXXXX")"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+cp "$TEMPLATE_FILE" "$BUILD_DIR/_mcp_gateway_app.py"
+
+# ---- 生成 Dockerfile ----
+UV_INSTALL='curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh'
+if [ -n "$PROXY_URL" ]; then
+  UV_INSTALL="curl -x $PROXY_URL -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh"
+fi
+
+AP="agentscope"
+if [ -n "$AGENTSCOPE_VERSION" ]; then
+  AP="agentscope==$AGENTSCOPE_VERSION"
+fi
+export AP
+
+cat > "$BUILD_DIR/Dockerfile" <<EOF
+FROM $BASE_IMAGE
+
+# 与 AgentScope K8s bootstrap 相同的系统依赖（curl/ca-certificates 供 uv 安装，ripgrep 供内置 Grep）
+RUN apt-get update -qq \\
+ && apt-get install -y --no-install-recommends curl ca-certificates ripgrep \\
+ && rm -rf /var/lib/apt/lists/*
+
+# uv（放入 PATH）
+RUN $UV_INSTALL
+
+# venv 已存在时允许幂等 clear（兜底，正常预置后不再重复创建）
+ENV UV_VENV_CLEAR=1
+
+# 预置网关 venv（与 agentscope _GATEWAY_BASE_REQUIREMENTS 一致）
+RUN uv venv $GATEWAY_VENV \\
+ && uv pip install --python $GATEWAY_VENV/bin/python \\
+      "mcp<2.0.0" uvicorn fastapi httpx \\
+ && uv pip install --python $GATEWAY_VENV/bin/python --no-deps "$AP"
+
+# 预置 gateway 脚本 → AgentScope 判定已初始化，新 Pod 冷启动跳过整个 bootstrap
+COPY _mcp_gateway_app.py $GATEWAY_HOME/_mcp_gateway_app.py
+EOF
+
+if [ "$DRY_RUN" = "true" ]; then
+  log_info "【演练模式】已生成构建上下文：$BUILD_DIR"
+  log_info "Dockerfile:"
+  sed 's/^/    /' "$BUILD_DIR/Dockerfile"
+  log_info "接下来会执行的命令："
+  printf "  %bdocker build -t %s %s%b\n" "${C_CYAN}" "$FULL_IMAGE" "$BUILD_DIR" "${C_RESET}"
+  printf "  %bdocker save %s -o nanzi-sandbox-k8s_%s.tar%s\n" "${C_CYAN}" "$FULL_IMAGE" "$IMAGE_TAG" "${C_RESET}"
+  if [ "$DO_IMPORT" = "true" ]; then
+    printf "  %bctr -n k8s.io images import nanzi-sandbox-k8s_%s.tar   # 非 K3s（普通 containerd）%s\n" "${C_CYAN}" "$IMAGE_TAG" "${C_RESET}"
+    printf "  %bk3s ctr images import nanzi-sandbox-k8s_%s.tar          # K3s%s\n" "${C_CYAN}" "$IMAGE_TAG" "${C_RESET}"
+  fi
+  log_success "演练完成，未实际构建/导入。"
+  exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  log_error "未找到 docker 命令。本脚本需要在能访问 Docker daemon 的构建机/节点执行。"
+  exit 1
+fi
+
+# 防误用：若当前身处容器 / K8s Pod 内（例如误在 NanZi 平台 Pod 里执行），提前提示
+if [ -f "/.dockerenv" ] || [ -n "${KUBERNETES_SERVICE_HOST:-}" ]; then
+  log_error "检测到当前环境可能是容器 / K8s Pod（存在 /.dockerenv 或 KUBERNETES_SERVICE_HOST）。"
+  log_warn "本脚本需要在【能访问 Docker daemon 的节点/构建机（宿主机）】执行，不要在 NanZi 平台 Pod 内构建。"
+  log_info "若节点没有 Docker：请在任意有 Docker 的开发机执行本脚本得到 <tar>，再把 tar 拷到节点用 ./install.sh import <tar> 导入。"
+  exit 1
+fi
+
+log_info "开始构建 K8s 沙箱网关预置镜像：${C_BOLD}${FULL_IMAGE}${C_RESET}（基础镜像 ${BASE_IMAGE}）"
+docker build -t "$FULL_IMAGE" "$BUILD_DIR"
+log_success "镜像构建完成：$FULL_IMAGE"
+
+TAR_FILE="nanzi-sandbox-k8s_${IMAGE_TAG}.tar"
+log_info "导出镜像为 tar（文件式，非管道）..."
+docker save "$FULL_IMAGE" -o "$TAR_FILE"
+log_success "已导出：$TAR_FILE"
+
+if [ "$DO_IMPORT" = "true" ]; then
+  IMPORTED=false
+  if command -v ctr >/dev/null 2>&1; then
+    log_info "正在导入节点 containerd（ctr -n k8s.io）..."
+    if sudo -n ctr -n k8s.io images import "$TAR_FILE" 2>/dev/null || ctr -n k8s.io images import "$TAR_FILE" 2>/dev/null; then
+      IMPORTED=true
+    fi
+  elif command -v k3s >/dev/null 2>&1; then
+    log_info "正在导入 K3s containerd（k3s ctr）..."
+    if sudo -n k3s ctr images import "$TAR_FILE" 2>/dev/null || k3s ctr images import "$TAR_FILE" 2>/dev/null; then
+      IMPORTED=true
+    fi
+  fi
+  if [ "$IMPORTED" = "true" ]; then
+    log_success "已导入节点容器运行时：$FULL_IMAGE"
+  else
+    log_warn "自动导入未成功（可能当前主机不是节点或权限不足）。请在节点手动执行："
+    printf "  %bctr -n k8s.io images import %s   # 非 K3s（普通 containerd）%b\n" "${C_CYAN}" "$TAR_FILE" "${C_RESET}"
+    printf "  %bk3s ctr images import %s          # K3s%b\n" "${C_CYAN}" "$TAR_FILE" "${C_RESET}"
+  fi
+else
+  log_info "已跳过自动导入。请将 tar 拷贝到节点后手动导入："
+  printf "  %bctr -n k8s.io images import %s   # 非 K3s（普通 containerd）%b\n" "${C_CYAN}" "$TAR_FILE" "${C_RESET}"
+  printf "  %bk3s ctr images import %s          # K3s%b\n" "${C_CYAN}" "$TAR_FILE" "${C_RESET}"
+fi
+
+cat <<EOF
+
+────────────────────────────────────────────────────────────────────
+✅ 构建完成。接下来让沙箱使用该预置镜像：
+
+1. 在节点/管理端确认镜像已导入：
+   crictl images | grep nanzi-sandbox-k8s   （或 ./install.sh --images nanzi-sandbox-k8s）
+
+2. 将系统配置 sandbox_k8s_image 设为: $FULL_IMAGE
+   （配置 -> 沙箱 -> sandbox_k8s_image）
+
+3. 之后新建/重启的沙箱 Pod 将直接使用预置网关环境，冷启动大幅加速。
+────────────────────────────────────────────────────────────────────
+EOF

--- a/k8s_deploy/install.sh
+++ b/k8s_deploy/install.sh
@@ -55,6 +55,8 @@ IMAGE_LIST_MODE=false
 IMAGE_LIST_FILTER=""
 IMAGE_IMPORT_MODE=false
 IMAGE_IMPORT_FILES=""
+CHECK_IMAGE_MODE=false
+CHECK_IMAGE_REF=""
 INSTALL_MODE=false
 
 show_help() {
@@ -67,6 +69,7 @@ show_help() {
   printf "  %-30s %b\n" "upgrade, -u, --upgrade [TAG]" "快速更新镜像模式（滚动升级；可带目标 Tag）"
   printf "  %-30s %b\n" "images, --images [关键字]" "只读列出节点容器运行时（ctr -n k8s.io）已导入的镜像，可带关键字过滤"
   printf "  %-30s %b\n" "import, --import <镜像tar> [tar...]" "将本地镜像 tar 导入容器运行时（ctr -n k8s.io images import）"
+  printf "  %-30s %b\n" "check-sandbox-image, --check-sandbox-image [镜像]" "检查节点是否已导入指定 K8s 沙箱镜像（缺省 nanzi-sandbox-k8s:latest），未导入时给出构建引导"
   printf "\n"
   printf "%b常用选项：%b\n" "${C_BOLD}" "${C_RESET}"
   printf "  %-30s %b\n" "-d, --dry-run, --try" "模拟演练模式（仅生成/更新本地配置并做语法预检，不下发真实变更）"
@@ -82,6 +85,7 @@ show_help() {
   printf "  %-30s # 查看节点容器运行时中已导入的全部镜像\n" "$0 images"
   printf "  %-30s # 只查看 NanZi 相关镜像（手动检查本地是否已导入）\n" "$0 images nanzi-ai-agent"
   printf "  %-30s # 导入本地镜像 tar 到 containerd（非 K3s 集群用 ctr -n k8s.io）\n" "$0 import ./nanzi.tar"
+  printf "  %-30s # 检查节点是否已导入 K8s 沙箱预置镜像\n" "$0 check-sandbox-image nanzi-sandbox-k8s:1.0.0"
   printf "  %-30s # 查看完整帮助\n" "$0 help"
   printf "\n"
   exit 0
@@ -117,6 +121,14 @@ while [ $# -gt 0 ]; do
       shift
       if [ $# -gt 0 ] && [ "${1#-}" = "$1" ]; then
         IMAGE_LIST_FILTER="$1"
+        shift
+      fi
+      ;;
+    check-sandbox-image|--check-sandbox-image)
+      CHECK_IMAGE_MODE=true
+      shift
+      if [ $# -gt 0 ] && [ "${1#-}" = "$1" ]; then
+        CHECK_IMAGE_REF="$1"
         shift
       fi
       ;;
@@ -548,12 +560,55 @@ run_import_images() {
   exit 0
 }
 
-# 独立工具模式：--images / --import 命中即执行并退出，不进入部署向导
+# 检查节点是否已导入指定 K8s 沙箱镜像（预置镜像未导入会导致沙箱 Pod 拉取失败）
+run_check_sandbox_image() {
+  image_ref="${1:-}"
+  print_header "🧪 K8s 沙箱镜像检查"
+  if [ -z "$image_ref" ]; then
+    prompt_input "要检查的沙箱镜像（如 nanzi-sandbox-k8s:1.0.0，回车默认）" "nanzi-sandbox-k8s:latest" image_ref
+  fi
+  image_ref="$(printf '%s' "$image_ref" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  if [ -z "$image_ref" ]; then
+    image_ref="nanzi-sandbox-k8s:latest"
+  fi
+
+  resolve_container_tool_cmd
+  if [ -z "$CONTAINER_TOOL_CMD" ]; then
+    log_error "当前节点未找到 ctr / k3s 命令，无法检查镜像。"
+    printf "%b请在 containerd 所在节点执行（普通 containerd 或 K3s 均可）。%b\n" "${C_GRAY}" "${C_RESET}"
+    return 1
+  fi
+
+  log_info "正在节点容器运行时中检索：${image_ref} ..."
+  if $CONTAINER_TOOL_CMD images list 2>/dev/null | grep -q -- "$image_ref"; then
+    log_success "节点已导入沙箱镜像：${image_ref}"
+    printf "%b提示：将系统配置 sandbox_k8s_image 指向该镜像即可加速沙箱冷启动。%b\n\n" "${C_GRAY}" "${C_RESET}"
+  else
+    log_warn "节点未找到沙箱镜像：${image_ref}"
+    printf "\n%b请确认沙箱镜像来源：%b\n" "${C_BOLD}" "${C_RESET}"
+    printf "  %b① 使用网关预置镜像（推荐加速冷启动）：%b\n" "${C_CYAN}" "${C_RESET}"
+    printf "     ./build-k8s-sandbox-image.sh --version <版本>      # 构建并导入\n"
+    printf "     ./install.sh import nanzi-sandbox-k8s_<版本>.tar   # 或仅导入已有 tar\n"
+    printf "     ./install.sh check-sandbox-image nanzi-sandbox-k8s:<版本>   # 复核\n"
+    printf "  %b② 若 sandbox_k8s_image 仍为官方默认 python:3.11-slim，集群可直接拉取，可忽略此提示。%b\n\n" "${C_GRAY}" "${C_RESET}"
+  fi
+  return 0
+}
+
+# 独立工具模式：--images / --import / --check-sandbox-image 命中即执行并退出
 if [ "$IMAGE_LIST_MODE" = "true" ]; then
   run_list_images
 fi
 if [ "$IMAGE_IMPORT_MODE" = "true" ]; then
   run_import_images
+fi
+if [ "$CHECK_IMAGE_MODE" = "true" ]; then
+  run_check_sandbox_image "$CHECK_IMAGE_REF"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    exit "$rc"
+  fi
+  exit 0
 fi
 
 # 安全门：未指定任何显式命令时只展示帮助，绝不误入安装向导
@@ -658,6 +713,13 @@ echo
 prompt_confirm "是否同时部署云原生 Pod 安全沙箱 RBAC (sandbox-rbac.example.yaml)？" "Y" enable_sandbox_rbac
 if [ "$enable_sandbox_rbac" = "true" ]; then
   apply_resource "-f" "sandbox-rbac.example.yaml" "沙箱 RBAC 权限与绑定"
+fi
+
+echo
+prompt_confirm "是否检查 K8s 沙箱镜像是否已导入节点（若 sandbox_k8s_image 使用自定义预置镜像需先导入）？" "N" check_sandbox_now
+if [ "$check_sandbox_now" = "true" ]; then
+  prompt_input "要检查的沙箱镜像" "nanzi-sandbox-k8s:latest" _sandbox_check_img
+  run_check_sandbox_image "$_sandbox_check_img" || true
 fi
 
 # ==============================================================================

--- a/k8s_deploy/sandbox-image/_mcp_gateway_app.py
+++ b/k8s_deploy/sandbox-image/_mcp_gateway_app.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+"""In-workspace MCP gateway — FastAPI router over agentscope MCPClients.
+
+Runs inside the workspace environment as a standalone script. It starts
+with an empty registry and never reads the workspace's ``.mcp`` file:
+the workspace is the authority on which MCPs exist, and registers them
+here on demand. Boot cost is therefore independent of how many agents
+or sessions the workspace has accumulated. Authentication is optional —
+sandboxes sharing a host network namespace can enable a bearer token to
+prevent cross-workspace gateway access.
+
+Endpoints::
+
+    GET    /health
+    GET    /mcps                       # [MCPClient.model_dump(), ...]
+    POST   /mcps                       # body: MCPClient.model_dump()
+    DELETE /mcps/{name}
+    GET    /mcps/{name}/tools
+    POST   /mcps/{name}/tools/{tool}   # body: {arguments: {...}}
+
+Every endpoint except ``/health`` takes ``?agent_id=&session_id=``.
+Upstream sessions are kept per agent, session and MCP name, so two
+sessions running the same MCP get independent state (browser cookies,
+login state) and one closing its client never disturbs the other.
+
+The absolute import for ``agentscope.mcp`` avoids loading
+``agentscope.workspace.__init__`` (which pulls in skill/tool trees the
+gateway does not need).
+"""
+
+import argparse
+import asyncio
+import secrets
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import PlainTextResponse
+
+from agentscope.mcp import MCPClient
+
+
+class _State:
+    """Mutable runtime state shared by FastAPI routes."""
+
+    def __init__(self) -> None:
+        self.clients: dict[tuple[str, str], dict[str, MCPClient]] = {}
+        self.lock = asyncio.Lock()
+
+
+async def _build_client(spec: dict[str, Any]) -> MCPClient:
+    """Validate a spec into an ``MCPClient``, connect if stateful,
+    and prime its tool cache.
+    """
+    client = MCPClient.model_validate(spec)
+    if client.is_stateful:
+        await client.connect()
+    await client.list_raw_tools()
+    return client
+
+
+def _build_app(
+    state: _State,
+    auth_token: str | None = None,
+    instance_nonce: str | None = None,
+) -> FastAPI:
+    """Build the FastAPI app with all routes wired against ``state``."""
+    app = FastAPI(title="agentscope-workspace-mcp-gateway")
+
+    def _lookup(agent_id: str, session_id: str, name: str) -> MCPClient:
+        """Resolve one registered client or raise 404."""
+        client = state.clients.get((agent_id, session_id), {}).get(name)
+        if client is None:
+            raise HTTPException(
+                404,
+                f"{name!r} not found for agent={agent_id!r} "
+                f"session={session_id!r}",
+            )
+        return client
+
+    if auth_token:
+
+        @app.middleware("http")
+        async def _auth_middleware(request: Request, call_next: Any) -> Any:
+            if request.url.path == "/health":
+                return await call_next(request)
+            header = request.headers.get("authorization", "")
+            expected = f"Bearer {auth_token}"
+            valid = (
+                header.isascii()
+                and expected.isascii()
+                and secrets.compare_digest(header, expected)
+            )
+            if not valid:
+                return PlainTextResponse(
+                    "invalid gateway token",
+                    status_code=401,
+                )
+            return await call_next(request)
+
+    @app.get("/health", response_model=None)
+    async def _health() -> Any:
+        if instance_nonce is not None:
+            return {"status": "ok", "instance_nonce": instance_nonce}
+        return PlainTextResponse("ok")
+
+    @app.get("/mcps")
+    async def _list_mcps(
+        agent_id: str = "",
+        session_id: str = "",
+    ) -> list[dict[str, Any]]:
+        return [
+            c.model_dump(mode="json")
+            for c in state.clients.get((agent_id, session_id), {}).values()
+        ]
+
+    @app.post("/mcps")
+    async def _add_mcp(
+        request: Request,
+        agent_id: str = "",
+        session_id: str = "",
+    ) -> dict[str, Any]:
+        body = await request.json()
+        name = body.get("name", "")
+        if not name:
+            raise HTTPException(400, "name required")
+        async with state.lock:
+            by_name = state.clients.setdefault((agent_id, session_id), {})
+            if name in by_name:
+                raise HTTPException(
+                    409,
+                    f"{name!r} already exists for agent={agent_id!r} "
+                    f"session={session_id!r}",
+                )
+            try:
+                by_name[name] = await _build_client(body)
+            except HTTPException:
+                raise
+            except Exception as e:  # noqa: BLE001
+                raise HTTPException(500, f"connect failed: {e}") from e
+        return {"ok": True}
+
+    @app.delete("/mcps/{name}")
+    async def _remove_mcp(
+        name: str,
+        agent_id: str = "",
+        session_id: str = "",
+    ) -> dict[str, Any]:
+        async with state.lock:
+            client = _lookup(agent_id, session_id, name)
+            del state.clients[(agent_id, session_id)][name]
+            if not state.clients[(agent_id, session_id)]:
+                del state.clients[(agent_id, session_id)]
+            if client.is_stateful and client.is_connected:
+                await client.close()
+        return {"ok": True}
+
+    @app.get("/mcps/{name}/tools")
+    async def _list_tools(
+        name: str,
+        agent_id: str = "",
+        session_id: str = "",
+    ) -> list[dict[str, Any]]:
+        client = _lookup(agent_id, session_id, name)
+        raw = await client.list_raw_tools()
+        return [t.model_dump(mode="json") for t in raw]
+
+    @app.post("/mcps/{name}/tools/{tool}")
+    async def _call_tool(
+        name: str,
+        tool: str,
+        request: Request,
+        agent_id: str = "",
+        session_id: str = "",
+    ) -> dict[str, Any]:
+        client = _lookup(agent_id, session_id, name)
+        body = await request.json()
+        arguments = body.get("arguments") or {}
+        try:
+            tool_obj = await client.get_tool(tool)
+            chunk = await tool_obj(**arguments)
+        except ValueError as e:
+            raise HTTPException(404, str(e)) from e
+        except Exception as e:  # noqa: BLE001
+            raise HTTPException(500, str(e)) from e
+        return {"chunk": chunk.model_dump(mode="json")}
+
+    return app
+
+
+async def _run(
+    port: int,
+    auth_token: str | None = None,
+    instance_nonce: str | None = None,
+) -> None:
+    """Start uvicorn on an empty registry, clean up upstreams on exit."""
+    state = _State()
+    app = _build_app(
+        state,
+        auth_token=auth_token,
+        instance_nonce=instance_nonce,
+    )
+    print(f"[gateway] serving on :{port}", flush=True)
+
+    import uvicorn
+
+    uvi_cfg = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="info",
+    )
+    server = uvicorn.Server(uvi_cfg)
+    try:
+        await server.serve()
+    finally:
+        for by_name in state.clients.values():
+            for client in by_name.values():
+                if client.is_stateful and client.is_connected:
+                    await client.close()
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="In-workspace MCP gateway (FastAPI)",
+    )
+    # Accepted and ignored — kept so an image shipping an older
+    # launch command still starts.
+    parser.add_argument("--config", default=None)
+    parser.add_argument("--port", type=int, default=5600)
+    parser.add_argument("--auth-token")
+    parser.add_argument("--instance-nonce")
+    args = parser.parse_args()
+    asyncio.run(
+        _run(
+            args.port,
+            auth_token=args.auth_token,
+            instance_nonce=args.instance_nonce,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/k8s_deploy/upgrade.md
+++ b/k8s_deploy/upgrade.md
@@ -3,6 +3,21 @@
 不建议手动删除 Pod。更新镜像后，应该通过 Deployment 做滚动更新。
 
 > [!TIP]
+> **可选加速：K8s 沙箱网关预置镜像** —— AgentScope 沙箱网关环境位于 Pod 内
+> `/root/.agentscope`（临时写层），每次新 Pod 冷启动都要跑 bootstrap（apt + uv + venv +
+> 安装依赖），这是 K8s 沙箱比 Docker 冷启动慢的根本原因。可用
+> [`build-k8s-sandbox-image.sh`](./build-k8s-sandbox-image.sh) 构建一个**网关预置镜像**，
+> 把 venv 与 gateway 脚本直接打进镜像；配置 `sandbox_k8s_image` 指向它后，新 Pod 冷启动
+> 直接可用，从数十秒降到秒级：
+>
+> ```bash
+> ./build-k8s-sandbox-image.sh --version 1.0.0     # docker build + save
+> ./build-k8s-sandbox-image.sh --dry-run           # 只预览 Dockerfile 与命令
+> # 产物 nanzi-sandbox-k8s:1.0.0 + tar；脚本会自动尝试导入节点（ctr -n k8s.io / k3s ctr）
+> # 随后把系统配置 sandbox_k8s_image 设为 nanzi-sandbox-k8s:1.0.0
+> ```
+
+> [!TIP]
 > **一键自动升级（推荐）**：目录向导安装器已深度集成镜像滚动发布流程，在将镜像导入节点后，直接运行：
 >
 > ```bash

--- a/tests/services/test_sandbox_policy_k8s.py
+++ b/tests/services/test_sandbox_policy_k8s.py
@@ -7,11 +7,18 @@ pytestmark = pytest.mark.no_infrastructure
 
 
 @pytest.mark.asyncio
-async def test_policy_k8s_workspace_build_and_initialize():
+async def test_policy_k8s_workspace_build_and_initialize(monkeypatch):
     from app.services.ai.runtime.agentscope.workspace import (
         _policy_k8s_workspace,
         SANDBOX_POLICY_K8S,
     )
+
+    # 避免任何 config 键触达真实 Redis（redis asyncio 连接跨 event loop 复用时
+    # 会在组合测试顺序下抛 "Future attached to a different loop"）。
+    async def fake_get(key, default=None):
+        return default
+
+    monkeypatch.setattr("app.services.config_service.ConfigService.get", fake_get)
 
     mock_ws = MagicMock()
     mock_ws.initialize = AsyncMock()
@@ -214,6 +221,10 @@ async def test_nanzi_k8s_adapter_create_pod_spec_structure(tmp_path):
     assert container.resources.requests["memory"] == "128Mi"
     assert container.resources.limits["cpu"] == "1000m"
     assert container.resources.limits["memory"] == "1Gi"
+
+    # 校验 uv venv 幂等开关注入（避免 Pod 重复 initialize 时 bootstrap 因 venv 已存在而失败）
+    env_map = {e.name: e.value for e in (container.env or [])}
+    assert env_map.get("UV_VENV_CLEAR") == "1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_k8s_deploy_docs_contract.py
+++ b/tests/test_k8s_deploy_docs_contract.py
@@ -84,3 +84,26 @@ def test_k8s_docs_cover_wizard_install_script_and_ops_tools():
     assert (K8S_DIR / "install.sh").is_file()
     assert (K8S_DIR / "nanzi-k8s.sh").is_file()
     assert (K8S_DIR / "upgrade.md").is_file()
+
+
+def test_k8s_build_sandbox_image_script_and_docs_contract():
+    """网关预置镜像构建脚本与文档指引契约。"""
+    build_script = K8S_DIR / "build-k8s-sandbox-image.sh"
+    assert build_script.is_file()
+    script_source = build_script.read_text(encoding="utf-8")
+    assert "build-k8s-sandbox-image.sh" in script_source
+    assert "_mcp_gateway_app.py" in script_source
+    assert 'GATEWAY_HOME="/root/.agentscope"' in script_source
+    assert "mcp<2.0.0" in script_source
+    assert "sandbox_k8s_image" in script_source
+    template = K8S_DIR / "sandbox-image" / "_mcp_gateway_app.py"
+    assert template.is_file()
+
+    upgrade_text = (K8S_DIR / "upgrade.md").read_text(encoding="utf-8")
+    assert "build-k8s-sandbox-image.sh" in upgrade_text
+    assert "网关预置镜像" in upgrade_text
+
+    readme_text = (K8S_DIR / "README.md").read_text(encoding="utf-8")
+    assert "build-k8s-sandbox-image.sh" in readme_text
+    assert "网关预置镜像" in readme_text
+    assert "check-sandbox-image" in readme_text


### PR DESCRIPTION
# Pull Request: K8s 沙箱冷启动加速（网关预置镜像）+ 初始化超时兜底与自动预热

## 概要 (Overview)

针对 K8s 沙箱（`sandbox_policy = k8s`）的“冷启动慢 / 初始化挂起导致卡死”做系统性收口，共三块：

1. **初始化不再无限卡**：沙箱初始化若长时间挂起（等锁/拉镜像/bootstrap），preflight 预热 60s 与执行阶段 90s 超时兜底，按“沙箱不可用”降级或明确报错；同时给沙箱容器注入 `UV_VENV_CLEAR=1`，修复 Pod 被重复 initialize 时 `uv venv` 因 venv 已存在而 exit 2 的失败。
2. **会话打开自动预热（默认开启）**：进入/新建会话自动静默 `ensure` 一次沙箱，首条消息通常已就绪，首 token 不再等冷启动；状态轮询延长至 60s，`starting` 状态允许手动刷新。
3. **K8s 沙箱“网关预置镜像”工具链**：新增 `build-k8s-sandbox-image.sh`，把 AgentScope 网关 venv + gateway 脚本预置进镜像（新 Pod 冷启动直接跳过 bootstrap，数十秒降到秒级）；`install.sh` 新增 `check-sandbox-image` 检查命令与向导可选检查；`upgrade.md`/`README.md`/系统配置页 `sandbox_k8s_image` 均补充构建引导与填写说明。

---

## 核心变更 (Key Changes)

### 1. 🚀 功能新增与增强 (New Features & Enhancements)
- [x] 会话打开/新建后**自动预热沙箱**（默认开启、每会话一次、静默、运行中不打扰、失败静默降级）；轮询延长至 60s 并在 `starting` 状态允许手动刷新。
- [x] `build-k8s-sandbox-image.sh`：生成与 AgentScope 布局一致的网关预置镜像（`/root/.agentscope/.venv` + `_mcp_gateway_app.py`），docker build → save → 自动导入节点 containerd（`ctr -n k8s.io` / `k3s ctr`）；支持 `--base-image/--version/--proxy/--agentscope-version/--dry-run/--sync-template/--no-import`，并做“容器/Pod 内误用”防护。
- [x] `install.sh` 新增 `check-sandbox-image` 命令与安装向导内的可选镜像检查（未导入时给出构建引导）。
- [x] 系统配置页 `sandbox_k8s_image` 增加“网关预置镜像”操作提示卡片与短描述。

### 2. 🎨 UI/UX 深度优化 (Visual & Interaction Polish)
- [x] 状态浮标：Pod 创建中自动轮询至就绪（最长约 60s），超时给出明确提示；`starting` 状态下手动「刷新」真正生效。

### 3. 🐞 关键修复 (Bug Fixes)
- [x] 沙箱初始化**挂起**（非快速失败）导致消息卡死：prewarm `asyncio.wait_for(60s)`、执行 `get_local_workspace` `wait_for(90s)`，超时按沙箱不可用处理（纯对话降级本地 / 需 Bash 时明确报错）。
- [x] 重复 initialize 同 Pod 时 `uv venv /root/.agentscope/.venv` 因 venv 已存在 exit 2：容器注入 `UV_VENV_CLEAR=1` 幂等重建。

---

## 表结构变更清单 (Database Schema Changes)

- [ ] 包含表结构变更 (DDL Migrations)
- [x] 无表结构变更 (No Schema Changes)

### 1. 🐬 MySQL 迁移脚本 (`db-prod/`)
无。

### 2. 🐘 PostgreSQL 迁移脚本 (`db-prod-pg/`)
无。

---

## 变更清单 (Commit Log)

| 简写 | 描述 |
| :--- | :--- |
| `6edd6a56` | feat(k8s): K8s 沙箱网关预置镜像构建脚本与文档/系统配置引导、install.sh check-sandbox-image 检查 |
| `b83f50fb` | feat(chat): 会话打开自动预热沙箱（默认开启、每会话一次、静默），状态轮询延长至 60s 并允许 starting 手动刷新 |
| `c7d7a117` | fix(sandbox): 沙箱初始化挂起加超时兜底（prewarm 60s/执行 90s），uv venv 幂等 UV_VENV_CLEAR |

---

## 测试覆盖 (Testing)
- [ ] **UI 兼容性**: 自动预热与浮标交互由用户在部署后真机走查（本 PR 未代跑 `./dev.sh`）。
- [x] **核心功能**: 后端相关 103 项（含超时/降级/exec/UV 断言）全绿；部署文档契约 8 项全绿。
- [x] **回归测试**: 前端契约 21 项全绿；`vue-tsc --noEmit` 0 error；`bash -n install.sh / build-k8s-sandbox-image.sh / nanzi-k8s.sh` 通过。

> [!IMPORTANT]
> 相关条目已记录于 `tests/CHECKLIST.md`；无新增表结构，无需迁移脚本。

---

## 其他备注 (Notes)

- 真机验证清单：`./dev.sh` 后——① 打开会话观察自动预热（浮标“未启动→创建中→已运行”，首条消息基本不等待）；② k8s 沙箱运行中执行 Bash 正常；③ 在有 Docker 的节点/构建机跑 `./build-k8s-sandbox-image.sh --dry-run` 后再真构建，并把 `sandbox_k8s_image` 指到产物；④ `./install.sh check-sandbox-image` 复核。
- 预置镜像与平台 agentscope 版本一致性：在平台代码目录（有 `.venv`）构建会自动 pin 平台 agentscope 版本，避免网关协议漂移。
- Agent 未代跑真实服务启停与部署脚本。
